### PR TITLE
Remove cases of postfix 'if' and 'unless' conditions in tests/

### DIFF
--- a/tests/01http-server.pl
+++ b/tests/01http-server.pl
@@ -139,10 +139,16 @@ package SyTest::HTTPServer {
 
       my $awaiter = extract_first_by {
          my $pathmatch = $_->pathmatch;
-         return 0 unless ( !ref $pathmatch and $path eq $pathmatch ) or
-                         ( ref $pathmatch  and $path =~ $pathmatch );
+         if( ref $pathmatch ) {
+            $path =~ $pathmatch or return 0;
+         }
+         else {
+            $path eq $pathmatch or return 0;
+         }
 
-         return 0 if $_->filter and not $_->filter->( $request );
+         if( $_->filter ) {
+            $_->filter->( $request ) or return 0;
+         }
 
          return 1;
       } @pending_awaiters;

--- a/tests/10apidoc/01register.pl
+++ b/tests/10apidoc/01register.pl
@@ -126,7 +126,8 @@ sub local_user_fixture
          matrix_register_user( $api_client )
          ->then_with_f( sub {
             my $f = shift;
-            return $f unless defined( my $displayname = $args{displayname} );
+            defined( my $displayname = $args{displayname} ) or
+               return $f;
 
             my $user = $f->get;
             do_request_json_for( $user,
@@ -137,7 +138,8 @@ sub local_user_fixture
             )->then_done( $user );
          })->then_with_f( sub {
             my $f = shift;
-            return $f unless defined( my $presence = $args{presence} );
+            defined( my $presence = $args{presence} ) or
+               return $f;
 
             my $user = $f->get;
             do_request_json_for( $user,

--- a/tests/10apidoc/33room-members.pl
+++ b/tests/10apidoc/33room-members.pl
@@ -370,8 +370,10 @@ sub matrix_create_and_join_room
          await_event_for( $creator, sub {
             my ( $event ) = @_;
 
-            return unless $event->{type} eq "m.room.member";
-            return unless $event->{room_id} eq $room_id;
+            $event->{type} eq "m.room.member" or
+               return 0;
+            $event->{room_id} eq $room_id or
+               return 0;
 
             $joined_members{ $event->{state_key} }++;
 

--- a/tests/10apidoc/33room-members.pl
+++ b/tests/10apidoc/33room-members.pl
@@ -357,7 +357,7 @@ sub matrix_create_and_join_room
             )
          } @local_members )
    })->then( sub {
-      return Future->done( $room_id ) unless $n_joiners;
+      $n_joiners or return Future->done( $room_id );
 
       # Now wait for the creator to see every join event, so we're sure
       # the remote joins have happened

--- a/tests/10apidoc/33room-members.pl
+++ b/tests/10apidoc/33room-members.pl
@@ -375,7 +375,9 @@ sub matrix_create_and_join_room
 
             $joined_members{ $event->{state_key} }++;
 
-            return 1 if keys( %joined_members ) == $n_joiners;
+            keys( %joined_members ) == $n_joiners
+               and return 1;
+
             return 0;
          }),
 

--- a/tests/20profile-events.pl
+++ b/tests/20profile-events.pl
@@ -20,9 +20,13 @@ test "Displayname change reports an event to myself",
       })->then( sub {
          await_event_for( $user, sub {
             my ( $event ) = @_;
-            return unless $event->{type} eq "m.presence";
+
+            $event->{type} eq "m.presence" or
+               return 0;
+
             my $content = $event->{content};
-            return unless $content->{user_id} eq $user->user_id;
+            $content->{user_id} eq $user->user_id or
+               return 0;
 
             $content->{displayname} eq $displayname or
                die "Expected displayname to be '$displayname'";
@@ -49,9 +53,13 @@ test "Avatar URL change reports an event to myself",
       )->then( sub {
          await_event_for( $user, sub {
             my ( $event ) = @_;
-            return unless $event->{type} eq "m.presence";
+
+            $event->{type} eq "m.presence" or
+               return 0;
+
             my $content = $event->{content};
-            return unless $content->{user_id} eq $user->user_id;
+            $content->{user_id} eq $user->user_id or
+               return 0;
 
             $content->{avatar_url} eq $avatar_url or
                die "Expected avatar_url to be '$avatar_url'";

--- a/tests/21presence-events.pl
+++ b/tests/21presence-events.pl
@@ -88,12 +88,15 @@ test "Friends presence changes reports events",
       })->then( sub {
          await_event_for( $user, sub {
             my ( $event ) = @_;
-            return unless $event->{type} eq "m.presence";
+
+            $event->{type} eq "m.presence" or
+               return 0;
 
             my $content = $event->{content};
             require_json_keys( $content, qw( user_id ));
 
-            return unless $content->{user_id} eq $friend->user_id;
+            $content->{user_id} eq $friend->user_id or
+               return 0;
 
             require_json_keys( $content, qw( presence status_msg ));
             $content->{presence} eq "online" or

--- a/tests/30rooms/01state.pl
+++ b/tests/30rooms/01state.pl
@@ -24,9 +24,13 @@ test "Room creation reports m.room.create to myself",
 
       await_event_for( $user, sub {
          my ( $event ) = @_;
-         return unless $event->{type} eq "m.room.create";
+
+         $event->{type} eq "m.room.create" or
+            return 0;
+
          require_json_keys( $event, qw( room_id user_id content ));
-         return unless $event->{room_id} eq $room_id;
+         $event->{room_id} eq $room_id or
+            return 0;
 
          $event->{user_id} eq $user->user_id or
             die "Expected user_id to be ${\$user->user_id}";
@@ -47,10 +51,15 @@ test "Room creation reports m.room.member to myself",
 
       await_event_for( $user, sub {
          my ( $event ) = @_;
-         return unless $event->{type} eq "m.room.member";
+
+         $event->{type} eq "m.room.member" or
+            return 0;
+
          require_json_keys( $event, qw( room_id user_id state_key content ));
-         return unless $event->{room_id} eq $room_id;
-         return unless $event->{state_key} eq $user->user_id;
+         $event->{room_id} eq $room_id or
+            return 0;
+         $event->{state_key} eq $user->user_id or
+            return 0;
 
          require_json_keys( my $content = $event->{content}, qw( membership ));
 
@@ -76,9 +85,13 @@ test "Setting room topic reports m.room.topic to myself",
       )->then( sub {
          await_event_for( $user, sub {
             my ( $event ) = @_;
-            return unless $event->{type} eq "m.room.topic";
+
+            $event->{type} eq "m.room.topic" or
+               return 0;
+
             require_json_keys( $event, qw( room_id user_id content ));
-            return unless $event->{room_id} eq $room_id;
+            $event->{room_id} eq $room_id or
+               return 0;
 
             $event->{user_id} eq $user->user_id or
                die "Expected user_id to be ${\$user->user_id}";

--- a/tests/30rooms/02members-local.pl
+++ b/tests/30rooms/02members-local.pl
@@ -38,11 +38,15 @@ test "New room members see their own join event",
 
       await_event_for( $local_user, sub {
          my ( $event ) = @_;
-         return unless $event->{type} eq "m.room.member";
+
+         $event->{type} eq "m.room.member" or
+            return 0;
 
          require_json_keys( $event, qw( type room_id user_id ));
-         return unless $event->{room_id} eq $room_id;
-         return unless $event->{user_id} eq $local_user->user_id;
+         $event->{room_id} eq $room_id or
+            return 0;
+         $event->{user_id} eq $local_user->user_id or
+            return 0;
 
          require_json_keys( my $content = $event->{content}, qw( membership ));
 
@@ -89,10 +93,15 @@ test "Existing members see new members' join events",
 
       await_event_for( $first_user, sub {
          my ( $event ) = @_;
-         return unless $event->{type} eq "m.room.member";
+
+         $event->{type} eq "m.room.member" or
+            return 0;
+
          require_json_keys( $event, qw( type room_id user_id ));
-         return unless $event->{room_id} eq $room_id;
-         return unless $event->{user_id} eq $local_user->user_id;
+         $event->{room_id} eq $room_id or
+            return 0;
+         $event->{user_id} eq $local_user->user_id or
+            return 0;
 
          require_json_keys( my $content = $event->{content}, qw( membership ));
 
@@ -111,10 +120,14 @@ test "Existing members see new members' presence",
 
       await_event_for( $first_user, sub {
          my ( $event ) = @_;
-         return unless $event->{type} eq "m.presence";
+
+         $event->{type} eq "m.presence" or
+            return 0;
+
          require_json_keys( $event, qw( type content ));
          require_json_keys( my $content = $event->{content}, qw( user_id presence ));
-         return unless $content->{user_id} eq $local_user->user_id;
+         $content->{user_id} eq $local_user->user_id or
+            return 0;
 
          return 1;
       });

--- a/tests/30rooms/03members-remote.pl
+++ b/tests/30rooms/03members-remote.pl
@@ -67,11 +67,15 @@ test "New room members see their own join event",
 
       await_event_for( $user, sub {
          my ( $event ) = @_;
-         return unless $event->{type} eq "m.room.member";
+
+         $event->{type} eq "m.room.member" or
+            return 0;
 
          require_json_keys( $event, qw( type room_id user_id ));
-         return unless $event->{room_id} eq $room_id;
-         return unless $event->{user_id} eq $user->user_id;
+         $event->{room_id} eq $room_id or
+            return 0;
+         $event->{user_id} eq $user->user_id or
+            return 0;
 
          require_json_keys( my $content = $event->{content}, qw( membership ));
 
@@ -122,10 +126,15 @@ test "Existing members see new members' join events",
 
       await_event_for( $first_user, sub {
          my ( $event ) = @_;
-         return unless $event->{type} eq "m.room.member";
+
+         $event->{type} eq "m.room.member" or
+            return 0;
+
          require_json_keys( $event, qw( type room_id user_id ));
-         return unless $event->{room_id} eq $room_id;
-         return unless $event->{user_id} eq $user->user_id;
+         $event->{room_id} eq $room_id or
+            return 0;
+         $event->{user_id} eq $user->user_id or
+            return 0;
 
          require_json_keys( my $content = $event->{content}, qw( membership ));
 
@@ -145,10 +154,15 @@ test "Existing members see new member's presence",
 
       await_event_for( $first_user, sub {
          my ( $event ) = @_;
-         return unless $event->{type} eq "m.presence";
+
+         $event->{type} eq "m.presence" or
+            return 0;
+
          require_json_keys( $event, qw( type content ));
          require_json_keys( my $content = $event->{content}, qw( user_id presence ));
-         return unless $content->{user_id} eq $user->user_id;
+
+         $content->{user_id} eq $user->user_id or
+            return 0;
 
          return 1;
       });

--- a/tests/30rooms/04messages.pl
+++ b/tests/30rooms/04messages.pl
@@ -28,12 +28,15 @@ test "Local room members see posted message events",
 
             await_event_for( $recvuser, sub {
                my ( $event ) = @_;
-               return unless $event->{type} eq "m.room.message";
+
+               $event->{type} eq "m.room.message" or
+                  return 0;
 
                require_json_keys( $event, qw( type content room_id user_id ));
                require_json_keys( my $content = $event->{content}, qw( msgtype body ));
 
-               return unless $event->{room_id} eq $room_id;
+               $event->{room_id} eq $room_id or
+                  return 0;
 
                $content->{msgtype} eq $msgtype or
                   die "Expected msgtype as $msgtype";
@@ -94,10 +97,12 @@ test "Local non-members don't see posted message events",
             my ( $event ) = @_;
             log_if_fail "Received event:", $event;
 
-            return unless $event->{type} eq "m.room.message";
+            $event->{type} eq "m.room.message" or
+               return 0;
 
             require_json_keys( $event, qw( type content room_id user_id ));
-            return unless $event->{room_id} eq $room_id;
+            $event->{room_id} eq $room_id or
+               return 0;
 
             die "Nonmember received event about a room they're not a member of";
          }),
@@ -153,12 +158,15 @@ test "Remote room members also see posted message events",
 
       await_event_for( $remote_user, sub {
          my ( $event ) = @_;
-         return unless $event->{type} eq "m.room.message";
+
+         $event->{type} eq "m.room.message" or
+            return 0;
 
          require_json_keys( $event, qw( type content room_id user_id ));
          require_json_keys( my $content = $event->{content}, qw( msgtype body ));
 
-         return unless $event->{room_id} eq $room_id;
+         $event->{room_id} eq $room_id or
+            return 0;
 
          $content->{msgtype} eq $msgtype or
             die "Expected msgtype as $msgtype";

--- a/tests/30rooms/06invite.pl
+++ b/tests/30rooms/06invite.pl
@@ -76,11 +76,15 @@ test "Invited user receives invite",
          my ( $event ) = @_;
 
          require_json_keys( $event, qw( type ));
-         return 0 unless $event->{type} eq "m.room.member";
+         $event->{type} eq "m.room.member" or
+            return 0;
 
          require_json_keys( $event, qw( room_id state_key ));
-         return 0 unless $event->{room_id} eq $room_id;
-         return 0 unless $event->{state_key} eq $invitee->user_id;
+
+         $event->{room_id} eq $room_id or
+            return 0;
+         $event->{state_key} eq $invitee->user_id or
+            return 0;
 
          require_json_keys( my $content = $event->{content}, qw( membership ));
 

--- a/tests/30rooms/09eventstream.pl
+++ b/tests/30rooms/09eventstream.pl
@@ -39,9 +39,11 @@ multi_test "Check that event streams started after a client joined a room work (
          # Wait for the message we just sent.
          await_event_for( $alice, sub {
             my ( $event ) = @_;
-            return unless $event->{type} eq "m.room.message";
-            return unless $event->{event_id} eq $event_id;
-            return 1;
+
+            $event->{type} eq "m.room.message" or
+               return 0;
+
+            return $event->{event_id} eq $event_id;
          })->SyTest::pass_on_done( "Alice saw her message" )
       })->then_done(1);
    };

--- a/tests/30rooms/13anonymousaccess.pl
+++ b/tests/30rooms/13anonymousaccess.pl
@@ -297,8 +297,11 @@ sub check_events
       foreach my $event ( @{ $body->{chunk} } ) {
          next if all { $_ ne "content" } keys %{ $event };
          next if all { $_ ne "body" } keys %{ $event->{content} };
+
          $found = 1 if $event->{content}->{body} eq "public";
-         die "Should not have found private" if $event->{content}->{body} eq "private";
+
+         $event->{content}->{body} eq "private" and
+            die "Should not have found private";
       }
 
       Future->done( $found );

--- a/tests/30rooms/20typing.pl
+++ b/tests/30rooms/20typing.pl
@@ -170,7 +170,7 @@ multi_test "Typing notifications timeout and can be resent",
             return unless $event->{type} eq "m.typing";
             return unless $event->{room_id} eq $room_id;
 
-            return if scalar @{ $event->{content}{user_ids} };
+            @{ $event->{content}{user_ids} } == 0 or return;
 
             ( time() - $start_time ) < 0.5 or
                die "Took too long to time out";

--- a/tests/30rooms/20typing.pl
+++ b/tests/30rooms/20typing.pl
@@ -52,12 +52,14 @@ test "Typing notification sent to local room members",
             await_event_for( $recvuser, sub {
                my ( $event ) = @_;
 
-               return unless $event->{type} eq "m.typing";
+               $event->{type} eq "m.typing" or
+                  return 0;
 
                require_json_keys( $event, qw( type room_id content ));
                require_json_keys( my $content = $event->{content}, qw( user_ids ));
 
-               return unless $event->{room_id} eq $room_id;
+               $event->{room_id} eq $room_id or
+                  return 0;
 
                require_json_list( my $users = $content->{user_ids} );
 
@@ -83,12 +85,14 @@ test "Typing notifications also sent to remote room members",
       await_event_for( $remote_user, sub {
          my ( $event ) = @_;
 
-         return unless $event->{type} eq "m.typing";
+         $event->{type} eq "m.typing" or
+            return 0;
 
          require_json_keys( $event, qw( type room_id content ));
          require_json_keys( my $content = $event->{content}, qw( user_ids ));
 
-         return unless $event->{room_id} eq $room_id;
+         $event->{room_id} eq $room_id or
+            return 0;
 
          require_json_list( my $users = $content->{user_ids} );
 
@@ -116,12 +120,14 @@ test "Typing can be explicitly stopped",
             await_event_for( $recvuser, sub {
                my ( $event ) = @_;
 
-               return unless $event->{type} eq "m.typing";
+               $event->{type} eq "m.typing" or
+                  return 0;
 
                require_json_keys( $event, qw( type room_id content ));
                require_json_keys( my $content = $event->{content}, qw( user_ids ));
 
-               return unless $event->{room_id} eq $room_id;
+               $event->{room_id} eq $room_id or
+                  return 0;
 
                require_json_list( my $users = $content->{user_ids} );
 
@@ -155,10 +161,14 @@ multi_test "Typing notifications timeout and can be resent",
          # start typing
          await_event_for( $user, sub {
             my ( $event ) = @_;
-            return unless $event->{type} eq "m.typing";
-            return unless $event->{room_id} eq $room_id;
 
-            return unless scalar @{ $event->{content}{user_ids} };
+            $event->{type} eq "m.typing" or
+               return 0;
+            $event->{room_id} eq $room_id or
+               return 0;
+
+            scalar @{ $event->{content}{user_ids} } or
+               return 0;
 
             pass( "Received start notification" );
             return 1;
@@ -167,8 +177,11 @@ multi_test "Typing notifications timeout and can be resent",
          # stop typing
          await_event_for( $user, sub {
             my ( $event ) = @_;
-            return unless $event->{type} eq "m.typing";
-            return unless $event->{room_id} eq $room_id;
+
+            $event->{type} eq "m.typing" or
+               return 0;
+            $event->{room_id} eq $room_id or
+               return 0;
 
             @{ $event->{content}{user_ids} } == 0 or return;
 

--- a/tests/40presence.pl
+++ b/tests/40presence.pl
@@ -32,7 +32,9 @@ test "Presence changes are reported to local room members",
 
             await_event_for( $recvuser, sub {
                my ( $event ) = @_;
-               return unless $event->{type} eq "m.presence";
+
+               $event->{type} eq "m.presence" or
+                  return 0;
 
                require_json_keys( $event, qw( type content ));
                require_json_keys( my $content = $event->{content},
@@ -61,7 +63,9 @@ test "Presence changes are also reported to remote room members",
 
       await_event_for( $remote_user, sub {
          my ( $event ) = @_;
-         return unless $event->{type} eq "m.presence";
+
+         $event->{type} eq "m.presence" or
+            return 0;
 
          require_json_keys( $event, qw( type content ));
          require_json_keys( my $content = $event->{content},
@@ -97,12 +101,16 @@ test "Presence changes to OFFLINE are reported to local room members",
 
             await_event_for( $recvuser, sub {
                my ( $event ) = @_;
-               return unless $event->{type} eq "m.presence";
+
+               $event->{type} eq "m.presence" or
+                  return 0;
 
                my $content = $event->{content};
-               return unless $content->{user_id} eq $senduser->user_id;
+               $content->{user_id} eq $senduser->user_id or
+                  return 0;
 
-               return unless $content->{presence} eq "offline";
+               $content->{presence} eq "offline" or
+                  return 0;
 
                return 1;
             })
@@ -120,12 +128,15 @@ test "Presence changes to OFFLINE are reported to remote room members",
       await_event_for( $remote_user, sub {
          my ( $event ) = @_;
 
-         return unless $event->{type} eq "m.presence";
+         $event->{type} eq "m.presence" or
+            return 0;
 
          my $content = $event->{content};
-         return unless $content->{user_id} eq $senduser->user_id;
+         $content->{user_id} eq $senduser->user_id or
+            return 0;
 
-         return unless $content->{presence} eq "offline";
+         $content->{presence} eq "offline" or
+            return 0;
 
          return 1;
       });

--- a/tests/42tags.pl
+++ b/tests/42tags.pl
@@ -219,8 +219,12 @@ test "Tags appear in the v1 /events stream",
 
          await_event_for( $user, sub {
             my ( $event ) = @_;
-            return unless $event->{type} eq "m.tag"
-               and $event->{room_id} eq $room_id;
+
+            $event->{type} eq "m.tag" or
+               return 0;
+
+            $event->{room_id} eq $room_id or
+               return 0;
 
             check_tag_event( $event );
 

--- a/tests/60app-services/02ghost.pl
+++ b/tests/60app-services/02ghost.pl
@@ -78,8 +78,11 @@ multi_test "AS-ghosted users can use rooms via AS",
       ->then( sub {
          await_event_for( $creator, sub {
             my ( $event ) = @_;
-            return unless $event->{type} eq "m.room.message";
-            return unless $event->{room_id} eq $room_id;
+
+            $event->{type} eq "m.room.message" or
+               return 0;
+            $event->{room_id} eq $room_id or
+               return 0;
 
             log_if_fail "Event", $event;
 
@@ -157,8 +160,11 @@ multi_test "AS-ghosted users can use rooms themselves",
       ->then( sub {
          await_event_for( $creator, sub {
             my ( $event ) = @_;
-            return unless $event->{type} eq "m.room.message";
-            return unless $event->{room_id} eq $room_id;
+
+            $event->{type} eq "m.room.message" or
+               return 0;
+            $event->{room_id} eq $room_id or
+               return 0;
 
             log_if_fail "Event", $event;
 

--- a/tests/61push/01message-pushed.pl
+++ b/tests/61push/01message-pushed.pl
@@ -43,11 +43,10 @@ multi_test "Test that a message is pushed",
          Future->needs_all(
             await_event_for( $bob, sub {
                my ( $event ) = @_;
-               return unless $event->{type} eq "m.room.member" and
-                  $event->{room_id} eq $room_id and
-                  $event->{state_key} eq $bob->user_id and
-                  $event->{content}{membership} eq "invite";
-               return 1;
+               return $event->{type} eq "m.room.member" &&
+                      $event->{room_id} eq $room_id &&
+                      $event->{state_key} eq $bob->user_id &&
+                      $event->{content}{membership} eq "invite";
             })->SyTest::pass_on_done( "Bob received invite" ),
 
             matrix_invite_user_to_room( $alice, $bob, $room_id ),
@@ -86,8 +85,11 @@ multi_test "Test that a message is pushed",
                my ( $request ) = @_;
                my $body = $request->body_from_json;
 
-               return unless $body->{notification}{type};
-               return unless $body->{notification}{type} eq "m.room.message";
+               $body->{notification}{type} or
+                  return 0;
+               $body->{notification}{type} eq "m.room.message" or
+                  return 0;
+
                return 1;
             })->then( sub {
                my ( $request ) = @_;

--- a/tests/90jira/SYN-115.pl
+++ b/tests/90jira/SYN-115.pl
@@ -30,12 +30,11 @@ multi_test "New federated private chats get full presence information (SYN-115)"
          # Bob should receive the invite
          await_event_for( $bob, sub {
             my ( $event ) = @_;
-            return unless $event->{type} eq "m.room.member" and
-                          $event->{room_id} eq $room_id and
-                          $event->{state_key} eq $bob->user_id and
-                          $event->{content}{membership} eq "invite";
 
-            return 1;
+            return $event->{type} eq "m.room.member" &&
+                   $event->{room_id} eq $room_id &&
+                   $event->{state_key} eq $bob->user_id &&
+                   $event->{content}{membership} eq "invite";
          })->SyTest::pass_on_done( "Received invite" )
       })->then( sub {
 

--- a/tests/90jira/SYN-205.pl
+++ b/tests/90jira/SYN-205.pl
@@ -13,12 +13,11 @@ multi_test "Rooms can be created with an initial invite list (SYN-205)",
 
          await_event_for( $invitee, sub {
             my ( $event ) = @_;
-            return unless $event->{type} eq "m.room.member" and
-                          $event->{room_id} eq $room_id and
-                          $event->{state_key} eq $invitee->user_id and
-                          $event->{content}{membership} eq "invite";
 
-            return 1;
+            return $event->{type} eq "m.room.member" &&
+                   $event->{room_id} eq $room_id &&
+                   $event->{state_key} eq $invitee->user_id &&
+                   $event->{content}{membership} eq "invite";
          })->SyTest::pass_on_done( "Invitee received invite event" )
       })->then_done(1);
    };

--- a/tests/90jira/SYN-328.pl
+++ b/tests/90jira/SYN-328.pl
@@ -24,10 +24,9 @@ multi_test "Typing notifications don't leak",
 
             await_event_for( $recvuser, sub {
                my ( $event ) = @_;
-               return unless $event->{type} eq "m.typing";
-               return unless $event->{room_id} eq $room_id;
 
-               return 1;
+               return $event->{type} eq "m.typing" &&
+                      $event->{room_id} eq $room_id;
             })
          } $creator, $member )
             ->SyTest::pass_on_done( "Members received notification" )
@@ -38,10 +37,9 @@ multi_test "Typing notifications don't leak",
 
             await_event_for( $nonmember, sub {
                my ( $event ) = @_;
-               return unless $event->{type} eq "m.typing";
-               return unless $event->{room_id} eq $room_id;
 
-               return 1;
+               return $event->{type} eq "m.typing" &&
+                      $event->{room_id} eq $room_id;
             })->then_fail( "Received unexpected typing notification" ),
          )->SyTest::pass_on_done( "Non-member did not receive it up to timeout" )
       })->then_done(1);

--- a/tests/90jira/SYN-442.pl
+++ b/tests/90jira/SYN-442.pl
@@ -24,9 +24,14 @@ multi_test "Test that we can be reinvited to a room we created",
 
          await_event_for( $user_2, sub {
             my ( $event ) = @_;
-            return 0 unless $event->{type} eq "m.room.member";
-            return 0 unless $event->{content}->{membership} eq "invite";
-            return 0 unless $event->{room_id} eq $room_id;
+
+            $event->{type} eq "m.room.member" or
+               return 0;
+            $event->{content}->{membership} eq "invite" or
+               return 0;
+            $event->{room_id} eq $room_id or
+               return 0;
+
             return 1;
          })->SyTest::pass_on_done( "User B received the invite from A" )
       })->then( sub {
@@ -48,9 +53,14 @@ multi_test "Test that we can be reinvited to a room we created",
 
          await_event_for( $user_2, sub {
             my ( $event ) = @_;
-            return 0 unless $event->{type} eq "m.room.member";
-            return 0 unless $event->{content}->{membership} eq "leave";
-            return 0 unless $event->{room_id} eq $room_id;
+
+            $event->{type} eq "m.room.member" or
+               return 0;
+            $event->{content}->{membership} eq "leave" or
+               return 0;
+            $event->{room_id} eq $room_id or
+               return 0;
+
             return 1;
          })->SyTest::pass_on_done( "User B received the leave event" )
       })->then( sub {
@@ -61,9 +71,14 @@ multi_test "Test that we can be reinvited to a room we created",
 
          await_event_for( $user_1, sub {
             my ( $event ) = @_;
-            return 0 unless $event->{type} eq "m.room.member";
-            return 0 unless $event->{content}->{membership} eq "invite";
-            return 0 unless $event->{room_id} eq $room_id;
+
+            $event->{type} eq "m.room.member" or
+               return 0;
+            $event->{content}->{membership} eq "invite" or
+               return 0;
+            $event->{room_id} eq $room_id or
+               return 0;
+
             return 1;
          })->SyTest::pass_on_done( "User A received the invite from user B" )
       })->then( sub {


### PR DESCRIPTION
To match STYLE-GUIDE.rst, replace cases of `SMT if/unless COND` with `COND and/or SMT`.