### PR TITLE
Correct display output for expected multitest failures

### DIFF
--- a/run-tests.pl
+++ b/run-tests.pl
@@ -557,7 +557,8 @@ sub test
       # is not yet fixed
       $params{expect_fail}++ if $params{bug} and not $FIXED_BUGS{ $params{bug} };
 
-      local $RUNNING_TEST = my $t = $output->enter_multi_test( $name );
+      local $RUNNING_TEST = my $t = $output->enter_multi_test(
+          $name, $params{expect_fail});
       _run_test( $t, %params );
       $t->leave;
 

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -558,7 +558,7 @@ sub test
       $params{expect_fail}++ if $params{bug} and not $FIXED_BUGS{ $params{bug} };
 
       local $RUNNING_TEST = my $t = $output->enter_multi_test(
-          $name, $params{expect_fail});
+          $name, $params{expect_fail} );
       _run_test( $t, %params );
       $t->leave;
 


### PR DESCRIPTION
We need to pass the $expect_fail setting into $output->enter_multi_test,
otherwise the display shows the wrong thing.