### PR TITLE
Rename "preparer" to "fixture"; give them teardown ability; document them

### DIFF
--- a/run-tests.pl
+++ b/run-tests.pl
@@ -298,8 +298,8 @@ sub preparer
 {
    my %args = @_;
 
-   my $do = $args{do} or croak "preparer needs a 'do' block";
-   ref( $do ) eq "CODE" or croak "Expected preparer 'do' block to be CODE";
+   my $setup = $args{setup} or croak "preparer needs a 'setup' block";
+   ref( $setup ) eq "CODE" or croak "Expected preparer 'setup' block to be CODE";
 
    my @req_futures;
    my $f_start = Future->new;
@@ -332,7 +332,7 @@ sub preparer
       sub { $f_start->done( @_ ) unless $f_start->is_ready },
 
       Future->needs_all( @req_futures )
-         ->then( $do )
+         ->then( $setup )
    );
 }
 

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -341,12 +341,16 @@ sub fixture
 
       $teardown ? sub {
          my ( $self ) = @_;
+         my $result_f = $self->result;
+         $self->result = Future->fail(
+            "This Fixture has been torn down and cannot be used again"
+         );
 
          if( $self->result->is_ready ) {
-            return $teardown->( $self->result->get );
+            return $teardown->( $result_f->get );
          }
          else {
-            $self->result->cancel;
+            $result_f->cancel;
             Future->done;
          }
       } : undef,

--- a/tests/10apidoc/01register.pl
+++ b/tests/10apidoc/01register.pl
@@ -111,13 +111,13 @@ sub matrix_register_user
    });
 }
 
-push @EXPORT, qw( local_user_preparer local_user_preparers );
+push @EXPORT, qw( local_user_fixture local_user_fixtures );
 
