### PR TITLE
Add a matrix_typing sub for marking a user as typing

### DIFF
--- a/tests/30rooms/20typing.pl
+++ b/tests/30rooms/20typing.pl
@@ -34,6 +34,7 @@ my $room_preparer = room_preparer(
    ],
 );
 
+
 test "Typing notification sent to local room members",
    requires => [ $typing_user_preparer, $local_user_preparer, $room_preparer,
                 qw( can_set_room_typing )],
@@ -50,6 +51,7 @@ test "Typing notification sent to local room members",
 
             await_event_for( $recvuser, sub {
                my ( $event ) = @_;
+
                return unless $event->{type} eq "m.typing";
 
                require_json_keys( $event, qw( type room_id content ));
@@ -62,13 +64,14 @@ test "Typing notification sent to local room members",
                scalar @$users == 1 or
                   die "Expected 1 member to be typing";
                $users->[0] eq $typinguser->user_id or
-                  die "Expected ${\$typinguser->user_id} to be typing";
+                  die "Expected ${\ $typinguser->user_id } to be typing";
 
                return 1;
             })
          } $typinguser, $local_user );
       });
    };
+
 
 test "Typing notifications also sent to remote room members",
    requires => [ $typing_user_preparer, $remote_user_preparer, $room_preparer,
@@ -79,6 +82,7 @@ test "Typing notifications also sent to remote room members",
 
       await_event_for( $remote_user, sub {
          my ( $event ) = @_;
+
          return unless $event->{type} eq "m.typing";
 
          require_json_keys( $event, qw( type room_id content ));
@@ -91,11 +95,12 @@ test "Typing notifications also sent to remote room members",
          scalar @$users == 1 or
             die "Expected 1 member to be typing";
          $users->[0] eq $typinguser->user_id or
-            die "Expected ${\$typinguser->user_id} to be typing";
+            die "Expected ${\ $typinguser->user_id } to be typing";
 
          return 1;
       })
    };
+
 
 test "Typing can be explicitly stopped",
    requires => [ $typing_user_preparer, $local_user_preparer, $room_preparer,
@@ -110,6 +115,7 @@ test "Typing can be explicitly stopped",
 
             await_event_for( $recvuser, sub {
                my ( $event ) = @_;
+
                return unless $event->{type} eq "m.typing";
 
                require_json_keys( $event, qw( type room_id content ));
@@ -128,6 +134,7 @@ test "Typing can be explicitly stopped",
       });
    };
 
+
 multi_test "Typing notifications timeout and can be resent",
    requires => [ $typing_user_preparer, $room_preparer,
                 qw( can_set_room_typing )],
@@ -137,12 +144,11 @@ multi_test "Typing notifications timeout and can be resent",
 
       my $start_time = time();
 
-      flush_events_for( $user )
-      ->then( sub {
+      flush_events_for( $user )->then( sub {
          matrix_typing( $user, $room_id,
             typing => 1,
             timeout => 100, # msec; i.e. very short
-         )
+         );
       })->then( sub {
          pass( "Sent typing notification" );
 
@@ -156,7 +162,7 @@ multi_test "Typing notifications timeout and can be resent",
 
             pass( "Received start notification" );
             return 1;
-         })
+         });
       })->then( sub {
          # stop typing
          await_event_for( $user, sub {
@@ -171,12 +177,12 @@ multi_test "Typing notifications timeout and can be resent",
 
             pass( "Received stop notification" );
             return 1;
-         })
+         });
       })->then( sub {
          matrix_typing( $user, $room_id,
             typing => 1,
             timeout => 10000,
-         )
+         );
       })->then( sub {
          pass( "Sent second notification" );
 


### PR DESCRIPTION
Since I'm just about to start checking for typing notifs in v2 sync.