### PR TITLE
Explicitly deref the hashes before calling keys on them

### DIFF
--- a/tests/30rooms/13anonymousaccess.pl
+++ b/tests/30rooms/13anonymousaccess.pl
@@ -208,13 +208,13 @@ sub check_events
       log_if_fail "Body", $body;
 
       require_json_keys( $body, qw( chunk ) );
-      @{$body->{chunk}} >= 1 or die "Want at least one event";
-      @{$body->{chunk}} < 3 or die "Want at most two events";
+      @{ $body->{chunk} } >= 1 or die "Want at least one event";
+      @{ $body->{chunk} } < 3 or die "Want at most two events";
 
       my $found = 0;
-      foreach my $event ($body->{chunk}) {
-         next if all { $_ ne "content" } keys $event;
-         next if all { $_ ne "body" } keys $event->{content};
+      foreach my $event ( @{ $body->{chunk} } ) {
+         next if all { $_ ne "content" } keys %{ $event };
+         next if all { $_ ne "body" } keys %{ $event->{content} };
          $found = 1 if $event->{content}->{body} eq "public";
          die "Should not have found private" if $event->{content}->{body} eq "private";
       }


### PR DESCRIPTION
Otherwise I get an error on perl 5.22.0 of:

"keys on reference is experimental at tests/30rooms/13anonymousaccess.pl line 216."