-sub local_user_preparer
+sub local_user_fixture
 {
    my %args = @_;
 
-   preparer(
+   fixture(
       requires => [qw( first_api_client )],
 
       setup => sub {
@@ -154,18 +154,18 @@ sub local_user_preparer
    );
 }
 
-sub local_user_preparers
+sub local_user_fixtures
 {
    my ( $count ) = @_;
 
-   return map { local_user_preparer() } 1 .. $count;
+   return map { local_user_fixture() } 1 .. $count;
 }
 
-push @EXPORT, qw( remote_user_preparer );
+push @EXPORT, qw( remote_user_fixture );
 
-sub remote_user_preparer
+sub remote_user_fixture
 {
-   preparer(
+   fixture(
       requires => [qw( api_clients )],
 
       setup => sub {
@@ -183,7 +183,7 @@ push @EXPORT, qw( SPYGLASS_USER );
 # allow it to perform HEAD and GET requests. This user is useful for tests that
 # don't mutate server-side state, so it's fairly safe to reüse this user among
 # different tests.
-our $SPYGLASS_USER = preparer(
+our $SPYGLASS_USER = fixture(
    requires => [qw( first_api_client )],
 
    setup => sub {

--- a/tests/10apidoc/01register.pl
+++ b/tests/10apidoc/01register.pl
@@ -120,7 +120,7 @@ sub local_user_preparer
    preparer(
       requires => [qw( first_api_client )],
 
-      do => sub {
+      setup => sub {
          my ( $api_client ) = @_;
 
          matrix_register_user( $api_client )
@@ -168,7 +168,7 @@ sub remote_user_preparer
    preparer(
       requires => [qw( api_clients )],
 
-      do => sub {
+      setup => sub {
          my ( $clients ) = @_;
          my $http = $clients->[1];
 
@@ -186,7 +186,7 @@ push @EXPORT, qw( SPYGLASS_USER );
 our $SPYGLASS_USER = preparer(
    requires => [qw( first_api_client )],
 
-   do => sub {
+   setup => sub {
       my ( $api_client ) = @_;
 
       matrix_register_user( $api_client )

--- a/tests/10apidoc/02login.pl
+++ b/tests/10apidoc/02login.pl
@@ -6,7 +6,7 @@ my $password = "s3kr1t";
 my $registered_user_preparer = preparer(
    requires => [qw( first_api_client )],
 
-   do => sub {
+   setup => sub {
       my ( $api_client ) = @_;
 
       $api_client->do_request_json(

--- a/tests/10apidoc/02login.pl
+++ b/tests/10apidoc/02login.pl
@@ -3,7 +3,7 @@ use JSON qw( decode_json );
 # Doesn't matter what this is, but later tests will use it.
 my $password = "s3kr1t";
 
-my $registered_user_preparer = preparer(
+my $registered_user_fixture = fixture(
    requires => [qw( first_api_client )],
 
    setup => sub {
@@ -68,7 +68,7 @@ test "GET /login yields a set of flows",
    };
 
 test "POST /login can log in as a user",
-   requires => [qw( first_api_client ), $registered_user_preparer,
+   requires => [qw( first_api_client ), $registered_user_fixture,
                 qw( can_login_password_flow )],
 
    provides => [qw( can_login first_home_server do_request_json_for do_request_json )],
@@ -103,7 +103,7 @@ test "POST /login can log in as a user",
    };
 
 test "POST /login wrong password is rejected",
-   requires => [qw( first_api_client ), $registered_user_preparer,
+   requires => [qw( first_api_client ), $registered_user_fixture,
                 qw( can_login_password_flow )],
 
    do => sub {
@@ -135,7 +135,7 @@ test "POST /login wrong password is rejected",
    };
 
 test "POST /tokenrefresh invalidates old refresh token",
-   requires => [qw( first_api_client ), $registered_user_preparer ],
+   requires => [qw( first_api_client ), $registered_user_fixture ],
 
    do => sub {
       my ( $http, $user_id ) = @_;

--- a/tests/10apidoc/10profile-displayname.pl
+++ b/tests/10apidoc/10profile-displayname.pl
@@ -1,9 +1,9 @@
-my $user_preparer = local_user_preparer();
+my $user_fixture = local_user_fixture();
 
 my $displayname = "Testing Displayname";
 
 test "PUT /profile/:user_id/displayname sets my name",
-   requires => [ $user_preparer ],
+   requires => [ $user_fixture ],
 
    provides => [qw( can_set_displayname )],
 
@@ -41,7 +41,7 @@ test "PUT /profile/:user_id/displayname sets my name",
    };
 
 test "GET /profile/:user_id/displayname publicly accessible",
-   requires => [ qw( first_api_client ), $user_preparer,
+   requires => [ qw( first_api_client ), $user_fixture,
                  qw( can_set_displayname )],
 
    provides => [qw( can_get_displayname )],

--- a/tests/10apidoc/11profile-avatar_url.pl
+++ b/tests/10apidoc/11profile-avatar_url.pl
@@ -1,9 +1,9 @@
-my $user_preparer = local_user_preparer();
+my $user_fixture = local_user_fixture();
 
 my $avatar_url = "http://somewhere/my-pic.jpg";
 
 test "PUT /profile/:user_id/avatar_url sets my avatar",
-   requires => [ $user_preparer ],
+   requires => [ $user_fixture ],
 
    provides => [qw( can_set_avatar_url )],
 
@@ -41,7 +41,7 @@ test "PUT /profile/:user_id/avatar_url sets my avatar",
    };
 
 test "GET /profile/:user_id/avatar_url publicly accessible",
-   requires => [qw( first_api_client ), $user_preparer,
+   requires => [qw( first_api_client ), $user_fixture,
                 qw( can_set_avatar_url )],
 
    check => sub {

--- a/tests/10apidoc/20presence.pl
+++ b/tests/10apidoc/20presence.pl
@@ -1,7 +1,7 @@
-my $preparer = local_user_preparer();
+my $fixture = local_user_fixture();
 
 test "GET /presence/:user_id/status fetches initial status",
-   requires => [ $preparer ],
+   requires => [ $fixture ],
 
    check => sub {
       my ( $user ) = @_;
@@ -27,7 +27,7 @@ test "GET /presence/:user_id/status fetches initial status",
 my $status_msg = "Testing something";
 
 test "PUT /presence/:user_id/status updates my presence",
-   requires => [ $preparer ],
+   requires => [ $fixture ],
 
    provides => [qw( can_set_presence )],
 

--- a/tests/10apidoc/21presence-list.pl
+++ b/tests/10apidoc/21presence-list.pl
@@ -1,11 +1,11 @@
 # Eventually this will be changed; see SPEC-53
 my $PRESENCE_LIST_URI = "/api/v1/presence/list/:user_id";
 
-my $preparer = local_user_preparer();
-my $friend_preparer = local_user_preparer();
+my $fixture = local_user_fixture();
+my $friend_fixture = local_user_fixture();
 
 test "GET /presence/:user_id/list initially empty",
-   requires => [ $preparer ],
+   requires => [ $fixture ],
 
    check => sub {
       my ( $user ) = @_;
@@ -24,7 +24,7 @@ test "GET /presence/:user_id/list initially empty",
    };
 
 test "POST /presence/:user_id/list can invite users",
-   requires => [ $preparer, $friend_preparer ],
+   requires => [ $fixture, $friend_fixture ],
 
    provides => [qw( can_invite_presence )],
 
@@ -63,7 +63,7 @@ test "POST /presence/:user_id/list can invite users",
    };
 
 test "POST /presence/:user_id/list can drop users",
-   requires => [ $preparer,
+   requires => [ $fixture,
                  qw( can_invite_presence )],
 
    provides => [qw( can_drop_presence )],

--- a/tests/10apidoc/30room-create.pl
+++ b/tests/10apidoc/30room-create.pl
@@ -1,7 +1,7 @@
-my $user_preparer = local_user_preparer();
+my $user_fixture = local_user_fixture();
 
 test "POST /createRoom makes a public room",
-   requires => [ $user_preparer,
+   requires => [ $user_fixture,
                  qw( can_initial_sync )],
 
    critical => 1,
@@ -44,7 +44,7 @@ test "POST /createRoom makes a public room",
    };
 
 test "POST /createRoom makes a private room",
-   requires => [ $user_preparer ],
+   requires => [ $user_fixture ],
 
    provides => [qw( can_create_private_room )],
 
@@ -71,7 +71,7 @@ test "POST /createRoom makes a private room",
    };
 
 test "POST /createRoom makes a private room with invites",
-   requires => [ $user_preparer, local_user_preparer(),
+   requires => [ $user_fixture, local_user_fixture(),
                  qw( can_create_private_room )],
 
    provides => [qw( can_create_private_room_with_invite )],

--- a/tests/10apidoc/31room-state.pl
+++ b/tests/10apidoc/31room-state.pl
@@ -8,7 +8,7 @@ my $user_preparer = local_user_preparer();
 my $room_preparer = preparer(
    requires => [ $user_preparer ],
 
-   do => sub {
+   setup => sub {
       my ( $user ) = @_;
 
       matrix_create_room( $user,

--- a/tests/10apidoc/31room-state.pl
+++ b/tests/10apidoc/31room-state.pl
@@ -2,11 +2,11 @@ use List::UtilsBy qw( partition_by );
 
 my $name = "room name here";
 
-my $user_preparer = local_user_preparer();
+my $user_fixture = local_user_fixture();
 
 # This provides $room_id *AND* $room_alias
-my $room_preparer = preparer(
-   requires => [ $user_preparer ],
+my $room_fixture = fixture(
+   requires => [ $user_fixture ],
 
    setup => sub {
       my ( $user ) = @_;
@@ -18,7 +18,7 @@ my $room_preparer = preparer(
 );
 
 test "GET /rooms/:room_id/state/m.room.member/:user_id fetches my membership",
-   requires => [ $user_preparer, $room_preparer ],
+   requires => [ $user_fixture, $room_fixture ],
 
    provides => [qw( can_get_room_membership )],
 
@@ -43,7 +43,7 @@ test "GET /rooms/:room_id/state/m.room.member/:user_id fetches my membership",
    };
 
 test "GET /rooms/:room_id/state/m.room.power_levels fetches powerlevels",
-   requires => [ $user_preparer, $room_preparer ],
+   requires => [ $user_fixture, $room_fixture ],
 
    provides => [qw( can_get_room_powerlevels )],
 
@@ -69,7 +69,7 @@ test "GET /rooms/:room_id/state/m.room.power_levels fetches powerlevels",
    };
 
 test "GET /rooms/:room_id/initialSync fetches initial sync state",
-   requires => [ $user_preparer, $room_preparer ],
+   requires => [ $user_fixture, $room_fixture ],
 
    provides => [qw( can_room_initial_sync )],
 
@@ -100,7 +100,7 @@ test "GET /rooms/:room_id/initialSync fetches initial sync state",
    };
 
 test "GET /publicRooms lists newly-created room",
-   requires => [qw( first_api_client ), $room_preparer ],
+   requires => [qw( first_api_client ), $room_fixture ],
 
    check => sub {
       my ( $http, $room_id, undef ) = @_;
@@ -131,7 +131,7 @@ test "GET /publicRooms lists newly-created room",
    };
 
 test "GET /directory/room/:room_alias yields room ID",
-   requires => [ our $SPYGLASS_USER, $room_preparer ],
+   requires => [ our $SPYGLASS_USER, $room_fixture ],
 
    check => sub {
       my ( $user, $room_id, $room_alias ) = @_;
@@ -152,7 +152,7 @@ test "GET /directory/room/:room_alias yields room ID",
    };
 
 test "POST /rooms/:room_id/state/m.room.name sets name",
-   requires => [ $user_preparer, $room_preparer,
+   requires => [ $user_fixture, $room_fixture,
                  qw( can_room_initial_sync )],
 
    provides => [qw( can_set_room_name )],
@@ -192,7 +192,7 @@ test "POST /rooms/:room_id/state/m.room.name sets name",
    };
 
 test "GET /rooms/:room_id/state/m.room.name gets name",
-   requires => [ $user_preparer, $room_preparer,
+   requires => [ $user_fixture, $room_fixture,
                  qw( can_set_room_name )],
 
    provides => [qw( can_get_room_name )],
@@ -220,7 +220,7 @@ test "GET /rooms/:room_id/state/m.room.name gets name",
 my $topic = "A new topic for the room";
 
 test "POST /rooms/:room_id/state/m.room.topic sets topic",
-   requires => [ $user_preparer, $room_preparer,
+   requires => [ $user_fixture, $room_fixture,
                  qw( can_room_initial_sync )],
 
    provides => [qw( can_set_room_topic )],
@@ -260,7 +260,7 @@ test "POST /rooms/:room_id/state/m.room.topic sets topic",
    };
 
 test "GET /rooms/:room_id/state/m.room.topic gets topic",
-   requires => [ $user_preparer, $room_preparer,
+   requires => [ $user_fixture, $room_fixture,
                  qw( can_set_room_topic )],
 
    provides => [qw( can_get_room_topic )],
@@ -286,7 +286,7 @@ test "GET /rooms/:room_id/state/m.room.topic gets topic",
    };
 
 test "GET /rooms/:room_id/state fetches entire room state",
-   requires => [ $user_preparer, $room_preparer ],
+   requires => [ $user_fixture, $room_fixture ],
 
    provides => [qw( can_get_room_all_state )],
 
@@ -315,7 +315,7 @@ test "GET /rooms/:room_id/state fetches entire room state",
 # This test is best deferred to here, so we can fetch the state
 
 test "POST /createRoom with creation content",
-   requires => [ $user_preparer ],
+   requires => [ $user_fixture ],
 
    provides => [qw( can_create_room_with_creation_content )],
 

--- a/tests/10apidoc/32room-alias.pl
+++ b/tests/10apidoc/32room-alias.pl
@@ -1,9 +1,9 @@
 my $alias_localpart = "#another-alias";
 
-my $user_preparer = local_user_preparer();
+my $user_fixture = local_user_fixture();
 
-my $room_preparer = preparer(
-   requires => [ $user_preparer ],
+my $room_fixture = fixture(
+   requires => [ $user_fixture ],
 
    setup => sub {
       my ( $user ) = @_;
@@ -13,7 +13,7 @@ my $room_preparer = preparer(
 );
 
 test "PUT /directory/room/:room_alias creates alias",
-   requires => [qw( first_home_server ), $user_preparer, $room_preparer ],
+   requires => [qw( first_home_server ), $user_fixture, $room_fixture ],
 
    provides => [qw( can_create_room_alias can_lookup_room_alias )],
 

--- a/tests/10apidoc/32room-alias.pl
+++ b/tests/10apidoc/32room-alias.pl
@@ -5,7 +5,7 @@ my $user_preparer = local_user_preparer();
 my $room_preparer = preparer(
    requires => [ $user_preparer ],
 
-   do => sub {
+   setup => sub {
       my ( $user ) = @_;
 
       matrix_create_room( $user );

--- a/tests/10apidoc/33room-members.pl
+++ b/tests/10apidoc/33room-members.pl
@@ -2,11 +2,11 @@ use Future 0.33; # then catch semantics
 use Future::Utils qw( fmap );
 use List::UtilsBy qw( partition_by );
 
-my $creator_preparer = local_user_preparer();
+my $creator_fixture = local_user_fixture();
 
 # This provides $room_id *AND* $room_alias
-my $room_preparer = preparer(
-   requires => [ $creator_preparer ],
+my $room_fixture = fixture(
+   requires => [ $creator_fixture ],
 
    setup => sub {
       my ( $user ) = @_;
@@ -18,7 +18,7 @@ my $room_preparer = preparer(
 );
 
 test "POST /rooms/:room_id/join can join a room",
-   requires => [ local_user_preparer(), $room_preparer,
+   requires => [ local_user_fixture(), $room_fixture,
                  qw( can_get_room_membership )],
 
    critical => 1,
@@ -66,7 +66,7 @@ sub matrix_join_room
 }
 
 test "POST /join/:room_alias can join a room",
-   requires => [ local_user_preparer(), $room_preparer,
+   requires => [ local_user_fixture(), $room_fixture,
                  qw( can_get_room_membership )],
 
    provides => [qw( can_join_room_by_alias )],
@@ -108,7 +108,7 @@ test "POST /join/:room_alias can join a room",
    };
 
 test "POST /join/:room_id can join a room",
-   requires => [ local_user_preparer(), $room_preparer,
+   requires => [ local_user_fixture(), $room_fixture,
                  qw( can_get_room_membership )],
 
    do => sub {
@@ -147,7 +147,7 @@ test "POST /join/:room_id can join a room",
    };
 
 test "POST /rooms/:room_id/leave can leave a room",
-   requires => [ local_user_preparer(), $room_preparer,
+   requires => [ local_user_fixture(), $room_fixture,
                  qw( can_get_room_membership )],
 
    critical => 1,
@@ -204,7 +204,7 @@ sub matrix_leave_room
 }
 
 test "POST /rooms/:room_id/invite can send an invite",
-   requires => [ $creator_preparer, local_user_preparer(), $room_preparer,
+   requires => [ $creator_fixture, local_user_fixture(), $room_fixture,
                  qw( can_get_room_membership )],
 
    provides => [qw( can_invite_room )],
@@ -265,7 +265,7 @@ sub matrix_invite_user_to_room
 }
 
 test "POST /rooms/:room_id/ban can ban a user",
-   requires => [ $creator_preparer, local_user_preparer(), $room_preparer,
+   requires => [ $creator_fixture, local_user_fixture(), $room_fixture,
                  qw( can_get_room_membership )],
 
    provides => [qw( can_ban_room )],
@@ -385,13 +385,13 @@ sub matrix_create_and_join_room
    })
 }
 
-push @EXPORT, qw( room_preparer );
+push @EXPORT, qw( room_fixture );
 
-sub room_preparer
+sub room_fixture
 {
    my %args = @_;
 
-   preparer(
+   fixture(
       requires => $args{requires_users},
 
       setup => sub {
@@ -402,14 +402,14 @@ sub room_preparer
    );
 }
 
-push @EXPORT, qw( local_user_and_room_preparers );
+push @EXPORT, qw( local_user_and_room_fixtures );
 
-sub local_user_and_room_preparers
+sub local_user_and_room_fixtures
 {
-   my $user_preparer = local_user_preparer();
+   my $user_fixture = local_user_fixture();
 
    return (
-      $user_preparer,
-      room_preparer( requires_users => [ $user_preparer ] ),
+      $user_fixture,
+      room_fixture( requires_users => [ $user_fixture ] ),
    );
 }

--- a/tests/10apidoc/33room-members.pl
+++ b/tests/10apidoc/33room-members.pl
@@ -8,7 +8,7 @@ my $creator_preparer = local_user_preparer();
 my $room_preparer = preparer(
    requires => [ $creator_preparer ],
 
-   do => sub {
+   setup => sub {
       my ( $user ) = @_;
 
       matrix_create_room( $user,
@@ -394,7 +394,7 @@ sub room_preparer
    preparer(
       requires => $args{requires_users},
 
-      do => sub {
+      setup => sub {
          my @members = @_;
 
          matrix_create_and_join_room( \@members )

--- a/tests/10apidoc/34room-messages.pl
+++ b/tests/10apidoc/34room-messages.pl
@@ -1,5 +1,5 @@
 test "POST /rooms/:room_id/send/:event_type sends a message",
-   requires => [ local_user_and_room_preparers() ],
+   requires => [ local_user_and_room_fixtures() ],
 
    provides => [qw( can_send_message )],
 
@@ -75,7 +75,7 @@ sub matrix_send_room_text_message
 }
 
 test "GET /rooms/:room_id/messages returns a message",
-   requires => [ local_user_and_room_preparers(),
+   requires => [ local_user_and_room_fixtures(),
                  qw( can_send_message )],
 
    provides => [qw( can_get_messages )],

--- a/tests/10apidoc/35room-typing.pl
+++ b/tests/10apidoc/35room-typing.pl
@@ -1,5 +1,5 @@
 test "PUT /rooms/:room_id/typing/:user_id sets typing notification",
-   requires => [ local_user_and_room_preparers() ],
+   requires => [ local_user_and_room_fixtures() ],
 
    provides => [qw( can_set_room_typing )],
 

--- a/tests/10apidoc/36room-levels.pl
+++ b/tests/10apidoc/36room-levels.pl
@@ -1,7 +1,7 @@
-my ( $user_preparer, $room_preparer ) = local_user_and_room_preparers();
+my ( $user_fixture, $room_fixture ) = local_user_and_room_fixtures();
 
 test "GET /rooms/:room_id/state/m.room.power_levels can fetch levels",
-   requires => [ $user_preparer, $room_preparer ],
+   requires => [ $user_fixture, $room_fixture ],
 
    provides => [qw( can_get_power_levels )],
 
@@ -37,7 +37,7 @@ test "GET /rooms/:room_id/state/m.room.power_levels can fetch levels",
    };
 
 test "PUT /rooms/:room_id/state/m.room.power_levels can set levels",
-   requires => [ $user_preparer, $room_preparer,
+   requires => [ $user_fixture, $room_fixture,
                  qw( can_get_power_levels )],
 
    provides => [qw( can_set_power_levels )],

--- a/tests/10apidoc/37room-receipts.pl
+++ b/tests/10apidoc/37room-receipts.pl
@@ -1,5 +1,5 @@
 test "POST /rooms/:room_id/receipt can create receipts",
-   requires => [ local_user_and_room_preparers() ],
+   requires => [ local_user_and_room_fixtures() ],
 
    provides => [qw( can_post_room_receipts )],
 

--- a/tests/10apidoc/40content.pl
+++ b/tests/10apidoc/40content.pl
@@ -6,7 +6,7 @@ my $content_type = "text/plain";
 my $content_id;
 
 test "POST /media/v1/upload can create an upload",
-   requires => [qw( first_api_client ), local_user_preparer() ],
+   requires => [qw( first_api_client ), local_user_fixture() ],
 
    provides => [qw( can_upload_media )],
 

--- a/tests/20profile-events.pl
+++ b/tests/20profile-events.pl
@@ -1,9 +1,9 @@
-my $user_preparer = local_user_preparer();
+my $user_fixture = local_user_fixture();
 
 my $displayname = "New displayname for 20profile-events.pl";
 
 test "Displayname change reports an event to myself",
-   requires => [ $user_preparer,
+   requires => [ $user_fixture,
                  qw( can_set_displayname )],
 
    do => sub {
@@ -35,7 +35,7 @@ test "Displayname change reports an event to myself",
 my $avatar_url = "http://a.new.url/for/20profile-events.pl";
 
 test "Avatar URL change reports an event to myself",
-   requires => [ $user_preparer,
+   requires => [ $user_fixture,
                  qw( can_set_avatar_url )],
 
    do => sub {
@@ -62,7 +62,7 @@ test "Avatar URL change reports an event to myself",
    };
 
 multi_test "Global /initialSync reports my own profile",
-   requires => [ $user_preparer,
+   requires => [ $user_fixture,
                  qw( can_set_displayname can_set_avatar_url can_initial_sync )],
 
    check => sub {

--- a/tests/21presence-events.pl
+++ b/tests/21presence-events.pl
@@ -1,10 +1,10 @@
 # Eventually this will be changed; see SPEC-53
 my $PRESENCE_LIST_URI = "/api/v1/presence/list/:user_id";
 
-my $preparer = local_user_preparer();
+my $fixture = local_user_fixture();
 
 test "initialSync sees my presence status",
-   requires => [ $preparer,
+   requires => [ $fixture,
                  qw( can_initial_sync )],
 
    check => sub {
@@ -36,7 +36,7 @@ test "initialSync sees my presence status",
 my $status_msg = "A status set by 21presence-events.pl";
 
 test "Presence change reports an event to myself",
-   requires => [ $preparer,
+   requires => [ $fixture,
                  qw( can_set_presence )],
 
    do => sub {
@@ -65,7 +65,7 @@ test "Presence change reports an event to myself",
 my $friend_status = "Status of a Friend";
 
 test "Friends presence changes reports events",
-   requires => [ $preparer, local_user_preparer(),
+   requires => [ $fixture, local_user_fixture(),
                  qw( can_set_presence can_invite_presence )],
 
    do => sub {

--- a/tests/30rooms/01state.pl
+++ b/tests/30rooms/01state.pl
@@ -1,11 +1,11 @@
 use List::UtilsBy qw( partition_by );
 
-my $user_preparer = local_user_preparer(
+my $user_fixture = local_user_fixture(
    presence => "online",
 );
 
-my $room_preparer = preparer(
-   requires => [ $user_preparer ],
+my $room_fixture = fixture(
+   requires => [ $user_fixture ],
 
    setup => sub {
       my ( $user ) = @_;
@@ -17,7 +17,7 @@ my $room_preparer = preparer(
 );
 
 test "Room creation reports m.room.create to myself",
-   requires => [ $user_preparer, $room_preparer ],
+   requires => [ $user_fixture, $room_fixture ],
 
    do => sub {
       my ( $user, $room_id ) = @_;
@@ -40,7 +40,7 @@ test "Room creation reports m.room.create to myself",
    };
 
 test "Room creation reports m.room.member to myself",
-   requires => [ $user_preparer, $room_preparer ],
+   requires => [ $user_fixture, $room_fixture ],
 
    do => sub {
       my ( $user, $room_id ) = @_;
@@ -64,7 +64,7 @@ test "Room creation reports m.room.member to myself",
 my $topic = "Testing topic for the new room";
 
 test "Setting room topic reports m.room.topic to myself",
-   requires => [ $user_preparer, $room_preparer,
+   requires => [ $user_fixture, $room_fixture,
                 qw( can_set_room_topic )],
 
    do => sub {
@@ -93,7 +93,7 @@ test "Setting room topic reports m.room.topic to myself",
    };
 
 multi_test "Global initialSync",
-   requires => [ $user_preparer, $room_preparer,
+   requires => [ $user_fixture, $room_fixture,
                 qw( can_initial_sync can_set_room_topic )],
 
    check => sub {
@@ -147,7 +147,7 @@ multi_test "Global initialSync",
    };
 
 test "Global initialSync with limit=0 gives no messages",
-   requires => [ $user_preparer, $room_preparer,
+   requires => [ $user_fixture, $room_fixture,
                 qw( can_initial_sync )],
 
    check => sub {
@@ -172,7 +172,7 @@ test "Global initialSync with limit=0 gives no messages",
    };
 
 multi_test "Room initialSync",
-   requires => [ $user_preparer, $room_preparer,
+   requires => [ $user_fixture, $room_fixture,
                 qw( can_room_initial_sync )],
 
    check => sub {
@@ -222,7 +222,7 @@ multi_test "Room initialSync",
    };
 
 test "Room initialSync with limit=0 gives no messages",
-   requires => [ $user_preparer, $room_preparer,
+   requires => [ $user_fixture, $room_fixture,
                 qw( can_initial_sync )],
 
    check => sub {

--- a/tests/30rooms/01state.pl
+++ b/tests/30rooms/01state.pl
@@ -7,7 +7,7 @@ my $user_preparer = local_user_preparer(
 my $room_preparer = preparer(
    requires => [ $user_preparer ],
 
-   do => sub {
+   setup => sub {
       my ( $user ) = @_;
 
       matrix_create_room( $user,

--- a/tests/30rooms/02members-local.pl
+++ b/tests/30rooms/02members-local.pl
@@ -1,14 +1,14 @@
 use List::Util qw( first );
 
-my $creator_preparer = local_user_preparer(
+my $creator_fixture = local_user_fixture(
    # Some of these tests depend on the user having a displayname
    displayname => "My name here",
 );
 
-my $local_user_preparer = local_user_preparer();
+my $local_user_fixture = local_user_fixture();
 
-my $room_preparer = preparer(
-   requires => [ $creator_preparer, $local_user_preparer ],
+my $room_fixture = fixture(
+   requires => [ $creator_fixture, $local_user_fixture ],
 
    setup => sub {
       my ( $creator, $local_user ) = @_;
@@ -31,7 +31,7 @@ my $room_preparer = preparer(
 );
 
 test "New room members see their own join event",
-   requires => [ $local_user_preparer, $room_preparer ],
+   requires => [ $local_user_fixture, $room_fixture ],
 
    do => sub {
       my ( $local_user, $room_id ) = @_;
@@ -54,7 +54,7 @@ test "New room members see their own join event",
    };
 
 test "New room members see existing users' presence in room initialSync",
-   requires => [ $creator_preparer, $local_user_preparer, $room_preparer,
+   requires => [ $creator_fixture, $local_user_fixture, $room_fixture,
                  qw( can_room_initial_sync )],
 
    check => sub {
@@ -82,7 +82,7 @@ test "New room members see existing users' presence in room initialSync",
    };
 
 test "Existing members see new members' join events",
-   requires => [ $creator_preparer, $local_user_preparer, $room_preparer ],
+   requires => [ $creator_fixture, $local_user_fixture, $room_fixture ],
 
    do => sub {
       my ( $first_user, $local_user, $room_id ) = @_;
@@ -104,7 +104,7 @@ test "Existing members see new members' join events",
    };
 
 test "Existing members see new members' presence",
-   requires => [ $creator_preparer, $local_user_preparer, $room_preparer ],
+   requires => [ $creator_fixture, $local_user_fixture, $room_fixture ],
 
    do => sub {
       my ( $first_user, $local_user ) = @_;
@@ -121,7 +121,7 @@ test "Existing members see new members' presence",
    };
 
 test "All room members see all room members' presence in global initialSync",
-   requires => [ $creator_preparer, $local_user_preparer, $room_preparer,
+   requires => [ $creator_fixture, $local_user_fixture, $room_fixture,
                  qw( can_initial_sync )],
 
    check => sub {
@@ -160,7 +160,7 @@ test "All room members see all room members' presence in global initialSync",
    };
 
 test "New room members see first user's profile information in global initialSync",
-   requires => [ $creator_preparer, $local_user_preparer, $room_preparer,
+   requires => [ $creator_fixture, $local_user_fixture, $room_fixture,
                  qw( can_initial_sync can_set_displayname can_set_avatar_url )],
 
    check => sub {
@@ -186,7 +186,7 @@ test "New room members see first user's profile information in global initialSyn
    };
 
 test "New room members see first user's profile information in per-room initialSync",
-   requires => [ $creator_preparer, $local_user_preparer, $room_preparer,
+   requires => [ $creator_fixture, $local_user_fixture, $room_fixture,
                  qw( can_room_initial_sync can_set_displayname can_set_avatar_url )],
 
    check => sub {

--- a/tests/30rooms/02members-local.pl
+++ b/tests/30rooms/02members-local.pl
@@ -10,7 +10,7 @@ my $local_user_preparer = local_user_preparer();
 my $room_preparer = preparer(
    requires => [ $creator_preparer, $local_user_preparer ],
 
-   do => sub {
+   setup => sub {
       my ( $creator, $local_user ) = @_;
 
       # Don't use matrix_create_and_join_room here because we explicitly do

--- a/tests/30rooms/03members-remote.pl
+++ b/tests/30rooms/03members-remote.pl
@@ -2,15 +2,15 @@ use Future::Utils 0.18 qw( try_repeat );
 use List::Util qw( first );
 use List::UtilsBy qw( partition_by );
 
-my $creator_preparer = local_user_preparer(
+my $creator_fixture = local_user_fixture(
    # Some of these tests depend on the user having a displayname
    displayname => "My name here",
 );
 
-my $remote_user_preparer = remote_user_preparer();
+my $remote_user_fixture = remote_user_fixture();
 
-my $room_preparer = preparer(
-   requires => [ $creator_preparer ],
+my $room_fixture = fixture(
+   requires => [ $creator_fixture ],
 
    setup => sub {
       my ( $user ) = @_;
@@ -22,7 +22,7 @@ my $room_preparer = preparer(
 );
 
 test "Remote users can join room by alias",
-   requires => [ $remote_user_preparer, $room_preparer,
+   requires => [ $remote_user_fixture, $room_fixture,
                  qw( can_join_room_by_alias can_get_room_membership )],
 
    provides => [qw( can_join_remote_room_by_alias )],
@@ -59,7 +59,7 @@ test "Remote users can join room by alias",
    };
 
 test "New room members see their own join event",
-   requires => [ $remote_user_preparer, $room_preparer,
+   requires => [ $remote_user_fixture, $room_fixture,
                  qw( can_join_remote_room_by_alias )],
 
    do => sub {
@@ -83,7 +83,7 @@ test "New room members see their own join event",
    };
 
 test "New room members see existing members' presence in room initialSync",
-   requires => [ $creator_preparer, $remote_user_preparer, $room_preparer,
+   requires => [ $creator_fixture, $remote_user_fixture, $room_fixture,
                  qw( can_join_remote_room_by_alias can_room_initial_sync )],
 
    do => sub {
@@ -114,7 +114,7 @@ test "New room members see existing members' presence in room initialSync",
    };
 
 test "Existing members see new members' join events",
-   requires => [ $creator_preparer, $remote_user_preparer, $room_preparer,
+   requires => [ $creator_fixture, $remote_user_fixture, $room_fixture,
                  qw( can_join_remote_room_by_alias )],
 
    do => sub {
@@ -137,7 +137,7 @@ test "Existing members see new members' join events",
    };
 
 test "Existing members see new member's presence",
-   requires => [ $creator_preparer, $remote_user_preparer, $room_preparer,
+   requires => [ $creator_fixture, $remote_user_fixture, $room_fixture,
                  qw( can_join_remote_room_by_alias )],
 
    do => sub {
@@ -155,7 +155,7 @@ test "Existing members see new member's presence",
    };
 
 test "New room members see first user's profile information in global initialSync",
-   requires => [ $creator_preparer, $remote_user_preparer, $room_preparer,
+   requires => [ $creator_fixture, $remote_user_fixture, $room_fixture,
                  qw( can_join_remote_room_by_alias can_initial_sync can_set_displayname can_set_avatar_url )],
 
    check => sub {
@@ -181,7 +181,7 @@ test "New room members see first user's profile information in global initialSyn
    };
 
 test "New room members see first user's profile information in per-room initialSync",
-   requires => [ $creator_preparer, $remote_user_preparer, $room_preparer,
+   requires => [ $creator_fixture, $remote_user_fixture, $room_fixture,
                  qw( can_room_initial_sync can_set_displayname can_set_avatar_url )],
 
    check => sub {
@@ -215,7 +215,7 @@ test "New room members see first user's profile information in per-room initialS
    };
 
 test "Remote users may not join unfederated rooms",
-   requires => [ local_user_preparer(), remote_user_preparer(),
+   requires => [ local_user_fixture(), remote_user_fixture(),
                  qw( can_create_room_with_creation_content )],
 
    check => sub {

--- a/tests/30rooms/03members-remote.pl
+++ b/tests/30rooms/03members-remote.pl
@@ -12,7 +12,7 @@ my $remote_user_preparer = remote_user_preparer();
 my $room_preparer = preparer(
    requires => [ $creator_preparer ],
 
-   do => sub {
+   setup => sub {
       my ( $user ) = @_;
 
       matrix_create_room( $user,

--- a/tests/30rooms/04messages.pl
+++ b/tests/30rooms/04messages.pl
@@ -1,18 +1,18 @@
-my $senduser_preparer = local_user_preparer();
+my $senduser_fixture = local_user_fixture();
 
-my $local_user_preparer = local_user_preparer();
+my $local_user_fixture = local_user_fixture();
 
-my $remote_preparer = remote_user_preparer();
+my $remote_fixture = remote_user_fixture();
 
-my $room_preparer = room_preparer(
-   requires_users => [ $senduser_preparer, $local_user_preparer, $remote_preparer ],
+my $room_fixture = room_fixture(
+   requires_users => [ $senduser_fixture, $local_user_fixture, $remote_fixture ],
 );
 
 my $msgtype = "m.message";
 my $msgbody = "Room message for 33room-messages";
 
 test "Local room members see posted message events",
-   requires => [ $senduser_preparer, $local_user_preparer, $room_preparer,
+   requires => [ $senduser_fixture, $local_user_fixture, $room_fixture,
                  qw( can_send_message )],
 
    provides => [qw( can_receive_room_message_locally )],
@@ -51,7 +51,7 @@ test "Local room members see posted message events",
    };
 
 test "Fetching eventstream a second time doesn't yield the message again",
-   requires => [ $senduser_preparer, $local_user_preparer,
+   requires => [ $senduser_fixture, $local_user_fixture,
                  qw( can_receive_room_message_locally )],
 
    check => sub {
@@ -84,7 +84,7 @@ test "Fetching eventstream a second time doesn't yield the message again",
    };
 
 test "Local non-members don't see posted message events",
-   requires => [ local_user_preparer(), $room_preparer, ],
+   requires => [ local_user_fixture(), $room_fixture, ],
 
    do => sub {
       my ( $nonmember, $room_id ) = @_;
@@ -108,7 +108,7 @@ test "Local non-members don't see posted message events",
    };
 
 test "Local room members can get room messages",
-   requires => [ $senduser_preparer, $local_user_preparer, $room_preparer,
+   requires => [ $senduser_fixture, $local_user_fixture, $room_fixture,
                  qw( can_send_message can_get_messages )],
 
    check => sub {
@@ -145,7 +145,7 @@ test "Local room members can get room messages",
    };
 
 test "Remote room members also see posted message events",
-   requires => [ $senduser_preparer, $remote_preparer, $room_preparer,
+   requires => [ $senduser_fixture, $remote_fixture, $room_fixture,
                 qw( can_receive_room_message_locally )],
 
    do => sub {
@@ -172,7 +172,7 @@ test "Remote room members also see posted message events",
    };
 
 test "Remote room members can get room messages",
-   requires => [ $remote_preparer, $room_preparer,
+   requires => [ $remote_fixture, $room_fixture,
                  qw( can_send_message can_get_messages )],
 
    check => sub {

--- a/tests/30rooms/05aliases.pl
+++ b/tests/30rooms/05aliases.pl
@@ -5,14 +5,14 @@ use utf8;
 my $alias_localpart = "#☕";
 my $room_alias;
 
-my $creator_preparer = local_user_preparer();
+my $creator_fixture = local_user_fixture();
 
-my $room_preparer = room_preparer(
-   requires_users => [ $creator_preparer ],
+my $room_fixture = room_fixture(
+   requires_users => [ $creator_fixture ],
 );
 
 test "Room aliases can contain Unicode",
-   requires => [qw( first_home_server ), $creator_preparer, $room_preparer,
+   requires => [qw( first_home_server ), $creator_fixture, $room_fixture,
                 qw( can_create_room_alias )],
 
    provides => [qw( can_create_room_alias_unicode )],
@@ -50,7 +50,7 @@ test "Room aliases can contain Unicode",
    };
 
 test "Remote room alias queries can handle Unicode",
-   requires => [ remote_user_preparer(), $room_preparer,
+   requires => [ remote_user_fixture(), $room_fixture,
                  qw( can_create_room_alias_unicode )],
 
    provides => [qw( can_federate_room_alias_unicode )],
@@ -73,7 +73,7 @@ test "Remote room alias queries can handle Unicode",
    };
 
 multi_test "Canonical alias can be set",
-   requires => [ local_user_preparer() ],
+   requires => [ local_user_fixture() ],
 
    do => sub {
       my ( $user ) = @_;

--- a/tests/30rooms/06invite.pl
+++ b/tests/30rooms/06invite.pl
@@ -9,7 +9,7 @@ sub inviteonly_room_preparer
    preparer(
       requires => [ $args{creator} ],
 
-      do => sub {
+      setup => sub {
          my ( $creator ) = @_;
 
          matrix_create_room( $creator,

--- a/tests/30rooms/06invite.pl
+++ b/tests/30rooms/06invite.pl
@@ -1,12 +1,12 @@
 use List::Util qw( first );
 
-my $creator_preparer = local_user_preparer();
+my $creator_fixture = local_user_fixture();
 
-sub inviteonly_room_preparer
+sub inviteonly_room_fixture
 {
    my %args = @_;
 
-   preparer(
+   fixture(
       requires => [ $args{creator} ],
 
       setup => sub {
@@ -41,10 +41,10 @@ sub inviteonly_room_preparer
    )
 };
 
-my $inviteonly_room_preparer = inviteonly_room_preparer( creator => $creator_preparer );
+my $inviteonly_room_fixture = inviteonly_room_fixture( creator => $creator_fixture );
 
 test "Uninvited users cannot join the room",
-   requires => [ local_user_preparer(), $inviteonly_room_preparer ],
+   requires => [ local_user_fixture(), $inviteonly_room_fixture ],
 
    check => sub {
       my ( $uninvited, $room_id ) = @_;
@@ -53,10 +53,10 @@ test "Uninvited users cannot join the room",
          ->main::expect_http_403;
    };
 
-my $invited_user_preparer = local_user_preparer();
+my $invited_user_fixture = local_user_fixture();
 
 test "Can invite users to invite-only rooms",
-   requires => [ $creator_preparer, $invited_user_preparer, $inviteonly_room_preparer,
+   requires => [ $creator_fixture, $invited_user_fixture, $inviteonly_room_fixture,
                 qw( can_invite_room )],
 
    do => sub {
@@ -66,7 +66,7 @@ test "Can invite users to invite-only rooms",
    };
 
 test "Invited user receives invite",
-   requires => [ $invited_user_preparer, $inviteonly_room_preparer,
+   requires => [ $invited_user_fixture, $inviteonly_room_fixture,
                  qw( can_invite_room )],
 
    do => sub {
@@ -92,7 +92,7 @@ test "Invited user receives invite",
    };
 
 test "Invited user can join the room",
-   requires => [ $invited_user_preparer, $inviteonly_room_preparer,
+   requires => [ $invited_user_fixture, $inviteonly_room_fixture,
                  qw( can_invite_room )],
 
    do => sub {
@@ -114,21 +114,21 @@ test "Invited user can join the room",
       });
    };
 
-my $other_local_user_preparer = local_user_preparer();
+my $other_local_user_fixture = local_user_fixture();
 
 test "Invited user can reject invite",
-   requires => [ local_user_preparer(),
+   requires => [ local_user_fixture(),
       do {
-         my $creator = local_user_preparer();
-         $creator, inviteonly_room_preparer( creator => $creator );
+         my $creator = local_user_fixture();
+         $creator, inviteonly_room_fixture( creator => $creator );
    } ],
    do => \&invited_user_can_reject_invite;
 
 test "Invited user can reject invite over federation",
-   requires => [ remote_user_preparer(),
+   requires => [ remote_user_fixture(),
       do {
-         my $creator = local_user_preparer();
-         $creator, inviteonly_room_preparer( creator => $creator );
+         my $creator = local_user_fixture();
+         $creator, inviteonly_room_fixture( creator => $creator );
    } ],
    do => \&invited_user_can_reject_invite;
 

--- a/tests/30rooms/07ban.pl
+++ b/tests/30rooms/07ban.pl
@@ -1,10 +1,10 @@
-my $creator_preparer = local_user_preparer();
+my $creator_fixture = local_user_fixture();
 
-my $banned_user_preparer = local_user_preparer();
+my $banned_user_fixture = local_user_fixture();
 
 test "Banned user is kicked and may not rejoin",
-   requires => [ $creator_preparer, $banned_user_preparer,
-                     room_preparer( requires_users => [ $creator_preparer, $banned_user_preparer ] ),
+   requires => [ $creator_fixture, $banned_user_fixture,
+                     room_fixture( requires_users => [ $creator_fixture, $banned_user_fixture ] ),
                 qw( can_ban_room )],
 
    do => sub {

--- a/tests/30rooms/08levels.pl
+++ b/tests/30rooms/08levels.pl
@@ -11,7 +11,7 @@ sub lockeddown_room_preparer
       requires => [ $creator_preparer, $user_preparer,
                     qw( can_change_power_levels ) ],
 
-      do => sub {
+      setup => sub {
          my ( $creator, $test_user ) = @_;
 
          matrix_create_and_join_room( [ $creator, $test_user ] )

--- a/tests/30rooms/08levels.pl
+++ b/tests/30rooms/08levels.pl
@@ -1,14 +1,14 @@
 use List::Util qw( first );
 
 # No harm in sharing the users as every test runs in its own room
-my $creator_preparer = local_user_preparer();
+my $creator_fixture = local_user_fixture();
 
-my $user_preparer = local_user_preparer();
+my $user_fixture = local_user_fixture();
 
-sub lockeddown_room_preparer
+sub lockeddown_room_fixture
 {
-   preparer(
-      requires => [ $creator_preparer, $user_preparer,
+   fixture(
+      requires => [ $creator_fixture, $user_fixture,
                     qw( can_change_power_levels ) ],
 
       setup => sub {
@@ -37,7 +37,7 @@ sub test_powerlevel
    my @requires = @{ $args{requires} };
 
    multi_test $name,
-      requires => [ $creator_preparer, $user_preparer, lockeddown_room_preparer(),
+      requires => [ $creator_fixture, $user_fixture, lockeddown_room_fixture(),
                     qw( can_change_power_levels ),
                     @requires ],
 
@@ -117,7 +117,7 @@ test_powerlevel "setting 'm.room.power_levels' respects room powerlevel",
    };
 
 test "Unprivileged users can set m.room.topic if it only needs level 0",
-   requires => [ $creator_preparer, $user_preparer, lockeddown_room_preparer(),
+   requires => [ $creator_fixture, $user_fixture, lockeddown_room_fixture(),
                  qw( can_change_power_levels )],
 
    do => sub {
@@ -137,7 +137,7 @@ test "Unprivileged users can set m.room.topic if it only needs level 0",
 
 foreach my $levelname (qw( ban kick redact )) {
    multi_test "Users cannot set $levelname powerlevel higher than their own",
-      requires => [ $creator_preparer, $user_preparer, lockeddown_room_preparer(),
+      requires => [ $creator_fixture, $user_fixture, lockeddown_room_fixture(),
                     qw( can_change_power_levels )],
 
       do => sub {

--- a/tests/30rooms/10redactions.pl
+++ b/tests/30rooms/10redactions.pl
@@ -17,7 +17,7 @@ sub make_room_and_message
 }
 
 test "POST /rooms/:room_id/redact/:event_id as power user redacts message",
-   requires => [ local_user_preparers( 2 ),
+   requires => [ local_user_fixtures( 2 ),
                  qw( can_send_message )],
 
    do => sub {
@@ -36,7 +36,7 @@ test "POST /rooms/:room_id/redact/:event_id as power user redacts message",
    };
 
 test "POST /rooms/:room_id/redact/:event_id as original message sender redacts message",
-   requires => [ local_user_preparers( 2 ),
+   requires => [ local_user_fixtures( 2 ),
                  qw( can_send_message )],
 
    do => sub {
@@ -55,7 +55,7 @@ test "POST /rooms/:room_id/redact/:event_id as original message sender redacts m
    };
 
 test "POST /rooms/:room_id/redact/:event_id as random user does not redact message",
-   requires => [ local_user_preparers( 3 ),
+   requires => [ local_user_fixtures( 3 ),
                  qw( can_send_message )],
 
    do => sub {

--- a/tests/30rooms/11leaving.pl
+++ b/tests/30rooms/11leaving.pl
@@ -6,7 +6,7 @@ my $room_preparer = preparer(
     requires => [ $left_user_preparer, local_user_preparer(),
                  qw( can_send_message )],
 
-    do => sub {
+    setup => sub {
         my ( $leaving_user, $other_user ) = @_;
 
         my $room_id;

--- a/tests/30rooms/11leaving.pl
+++ b/tests/30rooms/11leaving.pl
@@ -1,9 +1,9 @@
 use List::Util qw( first );
 
-my $left_user_preparer = local_user_preparer();
+my $left_user_fixture = local_user_fixture();
 
-my $room_preparer = preparer(
-    requires => [ $left_user_preparer, local_user_preparer(),
+my $room_fixture = fixture(
+    requires => [ $left_user_fixture, local_user_fixture(),
                  qw( can_send_message )],
 
     setup => sub {
@@ -64,7 +64,7 @@ my $room_preparer = preparer(
 );
 
 test "A departed room is still included in /initialSync (SPEC-216)",
-    requires => [ $left_user_preparer, $room_preparer ],
+    requires => [ $left_user_fixture, $room_fixture ],
 
     check => sub {
         my ( $user, $room_id ) = @_;
@@ -97,7 +97,7 @@ test "A departed room is still included in /initialSync (SPEC-216)",
     };
 
 test "Can get rooms/{roomId}/initialSync for a departed room (SPEC-216)",
-    requires => [ $left_user_preparer, $room_preparer ],
+    requires => [ $left_user_fixture, $room_fixture ],
 
     check => sub {
         my ( $user, $room_id ) = @_;
@@ -134,7 +134,7 @@ test "Can get rooms/{roomId}/initialSync for a departed room (SPEC-216)",
     };
 
 test "Can get rooms/{roomId}/state for a departed room (SPEC-216)",
-    requires => [ $left_user_preparer, $room_preparer ],
+    requires => [ $left_user_fixture, $room_fixture ],
 
     check => sub {
         my ( $user, $room_id ) = @_;
@@ -155,7 +155,7 @@ test "Can get rooms/{roomId}/state for a departed room (SPEC-216)",
     };
 
 test "Can get rooms/{roomId}/members for a departed room (SPEC-216)",
-    requires => [ $left_user_preparer, $room_preparer ],
+    requires => [ $left_user_fixture, $room_fixture ],
 
     check => sub {
         my ( $user, $room_id ) = @_;
@@ -180,7 +180,7 @@ test "Can get rooms/{roomId}/members for a departed room (SPEC-216)",
     };
 
 test "Can get rooms/{roomId}/messages for a departed room (SPEC-216)",
-    requires => [ $left_user_preparer, $room_preparer ],
+    requires => [ $left_user_fixture, $room_fixture ],
 
     check => sub {
         my ( $user, $room_id ) = @_;
@@ -204,7 +204,7 @@ test "Can get rooms/{roomId}/messages for a departed room (SPEC-216)",
     };
 
 test "Can get 'm.room.name' state for a departed room (SPEC-216)",
-    requires => [ $left_user_preparer, $room_preparer ],
+    requires => [ $left_user_fixture, $room_fixture ],
 
     check => sub {
         my ( $user, $room_id ) = @_;
@@ -224,7 +224,7 @@ test "Can get 'm.room.name' state for a departed room (SPEC-216)",
     };
 
 test "Getting messages going forward is limited for a departed room (SPEC-216)",
-    requires => [ $left_user_preparer, $room_preparer ],
+    requires => [ $left_user_fixture, $room_fixture ],
 
     check => sub {
         my ( $user, $room_id ) = @_;

--- a/tests/30rooms/12thirdpartyinvite.pl
+++ b/tests/30rooms/12thirdpartyinvite.pl
@@ -236,29 +236,25 @@ sub id_server_fixture
 {
    return fixture(
       setup => sub {
-         start_id_server();
+         my $id_server = SyTest::Identity::Server->new;
+         $loop->add( $id_server );
+
+         $id_server->listen(
+            host    => "localhost",
+            service => "",
+            extensions => [qw( SSL )],
+            # Synapse currently only talks IPv4
+            family => "inet",
+
+            SSL_cert_file => "$DIR/../../keys/tls-selfsigned.crt",
+            SSL_key_file => "$DIR/../../keys/tls-selfsigned.key",
+         )->then( sub {
+            my ( $listener ) = @_;
+
+            my $sock = $listener->read_handle;
+            my $id_server_hostandport = sprintf "%s:%d", $sock->sockhostname, $sock->sockport;
+            Future->done( $id_server );
+         })
       }
    );
-}
-
-sub start_id_server
-{
-   my $id_server = SyTest::Identity::Server->new;
-   $loop->add( $id_server );
-   $id_server->listen(
-      host    => "localhost",
-      service => "",
-      extensions => [qw( SSL )],
-      # Synapse currently only talks IPv4
-      family => "inet",
-
-      SSL_cert_file => "$DIR/../../keys/tls-selfsigned.crt",
-      SSL_key_file => "$DIR/../../keys/tls-selfsigned.key",
-   )->then( sub {
-      my ( $listener ) = @_;
-
-      my $sock = $listener->read_handle;
-      my $id_server_hostandport = sprintf "%s:%d", $sock->sockhostname, $sock->sockport;
-      Future->done( $id_server );
-   })
 }

--- a/tests/30rooms/12thirdpartyinvite.pl
+++ b/tests/30rooms/12thirdpartyinvite.pl
@@ -247,6 +247,13 @@ sub id_server_fixture
             SSL_cert_file => "$DIR/../../keys/tls-selfsigned.crt",
             SSL_key_file => "$DIR/../../keys/tls-selfsigned.key",
          )->then_done( $id_server );
-      }
+      },
+
+      teardown => sub {
+         my ( $id_server ) = @_;
+         $loop->remove( $id_server );
+
+         Future->done;
+      },
    );
 }

--- a/tests/30rooms/12thirdpartyinvite.pl
+++ b/tests/30rooms/12thirdpartyinvite.pl
@@ -11,73 +11,98 @@ my $DIR = dirname( __FILE__ );
 my $invitee_email = 'lemurs@monkeyworld.org';
 
 test "Can invite existing 3pid",
-   requires => [ local_user_fixtures( 2 ) ],
+   requires => [ local_user_fixtures( 2 ), id_server_fixture() ],
 
    do => sub {
-      my ( $inviter, $invitee ) = @_;
+      my ( $inviter, $invitee, $id_server ) = @_;
 
       my $invitee_mxid = $invitee->user_id;
 
       my $room_id;
 
-      start_id_server()->then( sub {
-         my ( $id_server ) = @_;
-
-         $id_server->bind_identity( undef, "email", $invitee_email, $invitee )
+      $id_server->bind_identity( undef, "email", $invitee_email, $invitee )
+      ->then( sub {
+         matrix_create_and_join_room( [ $inviter ], visibility => "private" )
          ->then( sub {
-            matrix_create_and_join_room( [ $inviter ], visibility => "private" )
-            ->then( sub {
-               ( $room_id ) = @_;
+            ( $room_id ) = @_;
 
-               do_request_json_for( $inviter,
-                  method => "POST",
-                  uri    => "/api/v1/rooms/$room_id/invite",
+            do_request_json_for( $inviter,
+               method => "POST",
+               uri    => "/api/v1/rooms/$room_id/invite",
 
-                  content => {
-                     id_server    => $id_server->name,
-                     medium       => "email",
-                     address      => $invitee_email,
-                     display_name => "Cute things",
-                  },
-               );
-            })->then( sub {
-               matrix_get_room_state( $inviter, $room_id,
-                  type      => "m.room.member",
-                  state_key => $invitee_mxid,
-               )->on_done( sub {
-                  my ( $body ) = @_;
+               content => {
+                  id_server    => $id_server->name,
+                  medium       => "email",
+                  address      => $invitee_email,
+                  display_name => "Cute things",
+               },
+            );
+         })->then( sub {
+            matrix_get_room_state( $inviter, $room_id,
+               type      => "m.room.member",
+               state_key => $invitee_mxid,
+            )->on_done( sub {
+               my ( $body ) = @_;
 
-                  log_if_fail "Body", $body;
-                  $body->{membership} eq "invite" or
-                     die "Expected invited user membership to be 'invite'";
-               });
+               log_if_fail "Body", $body;
+               $body->{membership} eq "invite" or
+                  die "Expected invited user membership to be 'invite'";
             });
          });
       });
    };
 
 test "Can invite unbound 3pid",
-   requires => [ local_user_fixtures( 2 ), qw( synapse_client_locations )],
-   do => sub {
-      my ( $inviter, $invitee, $locations ) = @_;
+   requires => [ local_user_fixtures( 2 ), qw( synapse_client_locations ),
+                    id_server_fixture() ],
 
-      can_invite_unbound_3pid( $inviter, $invitee, $locations->[0] );
+   do => sub {
+      my ( $inviter, $invitee, $locations, $id_server ) = @_;
+
+      can_invite_unbound_3pid( $inviter, $invitee, $locations->[0], $id_server );
    };
 
 test "Can invite unbound 3pid over federation",
-   requires => [ local_user_fixture(), remote_user_fixture(), qw( synapse_client_locations )],
-   do => sub {
-      my ( $inviter, $invitee, $locations ) = @_;
+   requires => [ local_user_fixture(), remote_user_fixture(), qw( synapse_client_locations ),
+                    id_server_fixture() ],
 
-      can_invite_unbound_3pid( $inviter, $invitee, $locations->[1] );
+   do => sub {
+      my ( $inviter, $invitee, $locations, $id_server ) = @_;
+
+      can_invite_unbound_3pid( $inviter, $invitee, $locations->[1], $id_server );
    };
 
 sub can_invite_unbound_3pid
 {
-   my ( $inviter, $invitee, $hs_uribase ) = @_;
+   my ( $inviter, $invitee, $hs_uribase, $id_server ) = @_;
 
-   start_id_server()->then( sub {
-      my ( $id_server ) = @_;
+   my $room_id;
+
+   matrix_create_room( $inviter, visibility => "private" )
+   ->then( sub {
+      ( $room_id ) = @_;
+
+      do_3pid_invite( $inviter, $room_id, $id_server->name, $invitee_email )
+   })->then( sub {
+      $id_server->bind_identity( $hs_uribase, "email", $invitee_email, $invitee );
+   })->then( sub {
+      matrix_join_room( $invitee, $room_id )
+   })->then( sub {
+      matrix_get_room_state( $inviter, $room_id,
+         type      => "m.room.member",
+         state_key => $invitee->user_id,
+      )
+   })->followed_by( assert_membership( "join" ) );
+}
+
+test "Can accept unbound 3pid invite after inviter leaves",
+   requires => [ local_user_fixtures( 3 ), qw( synapse_client_locations ),
+                    id_server_fixture() ],
+
+   do => sub {
+      my ( $inviter, $other_member, $invitee, $locations, $id_server ) = @_;
+
+      my $hs_uribase = $locations->[0];
 
       my $room_id;
 
@@ -85,93 +110,62 @@ sub can_invite_unbound_3pid
       ->then( sub {
          ( $room_id ) = @_;
 
+          matrix_invite_user_to_room( $inviter, $other_member, $room_id );
+      })->then( sub {
+          matrix_join_room( $other_member, $room_id );
+      })->then( sub {
          do_3pid_invite( $inviter, $room_id, $id_server->name, $invitee_email )
+      })->then( sub {
+         matrix_leave_room( $inviter, $room_id );
       })->then( sub {
          $id_server->bind_identity( $hs_uribase, "email", $invitee_email, $invitee );
       })->then( sub {
          matrix_join_room( $invitee, $room_id )
       })->then( sub {
-         matrix_get_room_state( $inviter, $room_id,
+         matrix_get_room_state( $other_member, $room_id,
             type      => "m.room.member",
             state_key => $invitee->user_id,
          )
       })->followed_by( assert_membership( "join" ) );
-   });
-}
-
-test "Can accept unbound 3pid invite after inviter leaves",
-   requires => [ local_user_fixtures( 3 ), qw( synapse_client_locations )],
-   do => sub {
-      my ( $inviter, $other_member, $invitee, $locations ) = @_;
-
-      my $hs_uribase = $locations->[0];
-
-      start_id_server()->then( sub {
-         my ( $id_server ) = @_;
-
-         my $room_id;
-
-         matrix_create_room( $inviter, visibility => "private" )
-         ->then( sub {
-            ( $room_id ) = @_;
-
-             matrix_invite_user_to_room( $inviter, $other_member, $room_id );
-         })->then( sub {
-             matrix_join_room( $other_member, $room_id );
-         })->then( sub {
-            do_3pid_invite( $inviter, $room_id, $id_server->name, $invitee_email )
-         })->then( sub {
-            matrix_leave_room( $inviter, $room_id );
-         })->then( sub {
-            $id_server->bind_identity( $hs_uribase, "email", $invitee_email, $invitee );
-         })->then( sub {
-            matrix_join_room( $invitee, $room_id )
-         })->then( sub {
-            matrix_get_room_state( $other_member, $room_id,
-               type      => "m.room.member",
-               state_key => $invitee->user_id,
-            )
-         })->followed_by( assert_membership( "join" ) );
-      });
    };
 
 test "3pid invite join with wrong but valid signature are rejected",
-   requires => [ local_user_fixtures( 2 ), qw( synapse_client_locations )],
+   requires => [ local_user_fixtures( 2 ), qw( synapse_client_locations ),
+                    id_server_fixture() ],
+
    do => sub {
-      my ( $inviter, $invitee, $locations ) = @_;
-
+      my ( $inviter, $invitee, $locations, $id_server ) = @_;
       my $hs_uribase = $locations->[0];
-      invite_should_fail( $inviter, $invitee, $hs_uribase, sub {
-         my ( $id_server ) = @_;
 
+      invite_should_fail( $inviter, $invitee, $hs_uribase, $id_server, sub {
          $id_server->rotate_keys;
          $id_server->bind_identity( $hs_uribase, "email", $invitee_email, $invitee );
       });
    };
 
 test "3pid invite join valid signature but revoked keys are rejected",
-   requires => [ local_user_fixtures( 2 ), qw( synapse_client_locations )],
+   requires => [ local_user_fixtures( 2 ), qw( synapse_client_locations ),
+                    id_server_fixture() ],
+
    do => sub {
-      my ( $inviter, $invitee, $locations ) = @_;
-
+      my ( $inviter, $invitee, $locations, $id_server ) = @_;
       my $hs_uribase = $locations->[0];
-      invite_should_fail( $inviter, $invitee, $hs_uribase, sub {
-         my ( $id_server ) = @_;
 
+      invite_should_fail( $inviter, $invitee, $hs_uribase, $id_server, sub {
          $id_server->bind_identity( $hs_uribase, "email", $invitee_email, $invitee,
             sub { $id_server->rotate_keys } );
       });
    };
 
 test "3pid invite join valid signature but unreachable ID server are rejected",
-   requires => [ local_user_fixtures( 2 ), qw( synapse_client_locations )],
+   requires => [ local_user_fixtures( 2 ), qw( synapse_client_locations ),
+                    id_server_fixture() ],
+
    do => sub {
-      my ( $inviter, $invitee, $locations ) = @_;
-
+      my ( $inviter, $invitee, $locations, $id_server ) = @_;
       my $hs_uribase = $locations->[0];
-      invite_should_fail( $inviter, $invitee, $hs_uribase, sub {
-         my ( $id_server ) = @_;
 
+      invite_should_fail( $inviter, $invitee, $hs_uribase, $id_server, sub {
          $id_server->bind_identity( $hs_uribase, "email", $invitee_email, $invitee, sub {
             $id_server->read_handle->close;
          })->then( sub {
@@ -182,29 +176,25 @@ test "3pid invite join valid signature but unreachable ID server are rejected",
    };
 
 sub invite_should_fail {
-   my ( $inviter, $invitee, $hs_base_url, $bind_sub ) = @_;
+   my ( $inviter, $invitee, $hs_base_url, $id_server, $bind_sub ) = @_;
 
    my $room_id;
 
-   start_id_server()->then( sub {
-      my ( $id_server ) = @_;
+   matrix_create_room( $inviter, visibility => "private" )
+   ->then( sub {
+      ( $room_id ) = @_;
 
-      matrix_create_room( $inviter, visibility => "private" )
-      ->then( sub {
-         ( $room_id ) = @_;
-
-         do_3pid_invite( $inviter, $room_id, $id_server->name, $invitee_email )
-      })->then( sub {
-         $bind_sub->( $id_server );
-      })->then( sub {
-         matrix_join_room( $invitee, $room_id )
-      })->followed_by(\&main::expect_http_4xx)->then( sub {
-         matrix_get_room_state( $inviter, $room_id,
-            type      => "m.room.member",
-            state_key => $invitee->user_id,
-         )
-      })->followed_by(assert_membership( undef ) );
-   });
+      do_3pid_invite( $inviter, $room_id, $id_server->name, $invitee_email )
+   })->then( sub {
+      $bind_sub->( $id_server );
+   })->then( sub {
+      matrix_join_room( $invitee, $room_id )
+   })->followed_by(\&main::expect_http_4xx)->then( sub {
+      matrix_get_room_state( $inviter, $room_id,
+         type      => "m.room.member",
+         state_key => $invitee->user_id,
+      )
+   })->followed_by(assert_membership( undef ) );
 }
 
 sub assert_membership {
@@ -240,6 +230,15 @@ sub do_3pid_invite {
          display_name => "Cool tails",
       }
    )
+}
+
+sub id_server_fixture
+{
+   return fixture(
+      setup => sub {
+         start_id_server();
+      }
+   );
 }
 
 sub start_id_server

--- a/tests/30rooms/12thirdpartyinvite.pl
+++ b/tests/30rooms/12thirdpartyinvite.pl
@@ -248,13 +248,7 @@ sub id_server_fixture
 
             SSL_cert_file => "$DIR/../../keys/tls-selfsigned.crt",
             SSL_key_file => "$DIR/../../keys/tls-selfsigned.key",
-         )->then( sub {
-            my ( $listener ) = @_;
-
-            my $sock = $listener->read_handle;
-            my $id_server_hostandport = sprintf "%s:%d", $sock->sockhostname, $sock->sockport;
-            Future->done( $id_server );
-         })
+         )->then_done( $id_server );
       }
    );
 }

--- a/tests/30rooms/12thirdpartyinvite.pl
+++ b/tests/30rooms/12thirdpartyinvite.pl
@@ -11,7 +11,7 @@ my $DIR = dirname( __FILE__ );
 my $invitee_email = 'lemurs@monkeyworld.org';
 
 test "Can invite existing 3pid",
-   requires => [ local_user_preparers( 2 ) ],
+   requires => [ local_user_fixtures( 2 ) ],
 
    do => sub {
       my ( $inviter, $invitee ) = @_;
@@ -57,7 +57,7 @@ test "Can invite existing 3pid",
    };
 
 test "Can invite unbound 3pid",
-   requires => [ local_user_preparers( 2 ), qw( synapse_client_locations )],
+   requires => [ local_user_fixtures( 2 ), qw( synapse_client_locations )],
    do => sub {
       my ( $inviter, $invitee, $locations ) = @_;
 
@@ -65,7 +65,7 @@ test "Can invite unbound 3pid",
    };
 
 test "Can invite unbound 3pid over federation",
-   requires => [ local_user_preparer(), remote_user_preparer(), qw( synapse_client_locations )],
+   requires => [ local_user_fixture(), remote_user_fixture(), qw( synapse_client_locations )],
    do => sub {
       my ( $inviter, $invitee, $locations ) = @_;
 
@@ -100,7 +100,7 @@ sub can_invite_unbound_3pid
 }
 
 test "Can accept unbound 3pid invite after inviter leaves",
-   requires => [ local_user_preparers( 3 ), qw( synapse_client_locations )],
+   requires => [ local_user_fixtures( 3 ), qw( synapse_client_locations )],
    do => sub {
       my ( $inviter, $other_member, $invitee, $locations ) = @_;
 
@@ -136,7 +136,7 @@ test "Can accept unbound 3pid invite after inviter leaves",
    };
 
 test "3pid invite join with wrong but valid signature are rejected",
-   requires => [ local_user_preparers( 2 ), qw( synapse_client_locations )],
+   requires => [ local_user_fixtures( 2 ), qw( synapse_client_locations )],
    do => sub {
       my ( $inviter, $invitee, $locations ) = @_;
 
@@ -150,7 +150,7 @@ test "3pid invite join with wrong but valid signature are rejected",
    };
 
 test "3pid invite join valid signature but revoked keys are rejected",
-   requires => [ local_user_preparers( 2 ), qw( synapse_client_locations )],
+   requires => [ local_user_fixtures( 2 ), qw( synapse_client_locations )],
    do => sub {
       my ( $inviter, $invitee, $locations ) = @_;
 
@@ -164,7 +164,7 @@ test "3pid invite join valid signature but revoked keys are rejected",
    };
 
 test "3pid invite join valid signature but unreachable ID server are rejected",
-   requires => [ local_user_preparers( 2 ), qw( synapse_client_locations )],
+   requires => [ local_user_fixtures( 2 ), qw( synapse_client_locations )],
    do => sub {
       my ( $inviter, $invitee, $locations ) = @_;
 

--- a/tests/30rooms/13anonymousaccess.pl
+++ b/tests/30rooms/13anonymousaccess.pl
@@ -1,5 +1,5 @@
 test "Anonymous user cannot view non-world-readable rooms",
-   requires => [ qw( first_api_client ), local_user_preparer() ],
+   requires => [ qw( first_api_client ), local_user_fixture() ],
 
    do => sub {
       my ( $api_client, $user ) = @_;
@@ -31,7 +31,7 @@ test "Anonymous user cannot view non-world-readable rooms",
    };
 
 test "Anonymous user can view world-readable rooms",
-   requires => [ qw( first_api_client ), local_user_preparer() ],
+   requires => [ qw( first_api_client ), local_user_fixture() ],
 
    do => sub {
       my ( $api_client, $user ) = @_;
@@ -63,7 +63,7 @@ test "Anonymous user can view world-readable rooms",
    };
 
 test "Anonymous user cannot call /events on non-world_readable room",
-   requires => [ qw( first_api_client ), local_user_preparer() ],
+   requires => [ qw( first_api_client ), local_user_fixture() ],
 
    do => sub {
       my ( $api_client, $user ) = @_;
@@ -93,7 +93,7 @@ test "Anonymous user cannot call /events on non-world_readable room",
    };
 
 test "Anonymous user can call /events on world_readable room",
-   requires => [ qw( first_api_client ), local_user_preparer() ],
+   requires => [ qw( first_api_client ), local_user_fixture() ],
 
    do => sub {
       my ( $api_client, $user ) = @_;
@@ -151,7 +151,7 @@ test "Anonymous user can call /events on world_readable room",
    };
 
 test "Anonymous user doesn't get events before room made world_readable",
-   requires => [ qw( first_api_client ), local_user_preparer() ],
+   requires => [ qw( first_api_client ), local_user_fixture() ],
 
    do => sub {
       my ( $api_client, $user ) = @_;
@@ -191,7 +191,7 @@ test "Anonymous user doesn't get events before room made world_readable",
    };
 
 test "Anonymous users can get state for non-world_readable rooms",
-   requires => [ local_user_and_room_preparers(), qw( first_api_client ) ],
+   requires => [ local_user_and_room_fixtures(), qw( first_api_client ) ],
 
    do => sub {
       my ( $user, $room_id ) = @_;
@@ -213,7 +213,7 @@ test "Anonymous users can get state for non-world_readable rooms",
    };
 
 test "Anonymous users can get individual state for world_readable rooms",
-   requires => [ local_user_and_room_preparers(), qw( first_api_client ) ],
+   requires => [ local_user_and_room_fixtures(), qw( first_api_client ) ],
 
    do => sub {
       my ( $user, $room_id ) = @_;

--- a/tests/30rooms/20typing.pl
+++ b/tests/30rooms/20typing.pl
@@ -22,21 +22,21 @@ sub matrix_typing
 }
 
 
-my $typing_user_preparer = local_user_preparer();
+my $typing_user_fixture = local_user_fixture();
 
-my $local_user_preparer = local_user_preparer();
+my $local_user_fixture = local_user_fixture();
 
-my $remote_user_preparer = remote_user_preparer();
+my $remote_user_fixture = remote_user_fixture();
 
-my $room_preparer = room_preparer(
+my $room_fixture = room_fixture(
    requires_users => [
-      $typing_user_preparer, $local_user_preparer, $remote_user_preparer
+      $typing_user_fixture, $local_user_fixture, $remote_user_fixture
    ],
 );
 
 
 test "Typing notification sent to local room members",
-   requires => [ $typing_user_preparer, $local_user_preparer, $room_preparer,
+   requires => [ $typing_user_fixture, $local_user_fixture, $room_fixture,
                 qw( can_set_room_typing )],
 
    do => sub {
@@ -74,7 +74,7 @@ test "Typing notification sent to local room members",
 
 
 test "Typing notifications also sent to remote room members",
-   requires => [ $typing_user_preparer, $remote_user_preparer, $room_preparer,
+   requires => [ $typing_user_fixture, $remote_user_fixture, $room_fixture,
                 qw( can_set_room_typing can_join_remote_room_by_alias )],
 
    do => sub {
@@ -103,7 +103,7 @@ test "Typing notifications also sent to remote room members",
 
 
 test "Typing can be explicitly stopped",
-   requires => [ $typing_user_preparer, $local_user_preparer, $room_preparer,
+   requires => [ $typing_user_fixture, $local_user_fixture, $room_fixture,
                 qw( can_set_room_typing )],
 
    do => sub {
@@ -136,7 +136,7 @@ test "Typing can be explicitly stopped",
 
 
 multi_test "Typing notifications timeout and can be resent",
-   requires => [ $typing_user_preparer, $room_preparer,
+   requires => [ $typing_user_fixture, $room_fixture,
                 qw( can_set_room_typing )],
 
    do => sub {

--- a/tests/30rooms/21receipts.pl
+++ b/tests/30rooms/21receipts.pl
@@ -29,7 +29,7 @@ sub find_receipt
 }
 
 multi_test "Read receipts are visible to /initialSync",
-   requires => [ local_user_and_room_preparers(),
+   requires => [ local_user_and_room_fixtures(),
                  qw( can_post_room_receipts )],
 
    do => sub {
@@ -120,7 +120,7 @@ multi_test "Read receipts are visible to /initialSync",
    };
 
 test "Read receipts are sent as events",
-   requires => [ local_user_and_room_preparers(),
+   requires => [ local_user_and_room_fixtures(),
                  qw( can_post_room_receipts )],
 
    do => sub {

--- a/tests/40presence.pl
+++ b/tests/40presence.pl
@@ -1,21 +1,21 @@
-my $senduser_preparer = local_user_preparer();
+my $senduser_fixture = local_user_fixture();
 
-my $local_user_preparer = local_user_preparer();
+my $local_user_fixture = local_user_fixture();
 
-my $remote_user_preparer = remote_user_preparer();
+my $remote_user_fixture = remote_user_fixture();
 
 # Ensure all the users are members of a shared room, so that we know presence
 # messages can be shared between them all
-my $room_preparer = room_preparer(
+my $room_fixture = room_fixture(
    requires_users => [
-      $senduser_preparer, $local_user_preparer, $remote_user_preparer
+      $senduser_fixture, $local_user_fixture, $remote_user_fixture
    ],
 );
 
 my $status_msg = "Update for room members";
 
 test "Presence changes are reported to local room members",
-   requires => [ $senduser_preparer, $local_user_preparer, $room_preparer,
+   requires => [ $senduser_fixture, $local_user_fixture, $room_fixture,
                  qw( can_set_presence )],
 
    do => sub {
@@ -53,7 +53,7 @@ test "Presence changes are reported to local room members",
    };
 
 test "Presence changes are also reported to remote room members",
-   requires => [ $senduser_preparer, $remote_user_preparer, $room_preparer,
+   requires => [ $senduser_fixture, $remote_user_fixture, $room_fixture,
                  qw( can_set_presence can_join_remote_room_by_alias )],
 
    do => sub {
@@ -80,7 +80,7 @@ test "Presence changes are also reported to remote room members",
    };
 
 test "Presence changes to OFFLINE are reported to local room members",
-   requires => [ $senduser_preparer, $local_user_preparer, $room_preparer,
+   requires => [ $senduser_fixture, $local_user_fixture, $room_fixture,
                  qw( can_set_presence )],
 
    do => sub {
@@ -111,7 +111,7 @@ test "Presence changes to OFFLINE are reported to local room members",
    };
 
 test "Presence changes to OFFLINE are reported to remote room members",
-   requires => [ $senduser_preparer, $remote_user_preparer, $room_preparer,
+   requires => [ $senduser_fixture, $remote_user_fixture, $room_fixture,
                  qw( can_set_presence can_join_remote_room_by_alias )],
 
    do => sub {
@@ -132,7 +132,7 @@ test "Presence changes to OFFLINE are reported to remote room members",
    };
 
 test "Newly created users see their own presence in /initialSync (SYT-34)",
-   requires => [ local_user_preparer(),
+   requires => [ local_user_fixture(),
                  qw( can_initial_sync )],
 
    do => sub {

--- a/tests/41end-to-end-keys/01-upload-key.pl
+++ b/tests/41end-to-end-keys/01-upload-key.pl
@@ -1,7 +1,7 @@
-my $preparer = local_user_preparer();
+my $fixture = local_user_fixture();
 
 test "Can upload device keys",
-   requires => [ $preparer ],
+   requires => [ $fixture ],
 
    provides => [qw( can_upload_e2e_keys )],
 
@@ -38,7 +38,7 @@ test "Can upload device keys",
    };
 
 test "Can query device keys using POST",
-   requires => [ $preparer,
+   requires => [ $fixture,
                  qw( can_upload_e2e_keys )],
 
    check => sub {
@@ -68,7 +68,7 @@ test "Can query device keys using POST",
    };
 
 test "Can query specific device keys using POST",
-   requires => [ $preparer,
+   requires => [ $fixture,
                  qw( can_upload_e2e_keys )],
 
    check => sub {
@@ -98,7 +98,7 @@ test "Can query specific device keys using POST",
    };
 
 test "Can query device keys using GET",
-   requires => [ $preparer,
+   requires => [ $fixture,
                  qw( can_upload_e2e_keys )],
 
    check => sub {

--- a/tests/41end-to-end-keys/03-one-time-keys.pl
+++ b/tests/41end-to-end-keys/03-one-time-keys.pl
@@ -1,5 +1,5 @@
 multi_test "Can claim one time key using POST",
-   requires => [ local_user_preparer(),
+   requires => [ local_user_fixture(),
                  qw( can_upload_e2e_keys )],
 
    check => sub {

--- a/tests/41end-to-end-keys/04-query-key-federation.pl
+++ b/tests/41end-to-end-keys/04-query-key-federation.pl
@@ -1,5 +1,5 @@
 multi_test "Can query remote device keys using POST",
-   requires => [ local_user_preparer(), remote_user_preparer(),
+   requires => [ local_user_fixture(), remote_user_fixture(),
                  qw( can_upload_e2e_keys )],
 
    check => sub {

--- a/tests/41end-to-end-keys/05-one-time-key-federation.pl
+++ b/tests/41end-to-end-keys/05-one-time-key-federation.pl
@@ -1,5 +1,5 @@
 multi_test "Can claim remote one time key using POST",
-   requires => [ local_user_preparer(), remote_user_preparer(),
+   requires => [ local_user_fixture(), remote_user_fixture(),
                  qw( can_upload_e2e_keys )],
 
    check => sub {

--- a/tests/50federation/10query-profile.pl
+++ b/tests/50federation/10query-profile.pl
@@ -36,7 +36,7 @@ test "Outbound federation can query profile data",
 my $dname = "Displayname Set For Federation Test";
 
 test "Inbound federation can query profile data",
-   requires => [qw( outbound_client ), local_user_preparer(),
+   requires => [qw( outbound_client ), local_user_fixture(),
                 qw( can_set_displayname )],
 
    do => sub {

--- a/tests/50federation/11query-directory.pl
+++ b/tests/50federation/11query-directory.pl
@@ -41,10 +41,10 @@ test "Outbound federation can query room alias directory",
    };
 
 test "Inbound federation can query room alias directory",
-   # TODO(paul): technically this doesn't need local_user_preparer(), if we had
+   # TODO(paul): technically this doesn't need local_user_fixture(), if we had
    #   some user we could assert can perform media/directory/etc... operations
    #   but doesn't mutate any of its own state, or join rooms, etc...
-   requires => [qw( outbound_client first_home_server ), local_user_preparer(),
+   requires => [qw( outbound_client first_home_server ), local_user_fixture(),
                 qw( can_create_room_alias)],
 
    do => sub {

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -2,7 +2,7 @@ use List::UtilsBy qw( partition_by );
 
 multi_test "Inbound federation can receive room-join requests",
    requires => [qw( outbound_client inbound_server first_home_server ),
-                 room_preparer( requires_users => [ local_user_preparer() ] ) ],
+                 room_fixture( requires_users => [ local_user_fixture() ] ) ],
 
    do => sub {
       my ( $outbound_client, $inbound_server, $first_home_server, $room_id ) = @_;

--- a/tests/51media/01unicode.pl
+++ b/tests/51media/01unicode.pl
@@ -6,7 +6,7 @@ my $FILENAME_ENCODED = uc uri_escape( $FILENAME );
 my $content_id;
 
 test "Can upload with Unicode file name",
-   requires => [qw( first_api_client ), local_user_preparer(),
+   requires => [qw( first_api_client ), local_user_fixture(),
                 qw( can_upload_media )],
 
    provides => [qw( can_upload_media_unicode )],

--- a/tests/51media/02nofilename.pl
+++ b/tests/51media/02nofilename.pl
@@ -1,7 +1,7 @@
 my $content_id;
 
 test "Can upload without a file name",
-   requires => [qw( first_api_client ), local_user_preparer() ],
+   requires => [qw( first_api_client ), local_user_fixture() ],
 
    do => sub {
       my ( $http, $user ) = @_;

--- a/tests/51media/03ascii.pl
+++ b/tests/51media/03ascii.pl
@@ -1,7 +1,7 @@
 my $content_id;
 
 test "Can upload with ASCII file name",
-   requires => [qw( first_api_client ), local_user_preparer() ],
+   requires => [qw( first_api_client ), local_user_fixture() ],
 
    do => sub {
       my ( $http, $user ) = @_;

--- a/tests/51media/10thumbnail.pl
+++ b/tests/51media/10thumbnail.pl
@@ -4,7 +4,7 @@ use File::Slurper qw( read_binary );
 my $dir = dirname __FILE__;
 
 test "POSTed media can be thumbnailed",
-   requires => [qw( first_api_client ), local_user_preparer(),
+   requires => [qw( first_api_client ), local_user_fixture(),
                 qw( can_upload_media can_download_media )],
 
    do => sub {

--- a/tests/60app-services/01as-create.pl
+++ b/tests/60app-services/01as-create.pl
@@ -1,11 +1,11 @@
-my $user_preparer = local_user_preparer();
+my $user_fixture = local_user_fixture();
 
-my $room_preparer = room_preparer(
-   requires_users => [ $user_preparer ],
+my $room_fixture = room_fixture(
+   requires_users => [ $user_fixture ],
 );
 
 test "AS can create a user",
-   requires => [qw( as_user ), $room_preparer ],
+   requires => [qw( as_user ), $room_fixture ],
 
    provides => [qw( make_as_user )],
 
@@ -80,7 +80,7 @@ test "Regular users cannot register within the AS namespace",
    };
 
 test "AS can make room aliases",
-   requires => [qw( await_as_event as_user first_home_server ), $room_preparer,
+   requires => [qw( await_as_event as_user first_home_server ), $room_fixture,
                 qw( can_create_room_alias )],
 
    do => sub {
@@ -139,7 +139,7 @@ test "AS can make room aliases",
    };
 
 test "Regular users cannot create room aliases within the AS namespace",
-   requires => [qw( first_home_server ), $user_preparer, $room_preparer,
+   requires => [qw( first_home_server ), $user_fixture, $room_fixture,
                 qw( can_create_room_alias )],
 
    do => sub {

--- a/tests/60app-services/02ghost.pl
+++ b/tests/60app-services/02ghost.pl
@@ -1,8 +1,8 @@
-my $user_preparer = local_user_preparer();
+my $user_fixture = local_user_fixture();
 
 multi_test "AS-ghosted users can use rooms via AS",
-   requires => [qw( make_as_user await_as_event as_user ), $user_preparer,
-                     room_preparer( requires_users => [ $user_preparer ] ),
+   requires => [qw( make_as_user await_as_event as_user ), $user_fixture,
+                     room_fixture( requires_users => [ $user_fixture ] ),
                 qw( can_receive_room_message_locally )],
 
    do => sub {
@@ -96,8 +96,8 @@ multi_test "AS-ghosted users can use rooms via AS",
    };
 
 multi_test "AS-ghosted users can use rooms themselves",
-   requires => [qw( make_as_user await_as_event ), $user_preparer,
-                     room_preparer( requires_users => [ $user_preparer ] ),
+   requires => [qw( make_as_user await_as_event ), $user_fixture,
+                     room_fixture( requires_users => [ $user_fixture ] ),
                 qw( can_receive_room_message_locally can_send_message )],
 
    do => sub {

--- a/tests/60app-services/03passive.pl
+++ b/tests/60app-services/03passive.pl
@@ -1,12 +1,12 @@
-my $user_preparer = local_user_preparer();
+my $user_fixture = local_user_fixture();
 
-my $room_preparer = room_preparer(
-   requires_users => [ $user_preparer ],
+my $room_fixture = room_fixture(
+   requires_users => [ $user_fixture ],
 );
 
 multi_test "Inviting an AS-hosted user asks the AS server",
    requires => [qw( await_as_event make_as_user first_home_server ),
-                     $user_preparer, $room_preparer,
+                     $user_fixture, $room_fixture,
                 qw( can_invite_room )],
 
    do => sub {
@@ -47,7 +47,7 @@ multi_test "Inviting an AS-hosted user asks the AS server",
 
 multi_test "Accesing an AS-hosted room alias asks the AS server",
    requires => [qw( await_as_event as_user first_home_server ),
-                  local_user_preparer(), $room_preparer,
+                  local_user_fixture(), $room_fixture,
 
                 qw( can_join_room_by_alias )],
 
@@ -126,7 +126,7 @@ multi_test "Accesing an AS-hosted room alias asks the AS server",
    };
 
 test "Events in rooms with AS-hosted room aliases are sent to AS server",
-   requires => [qw( await_as_event ), $user_preparer, $room_preparer,
+   requires => [qw( await_as_event ), $user_fixture, $room_fixture,
                 qw( can_join_room_by_alias can_send_message )],
 
    do => sub {

--- a/tests/80torture/03events.pl
+++ b/tests/80torture/03events.pl
@@ -56,7 +56,7 @@ test "GET /events with non-numeric 'timeout'",
    };
 
 test "Event size limits",
-   requires => [ local_user_and_room_preparers() ],
+   requires => [ local_user_and_room_fixtures() ],
 
    do => sub {
       my ( $user, $room_id ) = @_;

--- a/tests/90jira/SYN-115.pl
+++ b/tests/90jira/SYN-115.pl
@@ -1,7 +1,7 @@
 use Future::Utils qw( repeat );
 
 multi_test "New federated private chats get full presence information (SYN-115)",
-   requires => [ local_user_preparer(), remote_user_preparer(),
+   requires => [ local_user_fixture(), remote_user_fixture(),
                  qw( can_create_private_room )],
 
    do => sub {

--- a/tests/90jira/SYN-202.pl
+++ b/tests/90jira/SYN-202.pl
@@ -1,5 +1,5 @@
 multi_test "Left room members do not cause problems for presence",
-   requires => [ local_user_preparers( 2 ),
+   requires => [ local_user_fixtures( 2 ),
                  qw( can_room_initial_sync )],
 
    do => sub {

--- a/tests/90jira/SYN-205.pl
+++ b/tests/90jira/SYN-205.pl
@@ -1,5 +1,5 @@
 multi_test "Rooms can be created with an initial invite list (SYN-205)",
-   requires => [ local_user_preparers( 2 ),
+   requires => [ local_user_fixtures( 2 ),
                 qw( can_create_private_room_with_invite )],
 
    do => sub {

--- a/tests/90jira/SYN-328.pl
+++ b/tests/90jira/SYN-328.pl
@@ -1,5 +1,5 @@
 multi_test "Typing notifications don't leak",
-   requires => [ local_user_preparers( 3 ),
+   requires => [ local_user_fixtures( 3 ),
                  qw( can_set_room_typing )],
 
    do => sub {

--- a/tests/90jira/SYN-343.pl
+++ b/tests/90jira/SYN-343.pl
@@ -1,5 +1,5 @@
 multi_test "Non-present room members cannot ban others",
-   requires => [ local_user_preparers( 2 ),
+   requires => [ local_user_fixtures( 2 ),
                  qw( can_ban_room can_change_power_levels )],
 
    do => sub {

--- a/tests/90jira/SYN-390.pl
+++ b/tests/90jira/SYN-390.pl
@@ -1,5 +1,5 @@
 multi_test "Getting push rules doesn't corrupt the cache SYN-390",
-   requires => [ local_user_preparer() ],
+   requires => [ local_user_fixture() ],
 
    do => sub {
       my ( $user ) = @_;

--- a/tests/90jira/SYN-442.pl
+++ b/tests/90jira/SYN-442.pl
@@ -1,5 +1,5 @@
 multi_test "Test that we can be reinvited to a room we created",
-   requires => [ local_user_preparer(), remote_user_preparer(),
+   requires => [ local_user_fixture(), remote_user_fixture(),
                  qw( can_change_power_levels )],
 
    check => sub {


### PR DESCRIPTION
This fairly large set of changes is four conceptually-small pieces:

  * Rename `preparer` to `fixture`, and rename the `do` block to `setup` - this change represents the vast majority of the line count in this PR.

  * Give fixtures the ability to have a `teardown` block

  * Write some documentation about the general use of fixtures in the main `DEVELOP.rst`

  * Use the `teardown` fixture ability in 12thirdpartyinvites.pl to shut down the fake ID server at the end of each test