### PR TITLE
Update tests for SPEC-254

### DIFF
--- a/tests/31sync/06state.pl
+++ b/tests/31sync/06state.pl
@@ -2,6 +2,7 @@ use Future::Utils qw( repeat );
 
 # call /sync repeatedly until it returns a result
 # with an event in the given room
+# TODO: it might be good to combine this with await_event_for() at some point.
 sub wait_for_event_in_room {
     my ($user, $room_id, %params) = @_;
 
@@ -18,7 +19,7 @@ sub wait_for_event_in_room {
                           scalar @{ $room->{state}{events}})) {
                 Future->done($body);
             } else {
-                delay(0.1) -> then_done(undef);
+                delay(0.1)->then_done(undef);
             }
         });
     }, while => sub {!$_[0]->failure and !$_[0]->get});

--- a/tests/31sync/06state.pl
+++ b/tests/31sync/06state.pl
@@ -1,4 +1,30 @@
-test "State is included in the initial sync",
+use Future::Utils qw( repeat );
+
+# call /sync repeatedly until it returns a result
+# with an event in the given room
+sub wait_for_event_in_room {
+    my ($user, $room_id, %params) = @_;
+
+    my $sync_params = $params{sync_params} || {};
+
+    repeat(sub {
+        # returns the sync body if the event happened, else undef
+        matrix_sync( $user, %{ $sync_params } )->then( sub {
+            my ( $body ) = @_;
+
+            my $room = $body->{rooms}{joined}{$room_id};
+
+            if( $room && (scalar @{ $room->{timeline}{events}} ||
+                          scalar @{ $room->{state}{events}})) {
+                Future->done($body);
+            } else {
+                delay(0.1) -> then_done(undef);
+            }
+        });
+    }, while => sub {!$_[0]->failure and !$_[0]->get});
+}
+
+test "State is included in the timeline in the initial sync",
    requires => [qw( first_api_client can_sync )],
 
    check => sub {
@@ -8,7 +34,7 @@ test "State is included in the initial sync",
 
       my $filter = {
          room => {
-            timeline  => { types => [] },
+            timeline  => { types => [ "a.madeup.test.state" ] },
             state     => { types => [ "a.madeup.test.state" ] },
             ephemeral => { types => [] },
          },
@@ -33,10 +59,15 @@ test "State is included in the initial sync",
 
          my $room = $body->{rooms}{joined}{$room_id};
          require_json_keys( $room, qw( event_map timeline state ephemeral ));
-         @{ $room->{state}{events} } == 1
-            or die "Expected only one state event";
 
-         my $event_id = $room->{state}{events}[0];
+         # state from the timeline should *not* appear in the state dictionary
+         @{ $room->{state}{events} } == 0
+            or die "Expected no state events";
+
+         @{ $room->{timeline}{events} } == 1
+            or die "Expected one timeline event";
+
+         my $event_id = $room->{timeline}{events}[0];
          $room->{event_map}{$event_id}{type} eq "a.madeup.test.state"
             or die "Unexpected state event type";
          $room->{event_map}{$event_id}{content}{my_key} == 1
@@ -44,6 +75,63 @@ test "State is included in the initial sync",
 
          Future->done(1);
       })
+   };
+
+# state that has arrived over federation counts as an 'outlier', so should
+# only appear in the state dictionary, not the timeline.
+test "State from remote users is included in the state in the initial sync",
+    requires => [remote_user_fixture(), qw( first_api_client can_sync )],
+
+    check => sub {
+        my ( $remote_user, $http ) = @_;
+
+        my ( $user, $filter_id, $room_id );
+
+        my $filter = {
+            room => {
+                timeline  => { types => [ "a.madeup.test.state" ] },
+                state     => { types => [ "a.madeup.test.state" ] },
+                ephemeral => { types => [] },
+            },
+            presence => {types => [] },
+        };
+
+        matrix_register_user_with_filter( $http, $filter )->then( sub {
+            ( $user, $filter_id ) = @_;
+
+            matrix_create_room( $remote_user );
+        })->then( sub {
+            ( $room_id ) = @_;
+
+            matrix_put_room_state( $remote_user, $room_id,
+                                   type    => "a.madeup.test.state",
+                                   content => { "my_key" => 1 });
+        })->then( sub {
+            matrix_invite_user_to_room( $remote_user, $user, $room_id );
+        })->then( sub {
+            matrix_join_room( $user, $room_id );
+        })->then( sub {
+            matrix_sync( $user, filter => $filter_id );
+        })->then( sub {
+            my ( $body ) = @_;
+
+            my $room = $body->{rooms}{joined}{$room_id};
+            require_json_keys( $room, qw( event_map timeline state ephemeral ));
+
+            @{ $room->{state}{events} } == 1
+                or die "Expected one state event";
+
+            @{ $room->{timeline}{events} } == 0
+                or die "Expected no timeline events";
+
+            my $event_id = $room->{state}{events}[0];
+            $room->{event_map}{$event_id}{type} eq "a.madeup.test.state"
+                or die "Unexpected state event type";
+            $room->{event_map}{$event_id}{content}{my_key} == 1
+                or die "Unexpected event content";
+
+            Future->done(1);
+         })
    };
 
 
@@ -191,6 +279,69 @@ test "Changes to state are included in an gapped incremental sync",
    };
 
 
