### PR TITLE
Fix flaky test

### DIFF
--- a/tests/10apidoc/03events-initial.pl
+++ b/tests/10apidoc/03events-initial.pl
@@ -78,6 +78,7 @@ sub matrix_initialsync
 
 # A useful function which keeps track of the current eventstream token and
 #   fetches new events since it
+# $room_id may be undefined, in which case it gets events for all joined rooms.
 sub GET_new_events_for
 {
    my ( $user, $room_id ) = @_;
@@ -133,7 +134,7 @@ sub await_event_for
 {
    my ( $user, %params ) = @_;
 
-   my $filter = defined $params{filter} ? $params{filter} : sub { 1 };
+   my $filter = $params{filter} || sub { 1 };
    my $room_id = $params{room_id};  # May be undefined, in which case we listen to all joined rooms.
 
    my $failmsg = SyTest::CarpByFile::shortmess( "Timed out waiting for an event" );

--- a/tests/10apidoc/03events-initial.pl
+++ b/tests/10apidoc/03events-initial.pl
@@ -129,11 +129,13 @@ sub flush_events_for
 
 # Note that semantics are undefined if calls are interleaved with differing
 # $room_ids for the same user.
-#
-# if $room_id is undefined, all joined rooms will be listened to.
 sub await_event_for
 {
-   my ( $user, $filter, $room_id ) = @_;
+   my ( $user, %params ) = @_;
+
+   my $filter = defined $params{filter} ? $params{filter} : sub { 1 };
+   my $room_id = $params{room_id};  # May be undefined, in which case we listen to all joined rooms.
+
    my $failmsg = SyTest::CarpByFile::shortmess( "Timed out waiting for an event" );
 
    my $f = repeat {

--- a/tests/10apidoc/33room-members.pl
+++ b/tests/10apidoc/33room-members.pl
@@ -368,7 +368,7 @@ sub matrix_create_and_join_room
       #   timeout smaller than the default overall test timeout so if this
       #   fails to happen we'll fail sooner, and get a better message
       Future->wait_any(
-         await_event_for( $creator, sub {
+         await_event_for( $creator, filter => sub {
             my ( $event ) = @_;
 
             return unless $event->{type} eq "m.room.member";

--- a/tests/20profile-events.pl
+++ b/tests/20profile-events.pl
@@ -18,7 +18,7 @@ test "Displayname change reports an event to myself",
             content => { displayname => $displayname },
          )
       })->then( sub {
-         await_event_for( $user, sub {
+         await_event_for( $user, filter => sub {
             my ( $event ) = @_;
             return unless $event->{type} eq "m.presence";
             my $content = $event->{content};
@@ -47,7 +47,7 @@ test "Avatar URL change reports an event to myself",
 
          content => { avatar_url => $avatar_url },
       )->then( sub {
-         await_event_for( $user, sub {
+         await_event_for( $user, filter => sub {
             my ( $event ) = @_;
             return unless $event->{type} eq "m.presence";
             my $content = $event->{content};

--- a/tests/21presence-events.pl
+++ b/tests/21presence-events.pl
@@ -48,7 +48,7 @@ test "Presence change reports an event to myself",
 
          content => { presence => "online", status_msg => $status_msg },
       )->then( sub {
-         await_event_for( $user, sub {
+         await_event_for( $user, filter => sub {
             my ( $event ) = @_;
             next unless $event->{type} eq "m.presence";
             my $content = $event->{content};
@@ -86,7 +86,7 @@ test "Friends presence changes reports events",
             content => { presence => "online", status_msg => $friend_status },
          );
       })->then( sub {
-         await_event_for( $user, sub {
+         await_event_for( $user, filter => sub {
             my ( $event ) = @_;
             return unless $event->{type} eq "m.presence";
 

--- a/tests/30rooms/01state.pl
+++ b/tests/30rooms/01state.pl
@@ -22,7 +22,7 @@ test "Room creation reports m.room.create to myself",
    do => sub {
       my ( $user, $room_id ) = @_;
 
-      await_event_for( $user, sub {
+      await_event_for( $user, filter => sub {
          my ( $event ) = @_;
          return unless $event->{type} eq "m.room.create";
          require_json_keys( $event, qw( room_id user_id content ));
@@ -45,7 +45,7 @@ test "Room creation reports m.room.member to myself",
    do => sub {
       my ( $user, $room_id ) = @_;
 
-      await_event_for( $user, sub {
+      await_event_for( $user, filter => sub {
          my ( $event ) = @_;
          return unless $event->{type} eq "m.room.member";
          require_json_keys( $event, qw( room_id user_id state_key content ));
@@ -74,7 +74,7 @@ test "Setting room topic reports m.room.topic to myself",
          type    => "m.room.topic",
          content => { topic => $topic },
       )->then( sub {
-         await_event_for( $user, sub {
+         await_event_for( $user, filter => sub {
             my ( $event ) = @_;
             return unless $event->{type} eq "m.room.topic";
             require_json_keys( $event, qw( room_id user_id content ));

--- a/tests/30rooms/02members-local.pl
+++ b/tests/30rooms/02members-local.pl
@@ -36,7 +36,7 @@ test "New room members see their own join event",
    do => sub {
       my ( $local_user, $room_id ) = @_;
 
-      await_event_for( $local_user, sub {
+      await_event_for( $local_user, filter => sub {
          my ( $event ) = @_;
          return unless $event->{type} eq "m.room.member";
 
@@ -87,7 +87,7 @@ test "Existing members see new members' join events",
    do => sub {
       my ( $first_user, $local_user, $room_id ) = @_;
 
-      await_event_for( $first_user, sub {
+      await_event_for( $first_user, filter => sub {
          my ( $event ) = @_;
          return unless $event->{type} eq "m.room.member";
          require_json_keys( $event, qw( type room_id user_id ));
@@ -109,7 +109,7 @@ test "Existing members see new members' presence",
    do => sub {
       my ( $first_user, $local_user ) = @_;
 
-      await_event_for( $first_user, sub {
+      await_event_for( $first_user, filter => sub {
          my ( $event ) = @_;
          return unless $event->{type} eq "m.presence";
          require_json_keys( $event, qw( type content ));

--- a/tests/30rooms/03members-remote.pl
+++ b/tests/30rooms/03members-remote.pl
@@ -65,7 +65,7 @@ test "New room members see their own join event",
    do => sub {
       my ( $user, $room_id, $room_alias ) = @_;
 
-      await_event_for( $user, sub {
+      await_event_for( $user, filter => sub {
          my ( $event ) = @_;
          return unless $event->{type} eq "m.room.member";
 
@@ -120,7 +120,7 @@ test "Existing members see new members' join events",
    do => sub {
       my ( $first_user, $user, $room_id, $room_alias ) = @_;
 
-      await_event_for( $first_user, sub {
+      await_event_for( $first_user, filter => sub {
          my ( $event ) = @_;
          return unless $event->{type} eq "m.room.member";
          require_json_keys( $event, qw( type room_id user_id ));
@@ -143,7 +143,7 @@ test "Existing members see new member's presence",
    do => sub {
       my ( $first_user, $user, $room_id, $room_alias ) = @_;
 
-      await_event_for( $first_user, sub {
+      await_event_for( $first_user, filter => sub {
          my ( $event ) = @_;
          return unless $event->{type} eq "m.presence";
          require_json_keys( $event, qw( type content ));

--- a/tests/30rooms/04messages.pl
+++ b/tests/30rooms/04messages.pl
@@ -26,7 +26,7 @@ test "Local room members see posted message events",
          Future->needs_all( map {
             my $recvuser = $_;
 
-            await_event_for( $recvuser, sub {
+            await_event_for( $recvuser, filter => sub {
                my ( $event ) = @_;
                return unless $event->{type} eq "m.room.message";
 
@@ -90,7 +90,7 @@ test "Local non-members don't see posted message events",
       my ( $nonmember, $room_id ) = @_;
 
       Future->wait_any(
-         await_event_for( $nonmember, sub {
+         await_event_for( $nonmember, filter => sub {
             my ( $event ) = @_;
             log_if_fail "Received event:", $event;
 
@@ -151,7 +151,7 @@ test "Remote room members also see posted message events",
    do => sub {
       my ( $senduser, $remote_user, $room_id ) = @_;
 
-      await_event_for( $remote_user, sub {
+      await_event_for( $remote_user, filter => sub {
          my ( $event ) = @_;
          return unless $event->{type} eq "m.room.message";
 

--- a/tests/30rooms/06invite.pl
+++ b/tests/30rooms/06invite.pl
@@ -57,7 +57,7 @@ multi_test "Can invite users to invite-only rooms",
       matrix_invite_user_to_room( $creator, $invitee, $room_id )
          ->SyTest::pass_on_done( "Sent invite" )
       ->then( sub {
-         await_event_for( $invitee, sub {
+         await_event_for( $invitee, filter => sub {
             my ( $event ) = @_;
 
             require_json_keys( $event, qw( type ));
@@ -166,7 +166,7 @@ test "Invited user can see room metadata",
       )->then( sub {
          matrix_invite_user_to_room( $creator, $invitee, $room_id );
       })->then( sub {
-         await_event_for( $invitee, sub {
+         await_event_for( $invitee, filter => sub {
             my ( $event ) = @_;
             return $event->{type} eq "m.room.member" &&
                    $event->{room_id} eq $room_id;

--- a/tests/30rooms/09eventstream.pl
+++ b/tests/30rooms/09eventstream.pl
@@ -37,7 +37,7 @@ multi_test "Check that event streams started after a client joined a room work (
          my ( $event_id ) = @_;
 
          # Wait for the message we just sent.
-         await_event_for( $alice, sub {
+         await_event_for( $alice, filter => sub {
             my ( $event ) = @_;
             return unless $event->{type} eq "m.room.message";
             return unless $event->{event_id} eq $event_id;

--- a/tests/30rooms/13anonymousaccess.pl
+++ b/tests/30rooms/13anonymousaccess.pl
@@ -83,12 +83,12 @@ sub await_event_not_presence_for
 {
    my ( $user, $room_id, $ignored_users ) = @_;
    await_event_for( $user,
+      room_id => $room_id,
       filter  => sub {
          my ( $event ) = @_;
          return not( $event->{type} eq "m.presence" and
             any { $event->{content}{user_id} eq $_->user_id } @$ignored_users );
       },
-      room_id => $room_id,
    )->on_done( sub {
       my ( $event ) = @_;
       log_if_fail "event", $event

--- a/tests/30rooms/13anonymousaccess.pl
+++ b/tests/30rooms/13anonymousaccess.pl
@@ -82,11 +82,14 @@ test "Anonymous user cannot call /events on non-world_readable room",
 sub await_event_not_presence_for
 {
    my ( $user, $room_id, $ignored_users ) = @_;
-   await_event_for( $user, sub {
-      my ( $event ) = @_;
-      return not( $event->{type} eq "m.presence" and
-         any { $event->{content}{user_id} eq $_->user_id } @$ignored_users );
-   }, $room_id)->on_done( sub {
+   await_event_for( $user,
+      filter  => sub {
+         my ( $event ) = @_;
+         return not( $event->{type} eq "m.presence" and
+            any { $event->{content}{user_id} eq $_->user_id } @$ignored_users );
+      },
+      room_id => $room_id,
+   )->on_done( sub {
       my ( $event ) = @_;
       log_if_fail "event", $event
    });
@@ -579,7 +582,7 @@ test "Anonymous users are kicked from guest_access rooms on revocation of guest_
             $membership eq "join" or die("want membership to be join but is $membership");
 
             Future->needs_all(
-               await_event_for( $local_user, sub {
+               await_event_for( $local_user, filter => sub {
                   my ( $event ) = @_;
                   return $event->{type} eq "m.room.guest_access" && $event->{content}->{guest_access} eq "forbidden";
                }),

--- a/tests/30rooms/20typing.pl
+++ b/tests/30rooms/20typing.pl
@@ -49,7 +49,7 @@ test "Typing notification sent to local room members",
          Future->needs_all( map {
             my $recvuser = $_;
 
-            await_event_for( $recvuser, sub {
+            await_event_for( $recvuser, filter => sub {
                my ( $event ) = @_;
 
                return unless $event->{type} eq "m.typing";
@@ -80,7 +80,7 @@ test "Typing notifications also sent to remote room members",
    do => sub {
       my ( $typinguser, $remote_user, $room_id ) = @_;
 
-      await_event_for( $remote_user, sub {
+      await_event_for( $remote_user, filter => sub {
          my ( $event ) = @_;
 
          return unless $event->{type} eq "m.typing";
@@ -113,7 +113,7 @@ test "Typing can be explicitly stopped",
          Future->needs_all( map {
             my $recvuser = $_;
 
-            await_event_for( $recvuser, sub {
+            await_event_for( $recvuser, filter => sub {
                my ( $event ) = @_;
 
                return unless $event->{type} eq "m.typing";
@@ -153,7 +153,7 @@ multi_test "Typing notifications timeout and can be resent",
          pass( "Sent typing notification" );
 
          # start typing
-         await_event_for( $user, sub {
+         await_event_for( $user, filter => sub {
             my ( $event ) = @_;
             return unless $event->{type} eq "m.typing";
             return unless $event->{room_id} eq $room_id;
@@ -165,7 +165,7 @@ multi_test "Typing notifications timeout and can be resent",
          });
       })->then( sub {
          # stop typing
-         await_event_for( $user, sub {
+         await_event_for( $user, filter => sub {
             my ( $event ) = @_;
             return unless $event->{type} eq "m.typing";
             return unless $event->{room_id} eq $room_id;

--- a/tests/30rooms/21receipts.pl
+++ b/tests/30rooms/21receipts.pl
@@ -142,7 +142,7 @@ test "Read receipts are sent as events",
 
          matrix_advance_room_receipt( $user, $room_id, "m.read" => $event_id )
       })->then( sub {
-         await_event_for( $user, sub {
+         await_event_for( $user, filter => sub {
             my ( $event ) = @_;
 
             $event->{type} eq "m.receipt" or return;

--- a/tests/40presence.pl
+++ b/tests/40presence.pl
@@ -30,7 +30,7 @@ test "Presence changes are reported to local room members",
          Future->needs_all( map {
             my $recvuser = $_;
 
-            await_event_for( $recvuser, sub {
+            await_event_for( $recvuser, filter => sub {
                my ( $event ) = @_;
                return unless $event->{type} eq "m.presence";
 
@@ -59,7 +59,7 @@ test "Presence changes are also reported to remote room members",
    do => sub {
       my ( $senduser, $remote_user, undef ) = @_;
 
-      await_event_for( $remote_user, sub {
+      await_event_for( $remote_user, filter => sub {
          my ( $event ) = @_;
          return unless $event->{type} eq "m.presence";
 
@@ -95,7 +95,7 @@ test "Presence changes to OFFLINE are reported to local room members",
          Future->needs_all( map {
             my $recvuser = $_;
 
-            await_event_for( $recvuser, sub {
+            await_event_for( $recvuser, filter => sub {
                my ( $event ) = @_;
                return unless $event->{type} eq "m.presence";
 
@@ -117,7 +117,7 @@ test "Presence changes to OFFLINE are reported to remote room members",
    do => sub {
       my ( $senduser, $remote_user, undef ) = @_;
 
-      await_event_for( $remote_user, sub {
+      await_event_for( $remote_user, filter => sub {
          my ( $event ) = @_;
 
          return unless $event->{type} eq "m.presence";

--- a/tests/42tags.pl
+++ b/tests/42tags.pl
@@ -224,7 +224,7 @@ test "Tags appear in the v1 /events stream",
       )->then( sub {
          ( $user, $room_id ) = @_;
 
-         await_event_for( $user, sub {
+         await_event_for( $user, filter => sub {
             my ( $event ) = @_;
             return unless $event->{type} eq "m.tag"
                and $event->{room_id} eq $room_id;

--- a/tests/60app-services/02ghost.pl
+++ b/tests/60app-services/02ghost.pl
@@ -76,7 +76,7 @@ multi_test "AS-ghosted users can use rooms via AS",
          )
       })->SyTest::pass_on_done( "User posted message via AS" )
       ->then( sub {
-         await_event_for( $creator, sub {
+         await_event_for( $creator, filter => sub {
             my ( $event ) = @_;
             return unless $event->{type} eq "m.room.message";
             return unless $event->{room_id} eq $room_id;
@@ -155,7 +155,7 @@ multi_test "AS-ghosted users can use rooms themselves",
          )
       })->SyTest::pass_on_done( "Ghost posted message themselves" )
       ->then( sub {
-         await_event_for( $creator, sub {
+         await_event_for( $creator, filter => sub {
             my ( $event ) = @_;
             return unless $event->{type} eq "m.room.message";
             return unless $event->{room_id} eq $room_id;

--- a/tests/61push/01message-pushed.pl
+++ b/tests/61push/01message-pushed.pl
@@ -41,7 +41,7 @@ multi_test "Test that a message is pushed",
          # We also wait for the push notification for it
 
          Future->needs_all(
-            await_event_for( $bob, sub {
+            await_event_for( $bob, filter => sub {
                my ( $event ) = @_;
                return unless $event->{type} eq "m.room.member" and
                   $event->{room_id} eq $room_id and

--- a/tests/90jira/SYN-115.pl
+++ b/tests/90jira/SYN-115.pl
@@ -28,7 +28,7 @@ multi_test "New federated private chats get full presence information (SYN-115)"
       })->then( sub {
 
          # Bob should receive the invite
-         await_event_for( $bob, sub {
+         await_event_for( $bob, filter => sub {
             my ( $event ) = @_;
             return unless $event->{type} eq "m.room.member" and
                           $event->{room_id} eq $room_id and

--- a/tests/90jira/SYN-205.pl
+++ b/tests/90jira/SYN-205.pl
@@ -11,7 +11,7 @@ multi_test "Rooms can be created with an initial invite list (SYN-205)",
       ->then( sub {
          my ( $room_id ) = @_;
 
-         await_event_for( $invitee, sub {
+         await_event_for( $invitee, filter => sub {
             my ( $event ) = @_;
             return unless $event->{type} eq "m.room.member" and
                           $event->{room_id} eq $room_id and

--- a/tests/90jira/SYN-328.pl
+++ b/tests/90jira/SYN-328.pl
@@ -22,7 +22,7 @@ multi_test "Typing notifications don't leak",
          Future->needs_all( map {
             my $recvuser = $_;
 
-            await_event_for( $recvuser, sub {
+            await_event_for( $recvuser, filter => sub {
                my ( $event ) = @_;
                return unless $event->{type} eq "m.typing";
                return unless $event->{room_id} eq $room_id;
@@ -36,7 +36,7 @@ multi_test "Typing notifications don't leak",
          Future->wait_any(
             delay( 2 ),
 
-            await_event_for( $nonmember, sub {
+            await_event_for( $nonmember, filter => sub {
                my ( $event ) = @_;
                return unless $event->{type} eq "m.typing";
                return unless $event->{room_id} eq $room_id;

--- a/tests/90jira/SYN-442.pl
+++ b/tests/90jira/SYN-442.pl
@@ -22,7 +22,7 @@ multi_test "Test that we can be reinvited to a room we created",
             ->SyTest::pass_on_done( "User A invited user B" )
       })->then( sub {
 
-         await_event_for( $user_2, sub {
+         await_event_for( $user_2, filter => sub {
             my ( $event ) = @_;
             return 0 unless $event->{type} eq "m.room.member";
             return 0 unless $event->{content}->{membership} eq "invite";
@@ -46,7 +46,7 @@ multi_test "Test that we can be reinvited to a room we created",
             ->SyTest::pass_on_done( "User A left the room" )
       })->then( sub {
 
-         await_event_for( $user_2, sub {
+         await_event_for( $user_2, filter => sub {
             my ( $event ) = @_;
             return 0 unless $event->{type} eq "m.room.member";
             return 0 unless $event->{content}->{membership} eq "leave";
@@ -59,7 +59,7 @@ multi_test "Test that we can be reinvited to a room we created",
             ->SyTest::pass_on_done( "User B invited user A back to the room" )
       })->then( sub {
 
-         await_event_for( $user_1, sub {
+         await_event_for( $user_1, filter => sub {
             my ( $event ) = @_;
             return 0 unless $event->{type} eq "m.room.member";
             return 0 unless $event->{content}->{membership} eq "invite";


### PR DESCRIPTION
Use await_event_for so that batching of ignored presence events doesn't
matter.

This is a little questionable. The desired semantics for await_event_for
called across different room_ids is unclear. Probably saved_events
should be a hash of room_id => array of events, but that's quite fiddly
to set up.