### PR TITLE
Share all remaining inter-test information using fixtures instead of test env.

### DIFF
--- a/lib/SyTest/HTTPClient.pm
+++ b/lib/SyTest/HTTPClient.pm
@@ -28,11 +28,17 @@ sub configure
    my $self = shift;
    my %params = @_;
 
-   foreach (qw( uri_base restrict_methods )) {
+   foreach (qw( uri_base restrict_methods server_name )) {
       $self->{$_} = delete $params{$_} if exists $params{$_};
    }
 
    $self->SUPER::configure( %params );
+}
+
+sub server_name
+{
+   my $self = shift;
+   return $self->{server_name};
 }
 
 sub full_uri_for

--- a/tests/05synapse.pl
+++ b/tests/05synapse.pl
@@ -153,3 +153,15 @@ prepare "Starting synapse",
          provide first_home_server => $info[0]->server_name;
       });
    };
+
+push our @EXPORT, qw( HOMESERVER_INFO );
+
+# TODO: this should be an array
+our $HOMESERVER_INFO = fixture(
+   requires => [qw( homeserver_info )],
+
+   setup => sub {
+      my ( $info ) = @_;
+      Future->done( $info );
+   },
+);

--- a/tests/05synapse.pl
+++ b/tests/05synapse.pl
@@ -38,7 +38,7 @@ prepare "Starting synapse",
    requires => [qw( synapse_ports synapse_args test_http_server_uri_base want_tls )],
 
    provides => [qw(
-      homeserver_info as_credentials hs2as_token
+      homeserver_info first_home_server as_credentials hs2as_token
    )],
 
    do => sub {
@@ -126,5 +126,8 @@ prepare "Starting synapse",
       } 0 .. $#$ports )
       ->on_done( sub {
          provide homeserver_info => \@info;
+
+         # Legacy
+         provide first_home_server => $info[0]->server_name;
       });
    };

--- a/tests/05synapse.pl
+++ b/tests/05synapse.pl
@@ -57,15 +57,13 @@ prepare "Generating AS credentials",
 
 struct HomeserverInfo => [qw( server_name client_location )];
 
