### PR TITLE
Reduced use of 'api_client' values from test env.

### DIFF
--- a/tests/06http-clients.pl
+++ b/tests/06http-clients.pl
@@ -1,18 +1,19 @@
 use SyTest::HTTPClient;
 
-prepare "Creating generic HTTP client",
-   provides => [qw( http_client )],
+push our @EXPORT, qw( HTTP_CLIENT );
 
-   do => sub {
+our $HTTP_CLIENT = fixture(
+   setup => sub {
       # Generic NaHTTP client, with SSL verification turned off, in case tests
       # need to speak plain HTTP(S) to an endpoint
 
-      provide http_client => my $http_client = SyTest::HTTPClient->new;
+      my $http_client = SyTest::HTTPClient->new;
 
       $loop->add( $http_client );
 
-      Future->done;
-   };
+      Future->done( $http_client );
+   },
+);
 
 prepare "Creating test Matrix HTTP clients",
    requires => [qw( synapse_client_locations )],

--- a/tests/10apidoc/01register.pl
+++ b/tests/10apidoc/01register.pl
@@ -123,8 +123,9 @@ sub local_user_fixture
       setup => sub {
          my ( $api_client ) = @_;
 
-         matrix_register_user( $api_client )
-         ->then_with_f( sub {
+         matrix_register_user( $api_client, undef,
+            with_events => $args{with_events} // 1,
+         )->then_with_f( sub {
             my $f = shift;
             return $f unless defined( my $displayname = $args{displayname} );
 

--- a/tests/10apidoc/01register.pl
+++ b/tests/10apidoc/01register.pl
@@ -157,9 +157,9 @@ sub local_user_fixture
 
 sub local_user_fixtures
 {
-   my ( $count ) = @_;
+   my ( $count, %args ) = @_;
 
-   return map { local_user_fixture() } 1 .. $count;
+   return map { local_user_fixture( %args ) } 1 .. $count;
 }
 
 push @EXPORT, qw( remote_user_fixture );

--- a/tests/10apidoc/03events-initial.pl
+++ b/tests/10apidoc/03events-initial.pl
@@ -2,12 +2,12 @@ use List::UtilsBy qw( extract_first_by );
 use Future::Utils qw( repeat );
 
 test "GET /events initially",
-   requires => [ our $SPYGLASS_USER, qw( first_api_client )],
+   requires => [ our $SPYGLASS_USER ],
 
    critical => 1,
 
    check => sub {
-      my ( $user, $http ) = @_;
+      my ( $user ) = @_;
 
       do_request_json_for( $user,
          method => "GET",

--- a/tests/30rooms/09eventstream.pl
+++ b/tests/30rooms/09eventstream.pl
@@ -1,26 +1,18 @@
 multi_test "Check that event streams started after a client joined a room work (SYT-1)",
-   requires => [qw(
-      first_api_client
-      can_create_private_room can_send_message
-   )],
+   requires => [ local_user_fixture( with_events => 0 ),
+      qw( can_create_private_room can_send_message )
+   ],
 
    do => sub {
-      my ( $http ) = @_;
+      my ( $alice ) = @_;
 
-      my $alice;
       my $room_id;
 
-      matrix_register_user( $http, undef,
-         with_events => 0
-      )->SyTest::pass_on_done( "Registered user" )
+      # Have Alice create a new private room
+      matrix_create_room( $alice,
+         visibility => "private",
+      )->SyTest::pass_on_done( "Created a room" )
       ->then( sub {
-         ( $alice ) = @_;
-
-         # Have Alice create a new private room
-         matrix_create_room( $alice,
-            visibility => "private",
-         )->SyTest::pass_on_done( "Created a room" )
-      })->then( sub {
          ( $room_id ) = @_;
          # Now that we've joined a room, flush the event stream to get
          # a stream token from before we send a message.

--- a/tests/31sync/01filter.pl
+++ b/tests/31sync/01filter.pl
@@ -54,19 +54,15 @@ sub matrix_register_user_with_filter
 
 
 test "Can create filter",
-   requires => [qw( first_api_client )],
+   requires => [ local_user_fixture( with_events => 0 ) ],
 
    provides => [qw( can_create_filter )],
 
    do => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      matrix_register_user( $http, undef, with_events => 0 )->then( sub {
-         my ( $user ) = @_;
-
-         matrix_create_filter( $user, {
-            room => { timeline => { limit => 10 } },
-         })
+      matrix_create_filter( $user, {
+         room => { timeline => { limit => 10 } },
       })->on_done( sub {
          provide can_create_filter => 1
       })
@@ -74,19 +70,16 @@ test "Can create filter",
 
 
 test "Can download filter",
-   requires => [qw ( first_api_client can_create_filter )],
+   requires => [
+      local_user_fixture( with_events => 0 ),
+      qw( can_create_filter )
+   ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my $user;
-
-      matrix_register_user( $http, undef, with_events => 0 )->then( sub {
-         ( $user ) = @_;
-
-         matrix_create_filter( $user, {
-            room => { timeline => { limit => 10 } }
-         })
+      matrix_create_filter( $user, {
+         room => { timeline => { limit => 10 } }
       })->then( sub {
          my ( $filter_id ) = @_;
 

--- a/tests/31sync/01filter.pl
+++ b/tests/31sync/01filter.pl
@@ -1,4 +1,4 @@
-push our @EXPORT, qw( matrix_create_filter matrix_register_user_with_filter );
+push our @EXPORT, qw( matrix_create_filter );
 
 =head2 matrix_create_filter
 
@@ -22,33 +22,6 @@ sub matrix_create_filter
       assert_json_keys( $body, "filter_id" );
 
       Future->done( $body->{filter_id} )
-   })
-}
-
-=head2 matrix_register_user_with_filter
-
-   my ( $user, $filter_id ) =
-      matrix_register_user_with_filter( $http, \%filter )->get;
-
-Creates a user without an event stream and creates a filter for that user.
-Returns the created C<User> object and the filter id of the new filter.
-
-=cut
-
-sub matrix_register_user_with_filter
-{
-   my ( $http, $filter ) = @_;
-
-   my $user;
-
-   matrix_register_user( $http, undef, with_events => 0 )->then( sub {
-      ( $user ) = @_;
-
-      matrix_create_filter( $user, $filter );
-   })->then( sub {
-      my ( $filter_id ) = @_;
-
-      Future->done( $user, $filter_id )
    })
 }
 

--- a/tests/31sync/02sync.pl
+++ b/tests/31sync/02sync.pl
@@ -28,17 +28,18 @@ sub matrix_sync
 
 
 test "Can sync",
-    requires => [qw( first_api_client can_create_filter )],
+    requires => [ local_user_fixture( with_events => 0 ),
+                  qw( can_create_filter )],
 
     provides => [qw( can_sync )],
 
     do => sub {
-       my ( $http ) = @_;
+       my ( $user ) = @_;
 
-       my ( $user, $filter_id );
+       my $filter_id;
 
-       matrix_register_user_with_filter( $http, {} )->then( sub {
-          ( $user, $filter_id ) = @_;
+       matrix_create_filter( $user, {} )->then( sub {
+          ( $filter_id ) = @_;
 
           matrix_sync( $user, filter => $filter_id )
        })->then( sub {

--- a/tests/31sync/03joined.pl
+++ b/tests/31sync/03joined.pl
@@ -1,15 +1,16 @@
 test "Can sync a joined room",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $filter_id, $room_id );
+      my ( $filter_id, $room_id );
 
       my $filter = { room => { timeline => { limit => 10 } } };
 
-      matrix_register_user_with_filter( $http, $filter )->then( sub {
-         ( $user, $filter ) = @_;
+      matrix_create_filter( $user, $filter )->then( sub {
+         ( $filter ) = @_;
 
          matrix_create_room( $user )
       })->then( sub {
@@ -38,17 +39,18 @@ test "Can sync a joined room",
 
 
 test "Full state sync includes joined rooms",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_sync )],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $filter_id, $room_id );
+      my ( $filter_id, $room_id );
 
       my $filter = { room => { timeline => { limit => 10 } } };
 
-      matrix_register_user_with_filter( $http, $filter )->then( sub {
-         ( $user, $filter ) = @_;
+      matrix_create_filter( $user, $filter )->then( sub {
+         ( $filter ) = @_;
 
          matrix_create_room( $user )
       })->then( sub {
@@ -76,17 +78,18 @@ test "Full state sync includes joined rooms",
 
 
 test "Newly joined room is included in an incremental sync",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_sync )],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $filter_id, $room_id, $next_batch );
+      my ( $filter_id, $room_id, $next_batch );
 
       my $filter = { room => { timeline => { limit => 10 } } };
 
-      matrix_register_user_with_filter( $http, $filter )->then( sub {
-         ( $user, $filter_id ) = @_;
+      matrix_create_filter( $user, $filter )->then( sub {
+         ( $filter_id ) = @_;
 
          matrix_sync( $user, filter => $filter_id );
       })->then( sub {
@@ -121,12 +124,13 @@ test "Newly joined room is included in an incremental sync",
 
 
 test "Newly joined room has correct timeline in incremental sync",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ ( map { local_user_fixture( with_events => 0 ) } 1 .. 2 ),
+                 qw( can_sync )],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user_a, $user_b ) = @_;
 
-      my ( $user_a, $filter_id_a, $user_b, $filter_id_b, $room_id, $next_b );
+      my ( $filter_id_a, $filter_id_b, $room_id, $next_b );
 
       my $filter = {
          room => {
@@ -136,10 +140,10 @@ test "Newly joined room has correct timeline in incremental sync",
       };
 
       Future->needs_all(
-         matrix_register_user_with_filter( $http, $filter )
-            ->on_done( sub { ( $user_a, $filter_id_a ) = @_ } ),
-         matrix_register_user_with_filter( $http, $filter )
-            ->on_done( sub { ( $user_b, $filter_id_b ) = @_ } ),
+         matrix_create_filter( $user_a, $filter )
+            ->on_done( sub { ( $filter_id_a ) = @_ } ),
+         matrix_create_filter( $user_b, $filter )
+            ->on_done( sub { ( $filter_id_b ) = @_ } ),
       )->then( sub {
          matrix_create_room( $user_a )->on_done( sub { ( $room_id ) = @_ } );
       })->then( sub {

--- a/tests/31sync/03joined.pl
+++ b/tests/31sync/03joined.pl
@@ -124,7 +124,7 @@ test "Newly joined room is included in an incremental sync",
 
 
 test "Newly joined room has correct timeline in incremental sync",
-   requires => [ ( map { local_user_fixture( with_events => 0 ) } 1 .. 2 ),
+   requires => [ local_user_fixtures( 2, with_events => 0 ),
                  qw( can_sync )],
 
    check => sub {

--- a/tests/31sync/04timeline.pl
+++ b/tests/31sync/04timeline.pl
@@ -1,15 +1,16 @@
 test "Can sync a room with a single message",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $filter_id, $room_id, $event_id_1, $event_id_2 );
+      my ( $filter_id, $room_id, $event_id_1, $event_id_2 );
 
       my $filter = { room => { timeline => { limit => 2 } } };
 
-      matrix_register_user_with_filter( $http, $filter)->then( sub {
-         ( $user , $filter_id ) = @_;
+      matrix_create_filter( $user, $filter )->then( sub {
+         ( $filter_id ) = @_;
 
          matrix_create_room( $user );
       })->then( sub {
@@ -53,12 +54,13 @@ test "Can sync a room with a single message",
 
 
 test "Can sync a room with a message with a transaction id",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $filter_id, $room_id, $event_id );
+      my ( $filter_id, $room_id, $event_id );
 
       my $filter = {
          room => {
@@ -68,8 +70,8 @@ test "Can sync a room with a message with a transaction id",
          presence => { types => [] },
       };
 
-      matrix_register_user_with_filter( $http, $filter )->then( sub {
-         ( $user, $filter_id ) = @_;
+      matrix_create_filter( $user, $filter )->then( sub {
+         ( $filter_id ) = @_;
 
          matrix_create_room( $user );
       })->then( sub {
@@ -105,12 +107,13 @@ test "Can sync a room with a message with a transaction id",
 
 
 test "A message sent after an initial sync appears in the timeline of an incremental sync.",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $filter_id, $room_id, $event_id, $next_batch );
+      my ( $filter_id, $room_id, $event_id, $next_batch );
 
       my $filter = {
          room => {
@@ -120,8 +123,8 @@ test "A message sent after an initial sync appears in the timeline of an increme
          presence => { types => [] },
       };
 
-      matrix_register_user_with_filter( $http, $filter )->then( sub {
-         ( $user, $filter_id ) = @_;
+      matrix_create_filter( $user, $filter )->then( sub {
+         ( $filter_id ) = @_;
 
          matrix_create_room( $user );
       })->then( sub {
@@ -165,12 +168,13 @@ test "A message sent after an initial sync appears in the timeline of an increme
 
 
 test "A filtered timeline reaches its limit",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $filter_id, $room_id, $event_id );
+      my ( $filter_id, $room_id, $event_id );
 
       my $filter = {
          room => {
@@ -180,8 +184,8 @@ test "A filtered timeline reaches its limit",
          presence => { types => [] },
       };
 
-      matrix_register_user_with_filter( $http, $filter )->then( sub {
-         ( $user, $filter_id ) = @_;
+      matrix_create_filter( $user, $filter )->then( sub {
+         ( $filter_id ) = @_;
 
          matrix_create_room( $user );
       })->then( sub {
@@ -225,17 +229,18 @@ test "A filtered timeline reaches its limit",
 
 
 test "Syncing a new room with a large timeline limit isn't limited",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $filter_id, $room_id, $event_id );
+      my ( $filter_id, $room_id, $event_id );
 
       my $filter = { room => { timeline => { limit => 100 } } };
 
-      matrix_register_user_with_filter( $http, $filter )->then( sub {
-         ( $user, $filter_id ) = @_;
+      matrix_create_filter( $user, $filter )->then( sub {
+         ( $filter_id ) = @_;
 
          matrix_create_room( $user );
       })->then( sub {
@@ -258,17 +263,18 @@ test "Syncing a new room with a large timeline limit isn't limited",
 
 
 test "A full_state incremental update returns only recent timeline",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $filter_id, $room_id, $next_batch );
+      my ( $filter_id, $room_id, $next_batch );
 
       my $filter = { room => { timeline => { limit => 1 } } };
 
-      matrix_register_user_with_filter( $http, $filter )->then( sub {
-         ( $user, $filter_id ) = @_;
+      matrix_create_filter( $user, $filter )->then( sub {
+         ( $filter_id ) = @_;
 
          matrix_create_room( $user );
       })->then( sub {
@@ -311,17 +317,18 @@ test "A full_state incremental update returns only recent timeline",
 
 
 test "A prev_batch token can be used in the v1 messages API",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $filter_id, $room_id, $event_id_1, $event_id_2 );
+      my ( $filter_id, $room_id, $event_id_1, $event_id_2 );
 
       my $filter = { room => { timeline => { limit => 1 } } };
 
-      matrix_register_user_with_filter( $http, $filter )->then( sub {
-         ( $user, $filter_id ) = @_;
+      matrix_create_filter( $user, $filter )->then( sub {
+         ( $filter_id ) = @_;
 
          matrix_create_room( $user );
       })->then( sub {

--- a/tests/31sync/05presence.pl
+++ b/tests/31sync/05presence.pl
@@ -63,7 +63,7 @@ test "User is offline if they set_presence=offline in their sync",
 
 
 test "User sees updates to presence from other users in the incremental sync.",
-   requires => [ ( map { local_user_fixture( with_events => 0 ) } 1 .. 2 ),
+   requires => [ local_user_fixtures( 2, with_events => 0 ),
                  qw( can_sync ) ],
 
    check => sub {

--- a/tests/31sync/06state.pl
+++ b/tests/31sync/06state.pl
@@ -449,7 +449,7 @@ test "A full_state incremental update returns all state",
 
 
 test "When user joins a room the state is included in the next sync",
-   requires => [ ( map { local_user_fixture( with_events => 0 ) } 1 .. 2 ),
+   requires => [ local_user_fixtures( 2, with_events => 0 ),
                  qw( can_sync ) ],
 
    check => sub {
@@ -574,7 +574,7 @@ test "A change to displayname should not result in a full state sync",
 
 
 test "When user joins a room the state is included in a gapped sync",
-   requires => [ ( map { local_user_fixture( with_events => 0 ) } 1 .. 2 ),
+   requires => [ local_user_fixtures( 2, with_events => 0 ),
                  qw( can_sync )],
 
    check => sub {
@@ -644,7 +644,7 @@ test "When user joins a room the state is included in a gapped sync",
 
 test "When user joins and leaves a room in the same batch, the full state is still included in the next sync",
    bug => 'SYN-514',
-   requires => [ ( map { local_user_fixture( with_events => 0 ) } 1 .. 2 ),
+   requires => [ local_user_fixtures( 2, with_events => 0 ),
                  qw( can_sync ) ],
 
    check => sub {

--- a/tests/31sync/06state.pl
+++ b/tests/31sync/06state.pl
@@ -26,12 +26,13 @@ sub wait_for_event_in_room {
 }
 
 test "State is included in the timeline in the initial sync",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $filter_id, $room_id );
+      my ( $filter_id, $room_id );
 
       my $filter = {
          room => {
@@ -42,8 +43,8 @@ test "State is included in the timeline in the initial sync",
          presence => {types => [] },
       };
 
-      matrix_register_user_with_filter( $http, $filter )->then( sub {
-         ( $user, $filter_id ) = @_;
+      matrix_create_filter( $user, $filter )->then( sub {
+         ( $filter_id ) = @_;
 
          matrix_create_room( $user );
       })->then( sub {
@@ -81,12 +82,13 @@ test "State is included in the timeline in the initial sync",
 # state that has arrived over federation counts as an 'outlier', so should
 # only appear in the state dictionary, not the timeline.
 test "State from remote users is included in the state in the initial sync",
-    requires => [remote_user_fixture(), qw( first_api_client can_sync )],
+    requires => [ local_user_fixture( with_events => 0 ), remote_user_fixture(),
+                  qw( can_sync ) ],
 
     check => sub {
-        my ( $remote_user, $http ) = @_;
+        my ( $user, $remote_user) = @_;
 
-        my ( $user, $filter_id, $room_id );
+        my ( $filter_id, $room_id );
 
         my $filter = {
             room => {
@@ -97,8 +99,8 @@ test "State from remote users is included in the state in the initial sync",
             presence => {types => [] },
         };
 
-        matrix_register_user_with_filter( $http, $filter )->then( sub {
-            ( $user, $filter_id ) = @_;
+        matrix_create_filter( $user, $filter )->then( sub {
+            ( $filter_id ) = @_;
 
             matrix_create_room( $remote_user );
         })->then( sub {
@@ -137,12 +139,13 @@ test "State from remote users is included in the state in the initial sync",
 
 
 test "Changes to state are included in an incremental sync",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $filter_id, $room_id, $next_batch );
+      my ( $filter_id, $room_id, $next_batch );
 
       my $filter = {
          room => {
@@ -153,8 +156,8 @@ test "Changes to state are included in an incremental sync",
          presence => {types => [] },
       };
 
-      matrix_register_user_with_filter( $http, $filter )->then( sub {
-         ( $user, $filter_id ) = @_;
+      matrix_create_filter( $user, $filter )->then( sub {
+         ( $filter_id ) = @_;
 
          matrix_create_room( $user );
       })->then( sub {
@@ -204,12 +207,13 @@ test "Changes to state are included in an incremental sync",
 
 
 test "Changes to state are included in an gapped incremental sync",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $filter_id, $room_id, $next_batch );
+      my ( $filter_id, $room_id, $next_batch );
 
       my $filter = {
          room => {
@@ -220,8 +224,8 @@ test "Changes to state are included in an gapped incremental sync",
          presence => {types => [] },
       };
 
-      matrix_register_user_with_filter( $http, $filter )->then( sub {
-         ( $user, $filter_id ) = @_;
+      matrix_create_filter( $user, $filter )->then( sub {
+         ( $filter_id ) = @_;
 
          matrix_create_room( $user )
       })->then( sub {
@@ -281,12 +285,13 @@ test "Changes to state are included in an gapped incremental sync",
 
 
 test "State from remote users is included in the timeline in an incremental sync",
-    requires => [remote_user_fixture(), qw( first_api_client can_sync )],
+    requires => [ local_user_fixture( with_events => 0 ), remote_user_fixture(),
+                  qw( can_sync ) ],
 
     check => sub {
-        my ( $remote_user, $http ) = @_;
+        my ( $user, $remote_user ) = @_;
 
-        my ( $user, $filter_id, $room_id, $next_batch );
+        my ( $filter_id, $room_id, $next_batch );
 
         my $filter = {
             room => {
@@ -297,8 +302,8 @@ test "State from remote users is included in the timeline in an incremental sync
             presence => {types => [] },
         };
 
-        matrix_register_user_with_filter( $http, $filter )->then( sub {
-            ( $user, $filter_id ) = @_;
+        matrix_create_filter( $user, $filter )->then( sub {
+            ( $filter_id ) = @_;
 
             matrix_create_room( $remote_user );
         })->then( sub {
@@ -344,20 +349,21 @@ test "State from remote users is included in the timeline in an incremental sync
 
 
 test "A full_state incremental update returns all state",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $filter_id, $room_id, $next_batch );
+      my ( $filter_id, $room_id, $next_batch );
 
       my $filter = { room => {
           timeline => { limit => 2 },
           state     => { types => [ "a.madeup.test.state" ] },
       } };
 
-      matrix_register_user_with_filter( $http, $filter )->then( sub {
-         ( $user, $filter_id ) = @_;
+      matrix_create_filter( $user, $filter )->then( sub {
+         ( $filter_id ) = @_;
 
          matrix_create_room( $user );
       })->then( sub {
@@ -443,12 +449,13 @@ test "A full_state incremental update returns all state",
 
 
 test "When user joins a room the state is included in the next sync",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ ( map { local_user_fixture( with_events => 0 ) } 1 .. 2 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user_a, $user_b ) = @_;
 
-      my ( $user_a, $filter_id_a, $user_b, $filter_id_b, $room_id, $next_b );
+      my ( $filter_id_a, $filter_id_b, $room_id, $next_b );
 
       my $filter = {
          room => {
@@ -460,10 +467,10 @@ test "When user joins a room the state is included in the next sync",
       };
 
       Future->needs_all(
-         matrix_register_user_with_filter( $http, $filter ),
-         matrix_register_user_with_filter( $http, $filter ),
+         matrix_create_filter( $user_a, $filter ),
+         matrix_create_filter( $user_b, $filter ),
       )->then( sub {
-         ( $user_a, $filter_id_a, $user_b, $filter_id_b ) = @_;
+         ( $filter_id_a, $filter_id_b ) = @_;
 
          matrix_create_room( $user_a );
       })->then( sub {
@@ -505,13 +512,14 @@ test "When user joins a room the state is included in the next sync",
 
 
 test "A change to displayname should not result in a full state sync",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_sync ) ],
    bug => 'SYN-515',
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $filter_id, $room_id, $next_batch );
+      my ( $filter_id, $room_id, $next_batch );
 
       my $filter = {
          room => {
@@ -522,8 +530,8 @@ test "A change to displayname should not result in a full state sync",
          presence => { types => [] },
       };
 
-      matrix_register_user_with_filter( $http, $filter )->then( sub {
-         ( $user, $filter_id ) = @_;
+      matrix_create_filter( $user, $filter )->then( sub {
+         ( $filter_id ) = @_;
 
          matrix_create_room( $user );
       })->then( sub {
@@ -566,12 +574,13 @@ test "A change to displayname should not result in a full state sync",
 
 
 test "When user joins a room the state is included in a gapped sync",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ ( map { local_user_fixture( with_events => 0 ) } 1 .. 2 ),
+                 qw( can_sync )],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user_a, $user_b ) = @_;
 
-      my ( $user_a, $filter_id_a, $user_b, $filter_id_b, $room_id, $next_b );
+      my ( $filter_id_a, $filter_id_b, $room_id, $next_b );
 
       my $filter = {
          room => {
@@ -583,10 +592,11 @@ test "When user joins a room the state is included in a gapped sync",
       };
 
       Future->needs_all(
-         matrix_register_user_with_filter( $http, $filter ),
-         matrix_register_user_with_filter( $http, $filter ),
+         matrix_create_filter( $user_a, $filter ),
+         matrix_create_filter( $user_b, $filter ),
       )->then( sub {
-         ( $user_a, $filter_id_a, $user_b, $filter_id_b ) = @_;
+         ( $filter_id_a, $filter_id_b ) = @_;
+
          matrix_create_room( $user_a )
       })->then( sub {
          ( $room_id ) = @_;
@@ -634,12 +644,13 @@ test "When user joins a room the state is included in a gapped sync",
 
 test "When user joins and leaves a room in the same batch, the full state is still included in the next sync",
    bug => 'SYN-514',
-   requires => [qw( first_api_client can_sync )],
+   requires => [ ( map { local_user_fixture( with_events => 0 ) } 1 .. 2 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user_a, $user_b ) = @_;
 
-      my ( $user_a, $filter_id_a, $user_b, $filter_id_b, $room_id, $next_b );
+      my ( $filter_id_a, $filter_id_b, $room_id, $next_b );
 
       my $filter = {
          room => {
@@ -651,10 +662,10 @@ test "When user joins and leaves a room in the same batch, the full state is sti
       };
 
       Future->needs_all(
-         matrix_register_user_with_filter( $http, $filter ),
-         matrix_register_user_with_filter( $http, $filter ),
+         matrix_create_filter( $user_a, $filter ),
+         matrix_create_filter( $user_b, $filter ),
       )->then( sub {
-         ( $user_a, $filter_id_a, $user_b, $filter_id_b ) = @_;
+         ( $filter_id_a, $filter_id_b ) = @_;
 
          matrix_create_room( $user_a );
       })->then( sub {

--- a/tests/31sync/07invited.pl
+++ b/tests/31sync/07invited.pl
@@ -1,18 +1,19 @@
 use List::Util qw( first );
 
 test "Rooms a user is invited to appear in an initial sync",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ ( map { local_user_fixture( with_events => 0 ) } 1 .. 2 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user_a, $user_b ) = @_;
 
-      my ( $user_a, $filter_id_a, $user_b, $filter_id_b, $room_id );
+      my ( $filter_id_a, $filter_id_b, $room_id );
 
       Future->needs_all(
-         matrix_register_user_with_filter( $http, {} ),
-         matrix_register_user_with_filter( $http, {} ),
+         matrix_create_filter( $user_a, {} ),
+         matrix_create_filter( $user_b, {} ),
       )->then( sub {
-         ( $user_a, $filter_id_a, $user_b, $filter_id_b ) = @_;
+         ( $filter_id_a, $filter_id_b ) = @_;
 
          matrix_create_room( $user_a );
       })->then( sub {
@@ -45,18 +46,19 @@ test "Rooms a user is invited to appear in an initial sync",
 
 
 test "Rooms a user is invited to appear in an incremental sync",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ ( map { local_user_fixture( with_events => 0 ) } 1 .. 2 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user_a, $user_b ) = @_;
 
-      my ( $user_a, $filter_id_a, $user_b, $filter_id_b, $room_id, $next_b );
+      my ( $filter_id_a, $filter_id_b, $room_id, $next_b );
 
       Future->needs_all(
-         matrix_register_user_with_filter( $http, {} ),
-         matrix_register_user_with_filter( $http, {} ),
+         matrix_create_filter( $user_a, {} ),
+         matrix_create_filter( $user_b, {} ),
       )->then( sub {
-         ( $user_a, $filter_id_a, $user_b, $filter_id_b ) = @_;
+         ( $filter_id_a, $filter_id_b ) = @_;
 
          matrix_sync( $user_b, filter => $filter_id_b );
       })->then( sub {

--- a/tests/31sync/07invited.pl
+++ b/tests/31sync/07invited.pl
@@ -1,7 +1,7 @@
 use List::Util qw( first );
 
 test "Rooms a user is invited to appear in an initial sync",
-   requires => [ ( map { local_user_fixture( with_events => 0 ) } 1 .. 2 ),
+   requires => [ local_user_fixtures( 2, with_events => 0 ),
                  qw( can_sync ) ],
 
    check => sub {
@@ -46,7 +46,7 @@ test "Rooms a user is invited to appear in an initial sync",
 
 
 test "Rooms a user is invited to appear in an incremental sync",
-   requires => [ ( map { local_user_fixture( with_events => 0 ) } 1 .. 2 ),
+   requires => [ local_user_fixtures( 2, with_events => 0 ),
                  qw( can_sync ) ],
 
    check => sub {

--- a/tests/31sync/08polling.pl
+++ b/tests/31sync/08polling.pl
@@ -1,13 +1,14 @@
 test "Sync can be polled for updates",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $filter_id, $room_id, $next );
+      my ( $filter_id, $room_id, $next );
 
-      matrix_register_user_with_filter( $http, {} )->then( sub {
-         ( $user, $filter_id ) = @_;
+      matrix_create_filter( $user, {} )->then( sub {
+         ( $filter_id ) = @_;
 
          matrix_create_room( $user );
       })->then( sub {

--- a/tests/31sync/09archived.pl
+++ b/tests/31sync/09archived.pl
@@ -155,7 +155,7 @@ test "Left rooms appear in the leave section of full state sync",
 
 
 test "Archived rooms only contain history from before the user left",
-   requires => [ ( map { local_user_fixture( with_events => 0 ) } 1 .. 2 ),
+   requires => [ local_user_fixtures( 2, with_events => 0 ),
                  qw( can_sync ) ],
 
    check => sub {

--- a/tests/31sync/09archived.pl
+++ b/tests/31sync/09archived.pl
@@ -1,13 +1,14 @@
 test "Left rooms appear in the leave section of sync",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $filter_id, $room_id );
+      my ( $filter_id, $room_id );
 
-      matrix_register_user_with_filter( $http, {} )->then( sub {
-         ( $user, $filter_id ) = @_;
+      matrix_create_filter( $user, {} )->then( sub {
+         ( $filter_id ) = @_;
 
          matrix_create_room( $user );
       })->then( sub {
@@ -28,15 +29,16 @@ test "Left rooms appear in the leave section of sync",
 
 
 test "Newly left rooms appear in the leave section of incremental sync",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $filter_id, $room_id, $next );
+      my ( $filter_id, $room_id, $next );
 
-     matrix_register_user_with_filter( $http, {} )->then( sub {
-         ( $user, $filter_id ) = @_;
+     matrix_create_filter( $user, {} )->then( sub {
+         ( $filter_id ) = @_;
 
          matrix_create_room( $user );
       })->then( sub {
@@ -63,19 +65,20 @@ test "Newly left rooms appear in the leave section of incremental sync",
 
 
 test "Newly left rooms appear in the leave section of gapped sync",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $filter_id, $room_id_1, $room_id_2, $next );
+      my ( $filter_id, $room_id_1, $room_id_2, $next );
 
       my $filter = {
          room => { timeline => { limit => 1 } },
       };
 
-      matrix_register_user_with_filter( $http, {} )->then( sub {
-         ( $user, $filter_id ) = @_;
+      matrix_create_filter( $user, {} )->then( sub {
+         ( $filter_id ) = @_;
 
          Future->needs_all(
             matrix_create_room( $user )->on_done( sub { ( $room_id_1 ) = @_; } ),
@@ -115,15 +118,16 @@ test "Newly left rooms appear in the leave section of gapped sync",
 
 
 test "Left rooms appear in the leave section of full state sync",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $filter_id, $room_id, $next );
+      my ( $filter_id, $room_id, $next );
 
-      matrix_register_user_with_filter( $http, {} )->then( sub {
-         ( $user, $filter_id ) = @_;
+      matrix_create_filter( $user, {} )->then( sub {
+         ( $filter_id ) = @_;
 
          matrix_create_room( $user );
       })->then( sub {
@@ -151,12 +155,13 @@ test "Left rooms appear in the leave section of full state sync",
 
 
 test "Archived rooms only contain history from before the user left",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ ( map { local_user_fixture( with_events => 0 ) } 1 .. 2 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user_a, $user_b ) = @_;
 
-      my ( $user_a, $filter_id_a, $user_b, $filter_id_b, $room_id, $next_b );
+      my ( $filter_id_a, $filter_id_b, $room_id, $next_b );
 
       my $filter = {
          room => {
@@ -166,10 +171,10 @@ test "Archived rooms only contain history from before the user left",
       };
 
       Future->needs_all(
-         matrix_register_user_with_filter( $http, $filter ),
-         matrix_register_user_with_filter( $http, $filter ),
+         matrix_create_filter( $user_a, $filter ),
+         matrix_create_filter( $user_b, $filter ),
       )->then( sub {
-         ( $user_a, $filter_id_a, $user_b, $filter_id_b ) = @_;
+         ( $filter_id_a, $filter_id_b ) = @_;
 
          matrix_create_room( $user_a );
       })->then( sub {

--- a/tests/31sync/10archived-ban.pl
+++ b/tests/31sync/10archived-ban.pl
@@ -1,5 +1,5 @@
 test "Banned rooms appear in the leave section of sync",
-   requires => [ ( map { local_user_fixture( with_events => 0 ) } 1 .. 2 ),
+   requires => [ local_user_fixtures( 2, with_events => 0 ),
                  qw( can_sync ) ],
 
    check => sub {
@@ -39,7 +39,7 @@ test "Banned rooms appear in the leave section of sync",
 
 
 test "Newly banned rooms appear in the leave section of incremental sync",
-   requires => [ ( map { local_user_fixture( with_events => 0 ) } 1 .. 2 ),
+   requires => [ local_user_fixtures( 2, with_events => 0 ),
                  qw( can_sync ) ],
 
    check => sub {
@@ -84,7 +84,7 @@ test "Newly banned rooms appear in the leave section of incremental sync",
 
 
 test "Newly banned rooms appear in the leave section of incremental sync",
-   requires => [ ( map { local_user_fixture( with_events => 0 ) } 1 .. 2 ),
+   requires => [ local_user_fixtures( 2, with_events => 0 ),
                  qw( can_sync ) ],
 
    check => sub {

--- a/tests/31sync/10archived-ban.pl
+++ b/tests/31sync/10archived-ban.pl
@@ -1,16 +1,17 @@
 test "Banned rooms appear in the leave section of sync",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ ( map { local_user_fixture( with_events => 0 ) } 1 .. 2 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user_a, $user_b ) = @_;
 
-      my ( $user_a, $filter_id_a, $user_b, $filter_id_b, $room_id );
+      my ( $filter_id_a, $filter_id_b, $room_id );
 
       Future->needs_all(
-         matrix_register_user_with_filter( $http, {} ),
-         matrix_register_user_with_filter( $http, {} ),
+         matrix_create_filter( $user_a, {} ),
+         matrix_create_filter( $user_b, {} ),
       )->then( sub {
-         ( $user_a, $filter_id_a, $user_b, $filter_id_b ) = @_;
+         ( $filter_id_a, $filter_id_b ) = @_;
 
          matrix_create_room( $user_a );
       })->then( sub {
@@ -38,18 +39,19 @@ test "Banned rooms appear in the leave section of sync",
 
 
 test "Newly banned rooms appear in the leave section of incremental sync",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ ( map { local_user_fixture( with_events => 0 ) } 1 .. 2 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user_a, $user_b ) = @_;
 
-      my ( $user_a, $filter_id_a, $user_b, $filter_id_b, $room_id, $next_b );
+      my ( $filter_id_a, $filter_id_b, $room_id, $next_b );
 
       Future->needs_all(
-         matrix_register_user_with_filter( $http, {} ),
-         matrix_register_user_with_filter( $http, {} ),
+         matrix_create_filter( $user_a, {} ),
+         matrix_create_filter( $user_b, {} ),
       )->then( sub {
-         ( $user_a, $filter_id_a, $user_b, $filter_id_b ) = @_;
+         ( $filter_id_a, $filter_id_b ) = @_;
 
          matrix_create_room( $user_a );
       })->then( sub {
@@ -82,18 +84,19 @@ test "Newly banned rooms appear in the leave section of incremental sync",
 
 
 test "Newly banned rooms appear in the leave section of incremental sync",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ ( map { local_user_fixture( with_events => 0 ) } 1 .. 2 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user_a, $user_b ) = @_;
 
-      my ( $user_a, $filter_id_a, $user_b, $filter_id_b, $room_id, $next_b );
+      my ( $filter_id_a, $filter_id_b, $room_id, $next_b );
 
       Future->needs_all(
-         matrix_register_user_with_filter( $http, {} ),
-         matrix_register_user_with_filter( $http, {} ),
+         matrix_create_filter( $user_a, {} ),
+         matrix_create_filter( $user_b, {} ),
       )->then( sub {
-         ( $user_a, $filter_id_a, $user_b, $filter_id_b ) = @_;
+         ( $filter_id_a, $filter_id_b ) = @_;
 
          matrix_create_room( $user_a );
       })->then( sub {

--- a/tests/31sync/11typing.pl
+++ b/tests/31sync/11typing.pl
@@ -1,10 +1,11 @@
 test "Typing events appear in initial sync",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $filter_id, $room_id );
+      my ( $filter_id, $room_id );
 
       my $filter = {
          room => {
@@ -15,8 +16,8 @@ test "Typing events appear in initial sync",
          presence => { types => [] },
       };
 
-      matrix_register_user_with_filter( $http, $filter )->then( sub {
-         ( $user, $filter_id ) = @_;
+      matrix_create_filter( $user, $filter )->then( sub {
+         ( $filter_id ) = @_;
 
          matrix_create_room( $user );
       })->then( sub {
@@ -48,12 +49,13 @@ test "Typing events appear in initial sync",
 
 
 test "Typing events appear in incremental sync",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $filter_id, $room_id, $next );
+      my ( $filter_id, $room_id, $next );
 
       my $filter = {
          room => {
@@ -64,8 +66,8 @@ test "Typing events appear in incremental sync",
          presence => { types => [] },
       };
 
-      matrix_register_user_with_filter( $http, $filter )->then( sub {
-         ( $user, $filter_id ) = @_;
+      matrix_create_filter( $user, $filter )->then( sub {
+         ( $filter_id ) = @_;
 
          matrix_create_room( $user );
       })->then( sub {
@@ -103,12 +105,12 @@ test "Typing events appear in incremental sync",
 
 
 test "Typing events appear in gapped sync",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ), qw( can_sync )],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $filter_id, $room_id, $next );
+      my ( $filter_id, $room_id, $next );
 
       my $filter = {
          room => {
@@ -119,8 +121,8 @@ test "Typing events appear in gapped sync",
          presence => { types => [] },
       };
 
-      matrix_register_user_with_filter( $http, $filter )->then( sub {
-         ( $user, $filter_id ) = @_;
+      matrix_create_filter( $user, $filter )->then( sub {
+         ( $filter_id ) = @_;
 
          matrix_create_room( $user );
       })->then( sub {

--- a/tests/31sync/12receipts.pl
+++ b/tests/31sync/12receipts.pl
@@ -1,10 +1,11 @@
 test "Read receipts appear in initial v2 /sync",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $filter_id, $room_id, $event_id );
+      my ( $filter_id, $room_id, $event_id );
 
       my $filter = {
          presence => { types => [] },
@@ -15,8 +16,8 @@ test "Read receipts appear in initial v2 /sync",
          },
       };
 
-      matrix_register_user_with_filter( $http, $filter )->then( sub {
-         ( $user, $filter_id ) = @_;
+      matrix_create_filter( $user, $filter )->then( sub {
+         ( $filter_id ) = @_;
 
          matrix_create_room( $user );
       })->then( sub {
@@ -52,12 +53,13 @@ test "Read receipts appear in initial v2 /sync",
 
 
 test "New read receipts appear in incremental v2 /sync",
-   requires => [qw( first_api_client can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_sync ) ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $filter_id, $room_id, $event_id, $next_batch );
+      my ( $filter_id, $room_id, $event_id, $next_batch );
 
       my $filter = {
          presence => { types => [] },
@@ -68,8 +70,8 @@ test "New read receipts appear in incremental v2 /sync",
          },
       };
 
-      matrix_register_user_with_filter( $http, $filter )->then( sub {
-         ( $user, $filter_id ) = @_;
+      matrix_create_filter( $user, $filter )->then( sub {
+         ( $filter_id ) = @_;
 
          matrix_create_room( $user );
       })->then( sub {

--- a/tests/42tags.pl
+++ b/tests/42tags.pl
@@ -66,21 +66,15 @@ sub matrix_list_tags
 
 
 test "Can add tag",
-   requires => [qw( first_api_client )],
+   requires => [ local_user_fixture( with_events => 0 ) ],
 
    provides => [qw( can_add_tag )],
 
    do => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $room_id );
-
-      matrix_register_user( $http, undef, with_events => 0 )->then( sub {
-         ( $user ) = @_;
-
-         matrix_create_room( $user );
-      })->then( sub {
-         ( $room_id ) = @_;
+      matrix_create_room( $user )->then( sub {
+         my ( $room_id ) = @_;
 
          matrix_add_tag( $user, $room_id, "test_tag", {} );
       })->on_done( sub {
@@ -90,21 +84,15 @@ test "Can add tag",
 
 
 test "Can remove tag",
-   requires => [qw( first_api_client )],
+   requires => [ local_user_fixture( with_events => 0 ) ],
 
    provides => [qw( can_remove_tag )],
 
    do => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $room_id );
-
-      matrix_register_user( $http, undef, with_events => 0 )->then( sub {
-         ( $user ) = @_;
-
-         matrix_create_room( $user );
-      })->then( sub {
-         ( $room_id ) = @_;
+      matrix_create_room( $user )->then( sub {
+         my ( $room_id ) = @_;
 
          matrix_remove_tag( $user, $room_id, "test_tag" );
       })->on_done( sub {
@@ -114,18 +102,15 @@ test "Can remove tag",
 
 
 test "Can list tags for a room",
-   requires => [qw( first_api_client can_add_tag can_remove_tag )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_add_tag can_remove_tag )],
 
    do => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $room_id );
+      my $room_id;
 
-      matrix_register_user( $http, undef, with_events => 0 )->then( sub {
-         ( $user ) = @_;
-
-         matrix_create_room( $user );
-      })->then( sub {
+      matrix_create_room( $user )->then( sub {
          ( $room_id ) = @_;
 
          matrix_add_tag( $user, $room_id, "test_tag", {} );

--- a/tests/42tags.pl
+++ b/tests/42tags.pl
@@ -299,17 +299,18 @@ test "Tags appear in the v1 room initial sync",
 
 
 test "Tags appear in an initial v2 /sync",
-   requires => [qw( first_api_client can_add_tag can_remove_tag can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_add_tag can_remove_tag can_sync ) ],
 
    do => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $room_id, $filter_id );
+      my ( $room_id, $filter_id );
 
       my $filter = {};
 
-      matrix_register_user_with_filter( $http, $filter )->then( sub {
-         ( $user, $filter_id ) = @_;
+      matrix_create_filter( $user, $filter )->then( sub {
+         ( $filter_id ) = @_;
 
          matrix_create_room( $user );
       })->then( sub {
@@ -332,17 +333,18 @@ test "Tags appear in an initial v2 /sync",
 
 
 test "Newly updated tags appear in an incremental v2 /sync",
-   requires => [qw( first_api_client can_add_tag can_remove_tag can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_add_tag can_remove_tag can_sync ) ],
 
    do => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $room_id, $filter_id, $next_batch );
+      my ( $room_id, $filter_id, $next_batch );
 
       my $filter = {};
 
-      matrix_register_user_with_filter( $http, $filter )->then( sub {
-         ( $user, $filter_id ) = @_;
+      matrix_create_filter( $user, $filter )->then( sub {
+         ( $filter_id ) = @_;
 
          matrix_create_room( $user );
       })->then( sub {
@@ -370,17 +372,18 @@ test "Newly updated tags appear in an incremental v2 /sync",
    };
 
 test "Deleted tags appear in an incremental v2 /sync",
-   requires => [qw( first_api_client can_add_tag can_remove_tag can_sync )],
+   requires => [ local_user_fixture( with_events => 0 ),
+                 qw( can_add_tag can_remove_tag can_sync ) ],
 
    do => sub {
-      my ( $http ) = @_;
+      my ( $user ) = @_;
 
-      my ( $user, $room_id, $filter_id, $next_batch );
+      my ( $room_id, $filter_id, $next_batch );
 
       my $filter = {};
 
-      matrix_register_user_with_filter( $http, $filter )->then( sub {
-         ( $user, $filter_id ) = @_;
+      matrix_create_filter( $user, $filter )->then( sub {
+         ( $filter_id ) = @_;
 
          matrix_create_room( $user );
       })->then( sub {

--- a/tests/50federation/00prepare.pl
+++ b/tests/50federation/00prepare.pl
@@ -73,7 +73,7 @@ our $OUTBOUND_CLIENT = fixture(
 # correctly. If this test fails, it *ALWAYS* indicates a failure of SyTest
 # itself and not of the homeserver being tested.
 test "Checking local federation server",
-   requires => [ $INBOUND_SERVER, qw( http_client )],
+   requires => [ $INBOUND_SERVER, our $HTTP_CLIENT ],
 
    check => sub {
       my ( $inbound_server, $client ) = @_;

--- a/tests/50federation/01keys.pl
+++ b/tests/50federation/01keys.pl
@@ -10,7 +10,7 @@ our $INBOUND_SERVER;
 our $OUTBOUND_CLIENT;
 
 test "Federation key API allows unsigned requests for keys",
-   requires => [qw( first_home_server http_client )],
+   requires => [qw( first_home_server ), our $HTTP_CLIENT ],
 
    check => sub {
       my ( $first_home_server, $client ) = @_;

--- a/tests/61push/01message-pushed.pl
+++ b/tests/61push/01message-pushed.pl
@@ -1,37 +1,26 @@
 multi_test "Test that a message is pushed",
-   requires => [qw(
-      api_clients test_http_server_uri_base
-
-      can_create_private_room
-   )],
-
-   do => sub {
-      my ( $clients, $test_http_server_uri_base ) = @_;
-
-      my $http = $clients->[0];
-
-      my $alice;
-      my $bob;
-      my $room_id;
-
+   requires => [
       # We use the version of register new user that doesn't start the event
       # stream for Alice. Starting an event stream will make presence
       # consider Alice to be online. If presence considers alice to be online
       # then Alice might stop receiving push messages.
       # We need to register two users because you are never pushed for
       # messages that you send yourself.
-      Future->needs_all(
-         matrix_register_user( $http, undef, with_events => 0 ),
-         matrix_register_user( $http, undef, with_events => 0 ),
-      )->SyTest::pass_on_done( "Registered users" )
-      ->then( sub {
-         ( $alice, $bob ) = @_;
+      local_user_fixtures( 2, with_events => 0 ),
+      qw( test_http_server_uri_base
 
-         # Have Alice create a new private room
-         matrix_create_room( $alice,
-            visibility => "private",
-         )
-      })->then( sub {
+      can_create_private_room
+   )],
+
+   do => sub {
+      my ( $alice, $bob, $test_http_server_uri_base ) = @_;
+
+      my $room_id;
+
+      # Have Alice create a new private room
+      matrix_create_room( $alice,
+         visibility => "private",
+      )->then( sub {
          ( $room_id ) = @_;
          # Flush Bob's event stream so that we get a token from before
          # Alice sending the invite request.

--- a/tests/90jira/SYN-516.pl
+++ b/tests/90jira/SYN-516.pl
@@ -1,10 +1,10 @@
 multi_test "Multiple calls to /sync should not cause 500 errors",
-    requires => [qw(first_api_client can_sync can_send_message 
-                    can_post_room_receipts)],
+    requires => [ local_user_fixture( with_events => 0 ),
+                  qw( can_sync can_send_message can_post_room_receipts )],
     check => sub {
-        my ( $http ) = @_;
+        my ( $user ) = @_;
 
-        my ( $user, $filter_id, $room_id, $message_event_id );
+        my ( $filter_id, $room_id, $message_event_id );
 
         my $filter = {
            room => {
@@ -15,8 +15,8 @@ multi_test "Multiple calls to /sync should not cause 500 errors",
            presence => { types => [] },
         };
 
-        matrix_register_user_with_filter( $http, $filter )->then( sub {
-            ( $user, $filter_id ) = @_;
+        matrix_create_filter( $user, $filter )->then( sub {
+            ( $filter_id ) = @_;
 
             matrix_create_room( $user )
                 ->SyTest::pass_on_done( "User A created a room" );


### PR DESCRIPTION
Further advancement towards using fixtures for all inter-test value passing, which improves the ability to run just one file at a time.