### PR TITLE
Don't output control characters if not to TTY

### DIFF
--- a/lib/SyTest/Output/TAP.pm
+++ b/lib/SyTest/Output/TAP.pm
@@ -70,15 +70,6 @@ sub fail_prepare
    print "# $_\n" for split m/\n/, $failure;
 }
 
-# Wait status on longrunning tests
-sub start_waiting
-{
-}
-
-sub stop_waiting
-{
-}
-
 # Overall summary
 sub final_pass
 {

--- a/lib/SyTest/Output/Term.pm
+++ b/lib/SyTest/Output/Term.pm
@@ -7,20 +7,15 @@ use constant FORMAT => "term";
 
 # Some terminal control strings
 
-my $RED = "\e[31m";
-my $RED_B = "\e[1;31m";
-my $GREEN = "\e[32m";
-my $GREEN_B = "\e[1;32m";
-my $YELLOW_B = "\e[1;33m";
-my $CYAN = "\e[36m";
-my $CYAN_B = "\e[1;36m";
+my $RED = -t STDOUT ? "\e[31m" : "";
+my $RED_B = -t STDOUT ? "\e[1;31m" : "";
+my $GREEN = -t STDOUT ? "\e[32m" : "";
+my $GREEN_B = -t STDOUT ? "\e[1;32m" : "";
+my $YELLOW_B = -t STDOUT ? "\e[1;33m" : "";
+my $CYAN = -t STDOUT ? "\e[36m" : "";
+my $CYAN_B = -t STDOUT ? "\e[1;36m" : "";
 
-my $RESET = "\e[m";
-
-# Backspace
-my $BS = "\x08";
-# Erase to end of line
-my $EL_TO_EOL = "\e[K";
+my $RESET = -t STDOUT ? "\e[m" : "";
 
 # File status
 sub run_file
@@ -83,42 +78,26 @@ sub fail_prepare
    print " +----------------------\n";
 }
 
-# Wait status on longrunning tests
-
-my $waiting = "Waiting...";
-
-sub start_waiting
-{
-   shift;
-   print STDERR $waiting;
-}
-
-sub stop_waiting
-{
-   shift;
-   print STDERR $BS x length($waiting), $EL_TO_EOL;
-}
-
 # Overall summary
 sub final_pass
 {
    shift;
    my ( $expected_fail, $skipped_count ) = @_;
-   print STDERR "\n${GREEN_B}All tests PASSED${RESET}";
+   print "\n${GREEN_B}All tests PASSED${RESET}";
    if( $expected_fail ) {
-      print STDERR " (with $expected_fail expected failures)";
+      print " (with $expected_fail expected failures)";
    }
    if( $skipped_count ) {
-      print STDERR " (with ${YELLOW_B}$skipped_count skipped${RESET} tests)";
+      print " (with ${YELLOW_B}$skipped_count skipped${RESET} tests)";
    }
-   print STDERR "\n";
+   print "\n";
 }
 
 sub final_fail
 {
    shift;
    my ( $failed ) = @_;
-   print STDERR "\n${RED_B}$failed tests FAILED${RESET}\n";
+   print "\n${RED_B}$failed tests FAILED${RESET}\n";
 }
 
 # General diagnostic status
@@ -126,7 +105,7 @@ sub diag
 {
    shift;
    my ( $message ) = @_;
-   print STDERR "$message\n";
+   print "$message\n";
 }
 
 package SyTest::Output::Term::Test {

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -321,12 +321,6 @@ sub _run_test
       Future->wait_any(
          $f_test,
 
-         $loop->delay_future( after => 2 )
-            ->then( sub {
-               $output->start_waiting;
-               $loop->new_future->on_cancel( sub { $output->stop_waiting });
-            }),
-
          $loop->delay_future( after => $params{timeout} // 10 )
             ->then_fail( "Timed out waiting for test" )
       )->get;

--- a/tests/01http-server.pl
+++ b/tests/01http-server.pl
@@ -127,12 +127,12 @@ package SyTest::HTTPServer {
       my $path = uri_unescape $request->path;
 
       if( $CLIENT_LOG ) {
-         my $green = -t STDERR ? "\e[1;32m" : "";
-         my $reset = -t STDERR ? "\e[m" : "";
-         print STDERR "${green}Received Request${reset} for $method $path:\n";
+         my $green = -t STDOUT ? "\e[1;32m" : "";
+         my $reset = -t STDOUT ? "\e[m" : "";
+         print "${green}Received Request${reset} for $method $path:\n";
          #TODO log the HTTP Request headers
-         print STDERR "  $_\n" for split m/\n/, $request->body;
-         print STDERR "-- \n";
+         print "  $_\n" for split m/\n/, $request->body;
+         print "-- \n";
       }
 
       foreach my $idx ( 0 .. $#pending_awaiters ) {

--- a/tests/01http-server.pl
+++ b/tests/01http-server.pl
@@ -127,7 +127,9 @@ package SyTest::HTTPServer {
       my $path = uri_unescape $request->path;
 
       if( $CLIENT_LOG ) {
-         print STDERR "\e[1;32mReceived Request\e[m for $method $path:\n";
+         my $green = -t STDERR ? "\e[1;32m" : "";
+         my $reset = -t STDERR ? "\e[m" : "";
+         print STDERR "${green}Received Request${reset} for $method $path:\n";
          #TODO log the HTTP Request headers
          print STDERR "  $_\n" for split m/\n/, $request->body;
          print STDERR "-- \n";

--- a/tests/60app-services/00prepare.pl
+++ b/tests/60app-services/00prepare.pl
@@ -69,7 +69,7 @@ prepare "Creating test helper functions",
                   $f->done( $event );
                }
                else {
-                  print STDERR "Ignoring incoming AS event of type $type\n";
+                  print "Ignoring incoming AS event of type $type\n";
                }
             }
 


### PR DESCRIPTION
Side effects:
 * Stop mixing random output to STDERR
 * Stop outputting "Waiting..." for tests which are longer than 2
   seconds