+test "State from remote users is included in the timeline in an incremental sync",
+    requires => [remote_user_fixture(), qw( first_api_client can_sync )],
+
+    check => sub {
+        my ( $remote_user, $http ) = @_;
+
+        my ( $user, $filter_id, $room_id, $next_batch );
+
+        my $filter = {
+            room => {
+                timeline  => { types => [ "a.madeup.test.state" ] },
+                state     => { types => [ "a.madeup.test.state" ] },
+                ephemeral => { types => [] },
+            },
+            presence => {types => [] },
+        };
+
+        matrix_register_user_with_filter( $http, $filter )->then( sub {
+            ( $user, $filter_id ) = @_;
+
+            matrix_create_room( $remote_user );
+        })->then( sub {
+            ( $room_id ) = @_;
+            matrix_invite_user_to_room( $remote_user, $user, $room_id );
+        })->then( sub {
+            matrix_join_room( $user, $room_id );
+        })->then( sub {
+            matrix_sync( $user, filter => $filter_id );
+        })->then( sub {
+            my ( $body ) = @_;
+            $next_batch = $body->{next_batch};
+
+            matrix_put_room_state( $remote_user, $room_id,
+                                   type    => "a.madeup.test.state",
+                                   content => { "my_key" => 1 });
+        })->then( sub {
+            # wait for the event to turn up on the other side
+            wait_for_event_in_room( $user, $room_id, 
+               sync_params => { filter => $filter_id, since => $next_batch },
+            );
+        })->then( sub {
+            my ( $body ) = @_;
+
+            my $room = $body->{rooms}{joined}{$room_id};
+            require_json_keys( $room, qw( event_map timeline state ephemeral ));
+
+            @{ $room->{state}{events} } == 0
+                or die "Expected no state events";
+
+            @{ $room->{timeline}{events} } == 1
+                or die "Expected one timeline event";
+
+            my $event_id = $room->{timeline}{events}[0];
+            $room->{event_map}{$event_id}{type} eq "a.madeup.test.state"
+                or die "Unexpected state event type";
+            $room->{event_map}{$event_id}{content}{my_key} == 1
+                or die "Unexpected event content";
+
+            Future->done(1);
+         })
+   };
+
+
 test "A full_state incremental update returns all state",
    requires => [qw( first_api_client can_sync )],
 
@@ -200,7 +351,7 @@ test "A full_state incremental update returns all state",
       my ( $user, $filter_id, $room_id, $next_batch );
 
       my $filter = { room => {
-          timeline => { limit => 1 },
+          timeline => { limit => 2 },
           state     => { types => [ "a.madeup.test.state" ] },
       } };
 
@@ -228,8 +379,10 @@ test "A full_state incremental update returns all state",
          my ( $body ) = @_;
 
          $next_batch = $body->{next_batch};
-         @{ $body->{rooms}{joined}{$room_id}{state}{events} } == 2
-            or die "Expected two state events";
+         @{ $body->{rooms}{joined}{$room_id}{state}{events} } == 0
+             or die "Expected zero state events";
+         @{ $body->{rooms}{joined}{$room_id}{timeline}{events} } == 2
+             or die "Expected two timeline events";
 
          matrix_put_room_state( $user, $room_id,
             type      => "a.madeup.test.state",
@@ -253,23 +406,36 @@ test "A full_state incremental update returns all state",
          require_json_keys( $room, qw( event_map timeline state ephemeral ));
 
          @{ $room->{state}{events} } == 2
-            or die "Expected only two state events";
-
-         my $found_state_event = 0;
+            or die "Expected two state events";
+         my $got_key_1 = 0;
+         my $got_key_2 = 0;
          foreach my $event_id (@{ $room->{state}{events} }) {
-            my $event = $room->{event_map}{$event_id};
-            $event->{type} eq "a.madeup.test.state"
-               or die "Unexpected type";
-            $event->{state_key} eq 'this_state_changes' or next;
-            $event->{content}{my_key} == 2
-               or die "Unexpected event content";
-            $found_state_event = 1;
+             my $event = $room->{event_map}{$event_id};
+             $event->{type} eq "a.madeup.test.state"
+                 or die "Unexpected type";
+             my $my_key = $event->{content}{my_key};
+             if( $event->{state_key} eq 'this_state_does_not_change' ) {
+                 $got_key_1++;
+                 $my_key == 1
+                     or die "Unexpected event content ".$my_key;
+             } elsif( $event->{state_key} eq 'this_state_changes' ) {
+                 $got_key_2++;
+                 $my_key == 2
+                     or die "Unexpected event content ".$my_key;
+             } else {
+                 die "Unexpected state key ".$event->{state_key};
+             }
          }
+         $got_key_1 == 1 or die "missing this_state_does_not_change";
+         $got_key_2 == 1 or die "missing this_state_changes";
 
-         $found_state_event or die "Didn't find event with state_key this_state_changes state event";
-
-         @{ $room->{timeline}{events} } == 1
-             or die "Expected only one timeline event";
+         @{ $room->{timeline}{events} } == 2
+             or die "Expected two timeline event";
+         foreach my $i (0..1) {
+             my $event = $room->{event_map}{$room->{timeline}{events}[$i]};
+             $event->{type} eq "a.made.up.filler.type"
+                 or die "Unexpected type ".$event->{type};
+         }
 
          Future->done(1);
       })


### PR DESCRIPTION
Sync now returns state corresponding to the *start* of the timeline. Update the
tests to reflect that.

This code tests the changes introduced in
https://github.com/matrix-org/synapse/pull/373.