### PR TITLE
Test API for adding and removing tags

### DIFF
--- a/tests/42tags.pl
+++ b/tests/42tags.pl
@@ -176,6 +176,8 @@ test "Tags appear in the v1 /events stream",
             return unless $event->{type} eq "m.tag"
                and $event->{room_id} eq $room_id;
 
+            log_if_fail "Tag event", $event;
+
             my %tags = %{ $event->{content}{tags} };
             keys %tags == 1 or die "Expected exactly one tag";
             defined $tags{test_tag} or die "Unexpected tag";

--- a/tests/42tags.pl
+++ b/tests/42tags.pl
@@ -215,3 +215,40 @@ test "Tags appear in the v1 /initalSync",
          Future->done(1);
       });
    };
+
+test "Tags appear in the v1 room initial sync",
+   requires => [qw( first_api_client can_add_tag can_remove_tag )],
+
+   do => sub {
+      my ( $http ) = @_;
+
+      my ( $user, $room_id );
+
+      matrix_register_user( $http, undef, with_events => 0 )->then( sub {
+         ( $user ) = @_;
+
+         matrix_create_room( $user );
+      })->then( sub {
+         ( $room_id ) = @_;
+
+         matrix_add_tag( $user, $room_id, "test_tag");
+      })->then( sub {
+         do_request_json_for( $user,
+            method => "GET",
+            uri    => "/api/v1/rooms/$room_id/initialSync"
+        );
+      })->then( sub {
+         my ( $body ) = @_;
+
+         my $room = $body;
+         require_json_keys( $room, qw( private_user_data ) );
+
+         my $tags = $room->{private_user_data}->[0];
+
+         $tags->{type} eq "m.tag" or die "Expected a m.tag event";
+         $tags->{content}{tags}[0] eq "test_tag" or die "Unexpected tag";
+         $tags->{room_id} eq "Expected to get a room_id in v1";
+
+         Future->done(1);
+      });
+   };

--- a/tests/42tags.pl
+++ b/tests/42tags.pl
@@ -224,7 +224,7 @@ test "Tags appear in the v1 /initalSync",
          defined $tags{test_tag} or die "Unexpected tag";
          $tags{test_tag}{order} == 1 or die "Expected order == 1";
 
-         Future->done(1);
+         Future->done( 1 );
       });
    };
 
@@ -266,7 +266,7 @@ test "Tags appear in the v1 room initial sync",
          defined $tags{test_tag} or die "Unexpected tag";
          $tags{test_tag}{order} == 1 or die "Expected order == 1";
 
-         Future->done(1);
+         Future->done( 1 );
       });
    };
 
@@ -307,7 +307,7 @@ test "Tags appear in an initial v2 /sync",
          defined $tags{test_tag} or die "Unexpected tag";
          $tags{test_tag}{order} == 1 or die "Expected order == 1";
 
-         Future->done(1);
+         Future->done( 1 );
       });
    };
 
@@ -354,6 +354,6 @@ test "Newly updated tags appear in an incremental v2 /sync",
          defined $tags{test_tag} or die "Unexpected tag";
          $tags{test_tag}{order} == 1 or die "Expected order == 1";
 
-         Future->done(1);
+         Future->done( 1 );
       });
    };

