### PR TITLE
Cherrypick fixes to 'await_event_for()' from PR #65

### DIFF
--- a/tests/10apidoc/03events-initial.pl
+++ b/tests/10apidoc/03events-initial.pl
@@ -1,4 +1,4 @@
-use List::UtilsBy qw( extract_by );
+use List::UtilsBy qw( extract_first_by );
 use Future::Utils qw( repeat );
 
 test "GET /events initially",
@@ -139,14 +139,12 @@ sub await_event_for
          ? Future->done( splice @{ $user->saved_events } )  # fetch-and-clear
          : GET_new_events_for( $user )
       )->then( sub {
-         my $found;
-         foreach my $event ( @_ ) {
-            not $found and $filter->( $event ) and
-               $found = $event, next;
+         my @events = @_;
 
-            # Save it for later
-            push @{ $user->saved_events }, $event;
-         }
+         my $found = extract_first_by { $filter->( $_ ) } @events;
+
+         # Save the rest for next time
+         push @{ $user->saved_events }, @events;
 
          Future->done( $found );
       });

--- a/tests/10apidoc/03events-initial.pl
+++ b/tests/10apidoc/03events-initial.pl
@@ -142,7 +142,7 @@ sub await_event_for
          my $found;
          foreach my $event ( @_ ) {
             not $found and $filter->( $event ) and
-               $found = 1, next;
+               $found = $event, next;
 
             # Save it for later
             push @{ $user->saved_events }, $event;


### PR DESCRIPTION
I want to fix up some other tests before I finish work on the remaining comments on PR #65, but to fix those up requires first this (unrelated) fix to `await_event_for()`. So I've cherrypicked them here.