-prepare "Starting synapse",
+push our @EXPORT, qw( HOMESERVER_INFO );
+
+our $HOMESERVER_INFO = fixture(
    requires => [qw( synapse_ports synapse_args test_http_server_uri_base want_tls
                     as_user_info )],
 
-   provides => [qw(
-      homeserver_info first_home_server
-   )],
-
-   do => sub {
+   setup => sub {
       my ( $ports, $args, $test_http_server_uri_base, $want_tls,
            $as_user_info ) = @_;
 
@@ -146,22 +144,8 @@ prepare "Starting synapse",
                ->then_fail( "Synapse server on port $secure_port failed to start" ),
          );
       } 0 .. $#$ports )
-      ->on_done( sub {
-         provide homeserver_info => \@info;
-
-         # Legacy
-         provide first_home_server => $info[0]->server_name;
+      ->then( sub {
+         Future->done( \@info );
       });
-   };
-
-push our @EXPORT, qw( HOMESERVER_INFO );
-
-# TODO: this should be an array
-our $HOMESERVER_INFO = fixture(
-   requires => [qw( homeserver_info )],
-
-   setup => sub {
-      my ( $info ) = @_;
-      Future->done( $info );
    },
 );

--- a/tests/06http-clients.pl
+++ b/tests/06http-clients.pl
@@ -18,13 +18,13 @@ our $HTTP_CLIENT = fixture(
 # TODO: This ought to be an array, one per homeserver; though that's hard to
 #   arrange currently
 our $API_CLIENTS = fixture(
-   requires => [qw( synapse_client_locations )],
+   requires => [qw( homeserver_info )],
 
    setup => sub {
-      my ( $locations ) = @_;
+      my ( $info ) = @_;
 
       my @clients = map {
-         my $location = $_;
+         my $location = $_->client_location;
 
          my $client = SyTest::HTTPClient->new(
             max_connections_per_host => 3,
@@ -33,7 +33,7 @@ our $API_CLIENTS = fixture(
          $loop->add( $client );
 
          $client;
-      } @$locations;
+      } @$info;
 
       Future->done( \@clients );
    },

--- a/tests/06http-clients.pl
+++ b/tests/06http-clients.pl
@@ -31,6 +31,7 @@ our $API_CLIENTS = fixture(
          my $client = SyTest::HTTPClient->new(
             max_connections_per_host => 3,
             uri_base => "$location/_matrix/client",
+            server_name => $_->server_name,
          );
          $loop->add( $client );
 

--- a/tests/06http-clients.pl
+++ b/tests/06http-clients.pl
@@ -1,5 +1,7 @@
 use SyTest::HTTPClient;
 
+our $HOMESERVER_INFO;
+
 push our @EXPORT, qw( HTTP_CLIENT API_CLIENTS );
 
 our $HTTP_CLIENT = fixture(
@@ -18,7 +20,7 @@ our $HTTP_CLIENT = fixture(
 # TODO: This ought to be an array, one per homeserver; though that's hard to
 #   arrange currently
 our $API_CLIENTS = fixture(
-   requires => [qw( homeserver_info )],
+   requires => [ $HOMESERVER_INFO ],
 
    setup => sub {
       my ( $info ) = @_;

--- a/tests/10apidoc/02login.pl
+++ b/tests/10apidoc/02login.pl
@@ -70,13 +70,13 @@ test "GET /login yields a set of flows",
    };
 
 test "POST /login can log in as a user",
-   requires => [ $main::API_CLIENTS, $registered_user_fixture,
+   requires => [ $main::API_CLIENTS, $registered_user_fixture, qw( first_home_server ),
                  qw( can_login_password_flow )],
 
-   provides => [qw( can_login first_home_server )],
+   provides => [qw( can_login )],
 
    do => sub {
-      my ( $clients, $user_id ) = @_;
+      my ( $clients, $user_id, $home_server ) = @_;
       my $http = $clients->[0];
 
       $http->do_request_json(
@@ -93,9 +93,10 @@ test "POST /login can log in as a user",
 
          assert_json_keys( $body, qw( access_token home_server ));
 
-         provide can_login => 1;
+         assert_eq( $body->{home_server}, $home_server,
+            'Response home_server' );
 
-         provide first_home_server => $body->{home_server};
+         provide can_login => 1;
 
          Future->done(1);
       });

--- a/tests/10apidoc/02login.pl
+++ b/tests/10apidoc/02login.pl
@@ -70,13 +70,13 @@ test "GET /login yields a set of flows",
    };
 
 test "POST /login can log in as a user",
-   requires => [ $main::API_CLIENTS, $registered_user_fixture, qw( first_home_server ),
+   requires => [ $main::API_CLIENTS, $registered_user_fixture,
                  qw( can_login_password_flow )],
 
    provides => [qw( can_login )],
 
    do => sub {
-      my ( $clients, $user_id, $home_server ) = @_;
+      my ( $clients, $user_id ) = @_;
       my $http = $clients->[0];
 
       $http->do_request_json(
@@ -93,7 +93,7 @@ test "POST /login can log in as a user",
 
          assert_json_keys( $body, qw( access_token home_server ));
 
-         assert_eq( $body->{home_server}, $home_server,
+         assert_eq( $body->{home_server}, $http->server_name,
             'Response home_server' );
 
          provide can_login => 1;

--- a/tests/10apidoc/32room-alias.pl
+++ b/tests/10apidoc/32room-alias.pl
@@ -13,13 +13,14 @@ my $room_fixture = fixture(
 );
 
 test "PUT /directory/room/:room_alias creates alias",
-   requires => [qw( first_home_server ), $user_fixture, $room_fixture ],
+   requires => [ $user_fixture, $room_fixture ],
 
    provides => [qw( can_create_room_alias can_lookup_room_alias )],
 
    do => sub {
-      my ( $first_home_server, $user, $room_id ) = @_;
-      my $room_alias = "${alias_localpart}:$first_home_server";
+      my ( $user, $room_id ) = @_;
+      my $server_name = $user->http->server_name;
+      my $room_alias = "${alias_localpart}:$server_name";
 
       do_request_json_for( $user,
          method => "PUT",
@@ -34,8 +35,9 @@ test "PUT /directory/room/:room_alias creates alias",
    },
 
    check => sub {
-      my ( $first_home_server, $user, $room_id ) = @_;
-      my $room_alias = "${alias_localpart}:$first_home_server";
+      my ( $user, $room_id ) = @_;
+      my $server_name = $user->http->server_name;
+      my $room_alias = "${alias_localpart}:$server_name";
 
       do_request_json_for( $user,
          method => "GET",

--- a/tests/30rooms/05aliases.pl
+++ b/tests/30rooms/05aliases.pl
@@ -12,14 +12,15 @@ my $room_fixture = room_fixture(
 );
 
 test "Room aliases can contain Unicode",
-   requires => [qw( first_home_server ), $creator_fixture, $room_fixture,
-                qw( can_create_room_alias )],
+   requires => [ $creator_fixture, $room_fixture,
+                 qw( can_create_room_alias )],
 
    provides => [qw( can_create_room_alias_unicode )],
 
    do => sub {
-      my ( $first_home_server, $user, $room_id ) = @_;
-      $room_alias = "${alias_localpart}:$first_home_server";
+      my ( $user, $room_id ) = @_;
+      my $server_name = $user->http->server_name;
+      $room_alias = "${alias_localpart}:$server_name";
 
       do_request_json_for( $user,
          method => "PUT",
@@ -30,8 +31,9 @@ test "Room aliases can contain Unicode",
    },
 
    check => sub {
-      my ( $first_home_server, $user, $room_id ) = @_;
-      $room_alias = "${alias_localpart}:$first_home_server";
+      my ( $user, $room_id ) = @_;
+      my $server_name = $user->http->server_name;
+      $room_alias = "${alias_localpart}:$server_name";
 
       do_request_json_for( $user,
          method => "GET",

--- a/tests/30rooms/12thirdpartyinvite.pl
+++ b/tests/30rooms/12thirdpartyinvite.pl
@@ -54,23 +54,25 @@ test "Can invite existing 3pid",
    };
 
 test "Can invite unbound 3pid",
-   requires => [ local_user_fixtures( 2 ), qw( synapse_client_locations ),
+   requires => [ local_user_fixtures( 2 ), qw( homeserver_info ),
                     id_server_fixture() ],
 
    do => sub {
-      my ( $inviter, $invitee, $locations, $id_server ) = @_;
+      my ( $inviter, $invitee, $info, $id_server ) = @_;
+      my $hs_uribase = $info->[0]->client_location;
 
-      can_invite_unbound_3pid( $inviter, $invitee, $locations->[0], $id_server );
+      can_invite_unbound_3pid( $inviter, $invitee, $hs_uribase, $id_server );
    };
 
 test "Can invite unbound 3pid over federation",
-   requires => [ local_user_fixture(), remote_user_fixture(), qw( synapse_client_locations ),
+   requires => [ local_user_fixture(), remote_user_fixture(), qw( homeserver_info ),
                     id_server_fixture() ],
 
    do => sub {
-      my ( $inviter, $invitee, $locations, $id_server ) = @_;
+      my ( $inviter, $invitee, $info, $id_server ) = @_;
+      my $hs_uribase = $info->[1]->client_location;
 
-      can_invite_unbound_3pid( $inviter, $invitee, $locations->[1], $id_server );
+      can_invite_unbound_3pid( $inviter, $invitee, $hs_uribase, $id_server );
    };
 
 sub can_invite_unbound_3pid
@@ -97,13 +99,12 @@ sub can_invite_unbound_3pid
 }
 
 test "Can accept unbound 3pid invite after inviter leaves",
-   requires => [ local_user_fixtures( 3 ), qw( synapse_client_locations ),
+   requires => [ local_user_fixtures( 3 ), qw( homeserver_info ),
                     id_server_fixture() ],
 
    do => sub {
-      my ( $inviter, $other_member, $invitee, $locations, $id_server ) = @_;
-
-      my $hs_uribase = $locations->[0];
+      my ( $inviter, $other_member, $invitee, $info, $id_server ) = @_;
+      my $hs_uribase = $info->[0]->client_location;
 
       my $room_id;
 
@@ -131,12 +132,12 @@ test "Can accept unbound 3pid invite after inviter leaves",
    };
 
 test "3pid invite join with wrong but valid signature are rejected",
-   requires => [ local_user_fixtures( 2 ), qw( synapse_client_locations ),
+   requires => [ local_user_fixtures( 2 ), qw( homeserver_info ),
                     id_server_fixture() ],
 
    do => sub {
-      my ( $inviter, $invitee, $locations, $id_server ) = @_;
-      my $hs_uribase = $locations->[0];
+      my ( $inviter, $invitee, $info, $id_server ) = @_;
+      my $hs_uribase = $info->[0]->client_location;
 
       invite_should_fail( $inviter, $invitee, $hs_uribase, $id_server, sub {
          $id_server->rotate_keys;
@@ -145,12 +146,12 @@ test "3pid invite join with wrong but valid signature are rejected",
    };
 
 test "3pid invite join valid signature but revoked keys are rejected",
-   requires => [ local_user_fixtures( 2 ), qw( synapse_client_locations ),
+   requires => [ local_user_fixtures( 2 ), qw( homeserver_info ),
                     id_server_fixture() ],
 
    do => sub {
-      my ( $inviter, $invitee, $locations, $id_server ) = @_;
-      my $hs_uribase = $locations->[0];
+      my ( $inviter, $invitee, $info, $id_server ) = @_;
+      my $hs_uribase = $info->[0]->client_location;
 
       invite_should_fail( $inviter, $invitee, $hs_uribase, $id_server, sub {
          $id_server->bind_identity( $hs_uribase, "email", $invitee_email, $invitee,
@@ -159,12 +160,12 @@ test "3pid invite join valid signature but revoked keys are rejected",
    };
 
 test "3pid invite join valid signature but unreachable ID server are rejected",
-   requires => [ local_user_fixtures( 2 ), qw( synapse_client_locations ),
+   requires => [ local_user_fixtures( 2 ), qw( homeserver_info ),
                     id_server_fixture() ],
 
    do => sub {
-      my ( $inviter, $invitee, $locations, $id_server ) = @_;
-      my $hs_uribase = $locations->[0];
+      my ( $inviter, $invitee, $info, $id_server ) = @_;
+      my $hs_uribase = $info->[0]->client_location;
 
       invite_should_fail( $inviter, $invitee, $hs_uribase, $id_server, sub {
          $id_server->bind_identity( $hs_uribase, "email", $invitee_email, $invitee, sub {

--- a/tests/30rooms/12thirdpartyinvite.pl
+++ b/tests/30rooms/12thirdpartyinvite.pl
@@ -6,6 +6,8 @@ use SyTest::Identity::Server;
 
 use IO::Async::Listener 0.69;  # for ->configure( handle => undef )
 
+our $HOMESERVER_INFO;
+
 my $crypto_sign = Crypt::NaCl::Sodium->sign;
 
 my $DIR = dirname( __FILE__ );
@@ -54,8 +56,8 @@ test "Can invite existing 3pid",
    };
 
 test "Can invite unbound 3pid",
-   requires => [ local_user_fixtures( 2 ), qw( homeserver_info ),
-                    id_server_fixture() ],
+   requires => [ local_user_fixtures( 2 ), $HOMESERVER_INFO,
+                 id_server_fixture() ],
 
    do => sub {
       my ( $inviter, $invitee, $info, $id_server ) = @_;
@@ -65,7 +67,7 @@ test "Can invite unbound 3pid",
    };
 
 test "Can invite unbound 3pid over federation",
-   requires => [ local_user_fixture(), remote_user_fixture(), qw( homeserver_info ),
+   requires => [ local_user_fixture(), remote_user_fixture(), $HOMESERVER_INFO,
                     id_server_fixture() ],
 
    do => sub {
@@ -99,7 +101,7 @@ sub can_invite_unbound_3pid
 }
 
 test "Can accept unbound 3pid invite after inviter leaves",
-   requires => [ local_user_fixtures( 3 ), qw( homeserver_info ),
+   requires => [ local_user_fixtures( 3 ), $HOMESERVER_INFO,
                     id_server_fixture() ],
 
    do => sub {
@@ -132,7 +134,7 @@ test "Can accept unbound 3pid invite after inviter leaves",
    };
 
 test "3pid invite join with wrong but valid signature are rejected",
-   requires => [ local_user_fixtures( 2 ), qw( homeserver_info ),
+   requires => [ local_user_fixtures( 2 ), $HOMESERVER_INFO,
                     id_server_fixture() ],
 
    do => sub {
@@ -146,7 +148,7 @@ test "3pid invite join with wrong but valid signature are rejected",
    };
 
 test "3pid invite join valid signature but revoked keys are rejected",
-   requires => [ local_user_fixtures( 2 ), qw( homeserver_info ),
+   requires => [ local_user_fixtures( 2 ), $HOMESERVER_INFO,
                     id_server_fixture() ],
 
    do => sub {
@@ -160,7 +162,7 @@ test "3pid invite join valid signature but revoked keys are rejected",
    };
 
 test "3pid invite join valid signature but unreachable ID server are rejected",
-   requires => [ local_user_fixtures( 2 ), qw( homeserver_info ),
+   requires => [ local_user_fixtures( 2 ), $HOMESERVER_INFO,
                     id_server_fixture() ],
 
    do => sub {

--- a/tests/50federation/01keys.pl
+++ b/tests/50federation/01keys.pl
@@ -7,10 +7,11 @@ use Protocol::Matrix qw( encode_json_for_signing );
 my $crypto_sign = Crypt::NaCl::Sodium->sign;
 
 test "Federation key API allows unsigned requests for keys",
-   requires => [qw( first_home_server ), $main::HTTP_CLIENT ],
+   requires => [ $main::HOMESERVER_INFO, $main::HTTP_CLIENT ],
 
    check => sub {
-      my ( $first_home_server, $client ) = @_;
+      my ( $info, $client ) = @_;
+      my $first_home_server = $info->[0]->server_name;
 
       # Key API specifically does not require a signed request to ask for the
       # server's own key
@@ -77,10 +78,11 @@ test "Federation key API allows unsigned requests for keys",
    };
 
 test "Federation key API can act as a notary server",
-   requires => [qw( first_home_server ), $main::INBOUND_SERVER, $main::OUTBOUND_CLIENT ],
+   requires => [ $main::HOMESERVER_INFO, $main::INBOUND_SERVER, $main::OUTBOUND_CLIENT ],
 
    check => sub {
-      my ( $first_home_server, $inbound_server, $client ) = @_;
+      my ( $info, $inbound_server, $client ) = @_;
+      my $first_home_server = $info->[0]->server_name;
 
       my $key_id = $inbound_server->key_id;
       my $local_server_name = $inbound_server->server_name;

--- a/tests/50federation/10query-profile.pl
+++ b/tests/50federation/10query-profile.pl
@@ -36,11 +36,11 @@ test "Outbound federation can query profile data",
 my $dname = "Displayname Set For Federation Test";
 
 test "Inbound federation can query profile data",
-   requires => [ $main::OUTBOUND_CLIENT, qw( first_home_server ), local_user_fixture(),
+   requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO, local_user_fixture(),
                  qw( can_set_displayname )],
 
    do => sub {
-      my ( $outbound_client, $first_home_server, $user ) = @_;
+      my ( $outbound_client, $info, $user ) = @_;
 
       do_request_json_for( $user,
          method => "PUT",
@@ -52,7 +52,7 @@ test "Inbound federation can query profile data",
       )->then( sub {
          $outbound_client->do_request_json(
             method   => "GET",
-            hostname => $first_home_server,
+            hostname => $info->[0]->server_name,
             uri      => "/query/profile",
 
             params => {

--- a/tests/50federation/11query-directory.pl
+++ b/tests/50federation/11query-directory.pl
@@ -44,11 +44,12 @@ test "Inbound federation can query room alias directory",
    # TODO(paul): technically this doesn't need local_user_fixture(), if we had
    #   some user we could assert can perform media/directory/etc... operations
    #   but doesn't mutate any of its own state, or join rooms, etc...
-   requires => [ $main::OUTBOUND_CLIENT, qw( first_home_server ), local_user_fixture(),
+   requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO, local_user_fixture(),
                  qw( can_create_room_alias )],
 
    do => sub {
-      my ( $outbound_client, $first_home_server, $user ) = @_;
+      my ( $outbound_client, $info, $user ) = @_;
+      my $first_home_server = $info->[0]->server_name;
 
       my $room_id;
       my $room_alias = "#50federation-11query-directory:$first_home_server";

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -129,11 +129,12 @@ test "Outbound federation can send room-join requests",
    };
 
 test "Inbound federation can receive room-join requests",
-   requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, qw( first_home_server ),
+   requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO,
                  room_fixture( requires_users => [ local_user_fixture() ] ) ],
 
    do => sub {
-      my ( $outbound_client, $inbound_server, $first_home_server, $room_id ) = @_;
+      my ( $outbound_client, $inbound_server, $info, $room_id ) = @_;
+      my $first_home_server = $info->[0]->server_name;
 
       my $local_server_name = $outbound_client->server_name;
 

--- a/tests/60app-services/00prepare.pl
+++ b/tests/60app-services/00prepare.pl
@@ -3,7 +3,7 @@ use Future::Utils qw( repeat );
 push our @EXPORT, qw( AS_USER await_as_event );
 
 our $AS_USER = fixture(
-   requires => [ $main::API_CLIENTS, qw( as_user_info )],
+   requires => [ $main::API_CLIENTS, $main::AS_USER_INFO ],
 
    setup => sub {
       my ( $clients, $as_user_info ) = @_;

--- a/tests/60app-services/00prepare.pl
+++ b/tests/60app-services/00prepare.pl
@@ -3,14 +3,14 @@ use Future::Utils qw( repeat );
 push our @EXPORT, qw( AS_USER await_as_event );
 
 our $AS_USER = fixture(
-   requires => [ $main::API_CLIENTS, qw( as_credentials )],
+   requires => [ $main::API_CLIENTS, qw( as_user_info )],
 
    setup => sub {
-      my ( $clients, $as_credentials ) = @_;
+      my ( $clients, $as_user_info ) = @_;
       my $http = $clients->[0];
-      my ( $user_id, $token ) = @$as_credentials;
 
-      Future->done( User( $http, $user_id, $token, undef, undef, [], undef ) );
+      Future->done( User( $http, $as_user_info->user_id, $as_user_info->as2hs_token,
+            undef, undef, [], undef ) );
    },
 );
 

--- a/tests/60app-services/01as-create.pl
+++ b/tests/60app-services/01as-create.pl
@@ -58,12 +58,13 @@ test "Regular users cannot register within the AS namespace",
    };
 
 test "AS can make room aliases",
-   requires => [ $main::AS_USER, qw( as_user_info first_home_server ), $room_fixture,
+   requires => [ $main::AS_USER, qw( as_user_info ), $room_fixture,
                 qw( can_create_room_alias )],
 
    do => sub {
-      my ( $as_user, $as_user_info, $first_home_server, $room_id ) = @_;
-      my $room_alias = "#astest-01create-1:$first_home_server";
+      my ( $as_user, $as_user_info, $room_id ) = @_;
+      my $server_name = $as_user->http->server_name;
+      my $room_alias = "#astest-01create-1:$server_name";
 
       Future->needs_all(
          await_as_event( "m.room.aliases" )->then( sub {
@@ -127,12 +128,13 @@ test "AS can make room aliases",
    };
 
 test "Regular users cannot create room aliases within the AS namespace",
-   requires => [qw( first_home_server ), $user_fixture, $room_fixture,
-                qw( can_create_room_alias )],
+   requires => [ $user_fixture, $room_fixture,
+                 qw( can_create_room_alias )],
 
    do => sub {
-      my ( $first_home_server, $user, $room_id ) = @_;
-      my $room_alias = "#astest-01create-2:$first_home_server";
+      my ( $user, $room_id ) = @_;
+      my $server_name = $user->http->server_name;
+      my $room_alias = "#astest-01create-2:$server_name";
 
       do_request_json_for( $user,
          method => "PUT",

--- a/tests/60app-services/01as-create.pl
+++ b/tests/60app-services/01as-create.pl
@@ -58,7 +58,7 @@ test "Regular users cannot register within the AS namespace",
    };
 
 test "AS can make room aliases",
-   requires => [ $main::AS_USER, qw( as_user_info ), $room_fixture,
+   requires => [ $main::AS_USER, $main::AS_USER_INFO, $room_fixture,
                 qw( can_create_room_alias )],
 
    do => sub {

--- a/tests/60app-services/01as-create.pl
+++ b/tests/60app-services/01as-create.pl
@@ -58,11 +58,11 @@ test "Regular users cannot register within the AS namespace",
    };
 
 test "AS can make room aliases",
-   requires => [ $main::AS_USER, qw( hs2as_token first_home_server ), $room_fixture,
+   requires => [ $main::AS_USER, qw( as_user_info first_home_server ), $room_fixture,
                 qw( can_create_room_alias )],
 
    do => sub {
-      my ( $as_user, $hs2as_token, $first_home_server, $room_id ) = @_;
+      my ( $as_user, $as_user_info, $first_home_server, $room_id ) = @_;
       my $room_alias = "#astest-01create-1:$first_home_server";
 
       Future->needs_all(
@@ -76,7 +76,7 @@ test "AS can make room aliases",
 
             assert_ok( defined $access_token,
                "HS provides an access_token" );
-            assert_eq( $access_token, $hs2as_token,
+            assert_eq( $access_token, $as_user_info->hs2as_token,
                "HS provides the correct token" );
 
             log_if_fail "Event", $event;

--- a/tests/60app-services/03passive.pl
+++ b/tests/60app-services/03passive.pl
@@ -5,14 +5,15 @@ my $room_fixture = room_fixture(
 );
 
 multi_test "Inviting an AS-hosted user asks the AS server",
-   requires => [ $main::AS_USER, qw( first_home_server ), $user_fixture, $room_fixture,
+   requires => [ $main::AS_USER, $user_fixture, $room_fixture,
                  qw( can_invite_room )],
 
    do => sub {
-      my ( $as_user, $home_server, $creator, $room_id ) = @_;
+      my ( $as_user, $creator, $room_id ) = @_;
+      my $server_name = $as_user->http->server_name;
 
       my $localpart = "astest-03passive-1";
-      my $user_id = "\@$localpart:$home_server";
+      my $user_id = "\@$localpart:$server_name";
 
       require_stub await_http_request( "/appserv/users/$user_id", sub { 1 } )
          ->then( sub {
@@ -44,15 +45,15 @@ multi_test "Inviting an AS-hosted user asks the AS server",
    };
 
 multi_test "Accesing an AS-hosted room alias asks the AS server",
-   requires => [ $main::AS_USER, qw( first_home_server ),
-                  local_user_fixture(), $room_fixture,
+   requires => [ $main::AS_USER, local_user_fixture(), $room_fixture,
 
                 qw( can_join_room_by_alias )],
 
    do => sub {
-      my ( $as_user, $first_home_server,
-           $local_user, $room_id ) = @_;
-      my $room_alias = "#astest-03passive-1:$first_home_server";
+      my ( $as_user, $local_user, $room_id ) = @_;
+      my $server_name = $as_user->http->server_name;
+
+      my $room_alias = "#astest-03passive-1:$server_name";
 
       require_stub await_http_request( "/appserv/rooms/$room_alias", sub { 1 } )
          ->then( sub {

--- a/tests/61push/01message-pushed.pl
+++ b/tests/61push/01message-pushed.pl
@@ -7,13 +7,13 @@ multi_test "Test that a message is pushed",
       # We need to register two users because you are never pushed for
       # messages that you send yourself.
       local_user_fixtures( 2, with_events => 0 ),
-      qw( test_http_server_uri_base
+      $main::TEST_SERVER_INFO,
 
-      can_create_private_room
-   )],
+      qw( can_create_private_room )
+   ],
 
    do => sub {
-      my ( $alice, $bob, $test_http_server_uri_base ) = @_;
+      my ( $alice, $bob, $test_server_info ) = @_;
 
       my $room_id;
 
@@ -61,7 +61,7 @@ multi_test "Test that a message is pushed",
                pushkey             => "a_push_key",
                lang                => "en",
                data                => {
-                  url => "$test_http_server_uri_base/alice_push",
+                  url => $test_server_info->client_location . "/alice_push",
                },
             },
          )->SyTest::pass_on_done( "Alice's pusher created" )


### PR DESCRIPTION
At this point, the Fixtures now lazily create any of the required test state when it's first needed. The only remaining values living in the environment are boolean ability-test guards.