### PR TITLE
Merge a sequence of three `test`s into a single `multi_test`

### DIFF
--- a/tests/30rooms/06invite.pl
+++ b/tests/30rooms/06invite.pl
@@ -43,16 +43,6 @@ sub inviteonly_room_fixture
 
 my $inviteonly_room_fixture = inviteonly_room_fixture( creator => $creator_fixture );
 
-test "Uninvited users cannot join the room",
-   requires => [ local_user_fixture(), $inviteonly_room_fixture ],
-
-   check => sub {
-      my ( $uninvited, $room_id ) = @_;
-
-      matrix_join_room( $uninvited, $room_id )
-         ->main::expect_http_403;
-   };
-
 my $invited_user_fixture = local_user_fixture();
 
 test "Can invite users to invite-only rooms",
@@ -112,6 +102,17 @@ test "Invited user can join the room",
 
          Future->done(1);
       });
+   };
+
+test "Uninvited users cannot join the room",
+   requires => [ local_user_fixture(),
+                 inviteonly_room_fixture( creator => $creator_fixture ) ],
+
+   check => sub {
+      my ( $uninvited, $room_id ) = @_;
+
+      matrix_join_room( $uninvited, $room_id )
+         ->main::expect_http_403;
    };
 
 my $other_local_user_fixture = local_user_fixture();

--- a/tests/30rooms/06invite.pl
+++ b/tests/30rooms/06invite.pl
@@ -41,13 +41,10 @@ sub inviteonly_room_fixture
    )
 };
 
-my $inviteonly_room_fixture = inviteonly_room_fixture( creator => $creator_fixture );
-
-my $invited_user_fixture = local_user_fixture();
-
 multi_test "Can invite users to invite-only rooms",
-   requires => [ $creator_fixture, $invited_user_fixture, $inviteonly_room_fixture,
-                qw( can_invite_room )],
+   requires => [ $creator_fixture, local_user_fixture(),
+                 inviteonly_room_fixture( creator => $creator_fixture ),
+                 qw( can_invite_room )],
 
    do => sub {
       my ( $creator, $invitee, $room_id ) = @_;

--- a/tests/30rooms/06invite.pl
+++ b/tests/30rooms/06invite.pl
@@ -45,7 +45,7 @@ my $inviteonly_room_fixture = inviteonly_room_fixture( creator => $creator_fixtu
 
 my $invited_user_fixture = local_user_fixture();
 
-test "Can invite users to invite-only rooms",
+multi_test "Can invite users to invite-only rooms",
    requires => [ $creator_fixture, $invited_user_fixture, $inviteonly_room_fixture,
                 qw( can_invite_room )],
 
@@ -53,43 +53,33 @@ test "Can invite users to invite-only rooms",
       my ( $creator, $invitee, $room_id ) = @_;
 
       matrix_invite_user_to_room( $creator, $invitee, $room_id )
-   };
+         ->SyTest::pass_on_done( "Sent invite" )
+      ->then( sub {
+         await_event_for( $invitee, sub {
+            my ( $event ) = @_;
 
-test "Invited user receives invite",
-   requires => [ $invited_user_fixture, $inviteonly_room_fixture,
-                 qw( can_invite_room )],
+            require_json_keys( $event, qw( type ));
+            return 0 unless $event->{type} eq "m.room.member";
 
-   do => sub {
-      my ( $invitee, $room_id ) = @_;
+            require_json_keys( $event, qw( room_id state_key ));
+            return 0 unless $event->{room_id} eq $room_id;
+            return 0 unless $event->{state_key} eq $invitee->user_id;
 
-      await_event_for( $invitee, sub {
+            return 1;
+         })
+      })->then( sub {
          my ( $event ) = @_;
-
-         require_json_keys( $event, qw( type ));
-         return 0 unless $event->{type} eq "m.room.member";
-
-         require_json_keys( $event, qw( room_id state_key ));
-         return 0 unless $event->{room_id} eq $room_id;
-         return 0 unless $event->{state_key} eq $invitee->user_id;
 
          require_json_keys( my $content = $event->{content}, qw( membership ));
 
          $content->{membership} eq "invite" or
             die "Expected membership to be 'invite'";
 
-         return 1;
-      });
-   };
+         pass "Received invite";
 
-test "Invited user can join the room",
-   requires => [ $invited_user_fixture, $inviteonly_room_fixture,
-                 qw( can_invite_room )],
-
-   do => sub {
-      my ( $invitee, $room_id ) = @_;
-
-      matrix_join_room( $invitee, $room_id )
-      ->then( sub {
+         matrix_join_room( $invitee, $room_id )
+            ->SyTest::pass_on_done( "Joined room" )
+      })->then( sub {
          matrix_get_room_state( $invitee, $room_id,
             type      => "m.room.member",
             state_key => $invitee->user_id,

--- a/tests/30rooms/06invite.pl
+++ b/tests/30rooms/06invite.pl
@@ -1,6 +1,5 @@
 use List::Util qw( first );
 
-my $creator_fixture = local_user_fixture();
 
 sub inviteonly_room_fixture
 {
@@ -42,9 +41,16 @@ sub inviteonly_room_fixture
 };
 
 multi_test "Can invite users to invite-only rooms",
-   requires => [ $creator_fixture, local_user_fixture(),
-                 inviteonly_room_fixture( creator => $creator_fixture ),
-                 qw( can_invite_room )],
+   requires => do {
+      my $creator_fixture = local_user_fixture();
+
+      return [
+         $creator_fixture,
+         local_user_fixture(),
+         inviteonly_room_fixture( creator => $creator_fixture ),
+         qw( can_invite_room ),
+      ];
+   },
 
    do => sub {
       my ( $creator, $invitee, $room_id ) = @_;
@@ -93,7 +99,7 @@ multi_test "Can invite users to invite-only rooms",
 
 test "Uninvited users cannot join the room",
    requires => [ local_user_fixture(),
-                 inviteonly_room_fixture( creator => $creator_fixture ) ],
+                 inviteonly_room_fixture( creator => local_user_fixture() ) ],
 
    check => sub {
       my ( $uninvited, $room_id ) = @_;


### PR DESCRIPTION
Avoids inter-test related state due to shared fixtures. Makes it easier to extend the invite test in PR #65 later.