### PR TITLE
Test restriction of unfederated rooms

### DIFF
--- a/tests/10apidoc/30room-create.pl
+++ b/tests/10apidoc/30room-create.pl
@@ -120,6 +120,8 @@ sub matrix_create_room
             ( room_alias_name => $opts{room_alias_name} ) : () ),
          ( defined $opts{invite} ?
             ( invite => $opts{invite} ) : () ),
+         ( defined $opts{creation_content} ?
+            ( creation_content => $opts{creation_content} ) : () ),
       }
    )->then( sub {
       my ( $body ) = @_;

--- a/tests/10apidoc/33room-members.pl
+++ b/tests/10apidoc/33room-members.pl
@@ -54,12 +54,12 @@ push our @EXPORT, qw( matrix_join_room );
 
 sub matrix_join_room
 {
-   my ( $user, $room_id ) = @_;
+   my ( $user, $room ) = @_;
    is_User( $user ) or croak "Expected a User; got $user";
 
    do_request_json_for( $user,
       method => "POST",
-      uri    => "/api/v1/rooms/$room_id/join",
+      uri    => "/api/v1/join/$room",
 
       content => {},
    )->then_done(1);

--- a/tests/30rooms/03members-remote.pl
+++ b/tests/30rooms/03members-remote.pl
@@ -216,3 +216,22 @@ test "New room members see first user's profile information in per-room initialS
          Future->done(1);
       });
    };
+
+test "Remote users may not join unfederated rooms",
+   requires => [ local_user_preparer(), remote_user_preparer(),
+                 qw( can_create_room_with_creation_content )],
+
+   check => sub {
+      my ( $creator, $remote_user ) = @_;
+
+      matrix_create_room( $creator,
+         room_alias_name => "unfederated",
+         creation_content => {
+            "m.federate" => JSON::false,
+         },
+      )->then( sub {
+         my ( undef, $room_alias ) = @_;
+
+         matrix_join_room( $remote_user, $room_alias )
+      })->main::expect_http_403;
+   };

--- a/tests/30rooms/03members-remote.pl
+++ b/tests/30rooms/03members-remote.pl
@@ -225,7 +225,7 @@ test "Remote users may not join unfederated rooms",
       my ( $creator, $remote_user ) = @_;
 
       matrix_create_room( $creator,
-         room_alias_name => "unfederated",
+         room_alias_name  => "unfederated",
          creation_content => {
             "m.federate" => JSON::false,
          },


### PR DESCRIPTION
Test that remote users can't join a room with `m.federate` set to `false`