--- a/tests/42tags.pl
+++ b/tests/42tags.pl
@@ -134,6 +134,8 @@ test "Can list tags for a room",
       })->then( sub {
          my ( $tags ) = @_;
 
+         log_if_fail "Tags after add", $tags;
+
          keys %{ $tags } == 1 or die "Expected one tag for the room";
          defined $tags->{test_tag} or die "Unexpected tag";
 
@@ -142,6 +144,8 @@ test "Can list tags for a room",
          matrix_list_tags( $user, $room_id );
       })->then( sub {
          my ( $tags ) = @_;
+
+         log_if_fail "Tags after delete", $tags;
 
          keys %{ $tags } == 0 or die "Expected no tags for the room";
 

--- a/tests/42tags.pl
+++ b/tests/42tags.pl
@@ -1,0 +1,152 @@
+push our @EXPORT, qw( matrix_add_tag );
+
+=head2 matrix_add_tag
+
+   matrix_add_tag($user, $room_id, $tag)->get;
+
+Add a tag to the room for the user.
+
+=cut
+
+sub matrix_add_tag
+{
+   my ( $user, $room_id, $tag ) = @_;
+
+   do_request_json_for( $user,
+      method  => "PUT",
+      uri     => "/v2_alpha/user/:user_id/rooms/$room_id/tags/$tag",
+      content => {}
+   );
+}
+
+
+=head2 matrix_remove_tag
+
+    matrix_remove_tag( $user, $room_id, $tag )->get;
+
+Remove a tag from the room for the user.
+
+=cut
+
+sub matrix_remove_tag
+{
+   my ( $user, $room_id, $tag ) = @_;
+
+   do_request_json_for( $user,
+      method  => "DELETE",
+      uri     => "/v2_alpha/user/:user_id/rooms/$room_id/tags/$tag",
+      content => {}
+   );
+}
+
+
+=head2 matrix_list_tags
+
+    my $tags = matrix_list_tags( $user, $room_id )->get;
+
+List the tags on the room for the user.
+
+=cut
+
+sub matrix_list_tags
+{
+   my ( $user, $room_id ) = @_;
+
+   do_request_json_for( $user,
+      method  => "GET",
+      uri     => "/v2_alpha/user/:user_id/rooms/$room_id/tags",
+      content => {}
+   )->then( sub {
+      my ( $body ) = @_;
+
+      require_json_keys( $body, qw( tags ) );
+
+      Future->done( $body->{tags} );
+   });
+}
+
+
+test "Can add tag",
+   requires => [qw( first_api_client )],
+
+   provides => [qw( can_add_tag )],
+
+   do => sub {
+      my ( $http ) = @_;
+
+      my ( $user, $room_id );
+
+      matrix_register_user( $http, undef, with_events => 0 )->then( sub {
+         ( $user ) = @_;
+
+         matrix_create_room( $user );
+      })->then( sub {
+         ( $room_id ) = @_;
+
+         matrix_add_tag( $user, $room_id, "test_tag" );
+      })->on_done( sub {
+         provide can_add_tag => 1
+      });
+   };
+
+
+test "Can remove tag",
+   requires => [qw( first_api_client )],
+
+   provides => [qw( can_remove_tag )],
+
+   do => sub {
+      my ( $http ) = @_;
+
+      my ( $user, $room_id );
+
+      matrix_register_user( $http, undef, with_events => 0 )->then( sub {
+         ( $user ) = @_;
+
+         matrix_create_room( $user );
+      })->then( sub {
+         ( $room_id ) = @_;
+
+         matrix_remove_tag( $user, $room_id, "test_tag" );
+      })->on_done( sub {
+         provide can_remove_tag => 1
+      });
+   };
+
+
+test "Can list tags for a room",
+   requires => [qw( first_api_client can_add_tag can_remove_tag )],
+
+
+   do => sub {
+      my ( $http ) = @_;
+
+      my ( $user, $room_id );
+
+      matrix_register_user( $http, undef, with_events => 0 )->then( sub {
+         ( $user ) = @_;
+
+         matrix_create_room( $user );
+      })->then( sub {
+         ( $room_id ) = @_;
+
+         matrix_add_tag( $user, $room_id, "test_tag" );
+      })->then( sub {
+         matrix_list_tags( $user, $room_id );
+      })->then( sub {
+         my ( $tags ) = @_;
+
+         @{ $tags } == 1 or die "Expected one tag for the room";
+         $tags->[0] eq "test_tag" or die "Unexpected tag";
+
+         matrix_remove_tag( $user, $room_id, "test_tag" );
+      })->then( sub {
+         matrix_list_tags( $user, $room_id );
+      })->then( sub {
+         my ( $tags ) = @_;
+
+         @{ $tags } == 0 or die "Expected no tags for the room";
+
+         Future->done(1);
+      });
+   };


### PR DESCRIPTION
Test changes made in matrix-org/synapse#335

TODO:

 * [x] Add tests for getting tags in v1 /initialSync
 * [x] Add tests for getting tags in v1 /events
 * [x] Add tests for getting tags in v2 /sync