### PR TITLE
Nicer partial runs of selected file(s)

### DIFF
--- a/lib/SyTest/Output/Term.pm
+++ b/lib/SyTest/Output/Term.pm
@@ -105,7 +105,7 @@ sub diag
 {
    shift;
    my ( $message ) = @_;
-   print "$message\n";
+   print "\n${YELLOW_B} #${RESET} $message";
 }
 
 package SyTest::Output::Term::Test {

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -334,6 +334,7 @@ my $failed;
 my $expected_fail;
 my $skipped_count = 0;
 
+use constant { PROVEN => 1, PRESUMED => 2 };
 my %proven;
 
 our $SKIPPING;
@@ -374,6 +375,7 @@ sub _run_test
 
    # If we're in skipping mode, just stop right now
    if( $SKIPPING ) {
+      $proven{$_} = PRESUMED for @{ $params{proves} // [] };
       $t->skipped++;
       return;
    }
@@ -397,6 +399,7 @@ sub _run_test
             $t->skip( "lack of $req" );
             return;
          }
+         $output->diag( "Presuming ability '$req'" ) if $proven{$req} == PRESUMED;
       }
    }
 
@@ -469,7 +472,7 @@ sub _run_test
    } @requires )->get;
 
    if( $success ) {
-      $proven{$_}++ for @{ $params{proves} // [] };
+      $proven{$_} = PROVEN for @{ $params{proves} // [] };
       $t->pass;
    }
    else {

--- a/tests/10apidoc/33room-members.pl
+++ b/tests/10apidoc/33room-members.pl
@@ -186,7 +186,7 @@ test "POST /rooms/:room_id/leave can leave a room",
       );
    };
 
-push @EXPORT, qw( matrix_leave_room );
+push our @EXPORT, qw( matrix_leave_room );
 
 sub matrix_leave_room
 {
@@ -230,11 +230,11 @@ test "POST /rooms/:room_id/invite can send an invite",
          $body->{membership} eq "invite" or
             die "Expected membership to be 'invite'";
 
-         push our @EXPORT, qw( matrix_invite_user_to_room );
-
          Future->done(1);
       });
    };
+
+push our @EXPORT, qw( matrix_invite_user_to_room );
 
 sub matrix_invite_user_to_room
 {

--- a/tests/10apidoc/34room-messages.pl
+++ b/tests/10apidoc/34room-messages.pl
@@ -17,13 +17,11 @@ test "POST /rooms/:room_id/send/:event_type sends a message",
          assert_json_keys( $body, qw( event_id ));
          assert_json_nonempty_string( $body->{event_id} );
 
-         push our @EXPORT, qw(
-            matrix_send_room_message matrix_send_room_text_message
-         );
-
          Future->done(1);
       });
    };
+
+push our @EXPORT, qw( matrix_send_room_message matrix_send_room_text_message );
 
 sub matrix_send_room_message
 {
@@ -100,11 +98,11 @@ test "GET /rooms/:room_id/messages returns a message",
          scalar @{ $body->{chunk} } > 0 or
             die "Expected some messages but got none at all\n";
 
-         push our @EXPORT, qw( matrix_get_room_messages );
-
          Future->done(1);
       });
    };
+
+push our @EXPORT, qw( matrix_get_room_messages );
 
 sub matrix_get_room_messages
 {

--- a/tests/10apidoc/36room-levels.pl
+++ b/tests/10apidoc/36room-levels.pl
@@ -75,10 +75,10 @@ test "Both GET and PUT work",
    check => sub {
       # Nothing to be done
 
-      push our @EXPORT, qw( matrix_change_room_powerlevels );
-
       Future->done(1);
    };
+
+push our @EXPORT, qw( matrix_change_room_powerlevels );
 
 sub matrix_change_room_powerlevels
 {

--- a/tests/10apidoc/37room-receipts.pl
+++ b/tests/10apidoc/37room-receipts.pl
@@ -25,12 +25,10 @@ test "POST /rooms/:room_id/receipt can create receipts",
 
             content => {},
          );
-      })->then( sub {
-         push our @EXPORT, qw( matrix_advance_room_receipt );
-
-         Future->done(1);
-      });
+      })->then_done(1);
    };
+
+push our @EXPORT, qw( matrix_advance_room_receipt );
 
 sub matrix_advance_room_receipt
 {


### PR DESCRIPTION
 * Don't run tests in skipped files even if they 'prove' things; just mark their abilities as presumed
 * Print notification when later tests depend on those presumed abilities, so if it fails you might know why
 * We can't defer pushing to `@EXPORT` any more, because of skipped tests that would export functions that later files need.