### PR TITLE
Support lazy starting of homeservers

### DIFF
--- a/tests/06http-clients.pl
+++ b/tests/06http-clients.pl
@@ -15,27 +15,25 @@ our $HTTP_CLIENT = fixture(
    },
 );
 
-# TODO: This ought to be an array, one per homeserver; though that's hard to
-#   arrange currently
-our $API_CLIENTS = fixture(
-   requires => [ @main::HOMESERVER_INFO ],
+our @API_CLIENTS = map {
+   my $info_fixture = $_;
 
-   setup => sub {
-      my @info = @_;
+   fixture(
+      requires => [ $info_fixture ],
 
-      my @clients = map {
-         my $location = $_->client_location;
+      setup => sub {
+         my ( $info ) = @_;
+
+         my $location = $info->client_location;
 
          my $client = SyTest::HTTPClient->new(
             max_connections_per_host => 3,
             uri_base => "$location/_matrix/client",
-            server_name => $_->server_name,
+            server_name => $info->server_name,
          );
          $loop->add( $client );
 
-         $client;
-      } @info;
-
-      Future->done( \@clients );
-   },
-);
+         Future->done( $client );
+      },
+   );
+} @main::HOMESERVER_INFO;

--- a/tests/06http-clients.pl
+++ b/tests/06http-clients.pl
@@ -18,10 +18,10 @@ our $HTTP_CLIENT = fixture(
 # TODO: This ought to be an array, one per homeserver; though that's hard to
 #   arrange currently
 our $API_CLIENTS = fixture(
-   requires => [ $main::HOMESERVER_INFO ],
+   requires => [ @main::HOMESERVER_INFO ],
 
    setup => sub {
-      my ( $info ) = @_;
+      my @info = @_;
 
       my @clients = map {
          my $location = $_->client_location;
@@ -34,7 +34,7 @@ our $API_CLIENTS = fixture(
          $loop->add( $client );
 
          $client;
-      } @$info;
+      } @info;
 
       Future->done( \@clients );
    },

--- a/tests/10apidoc/01register.pl
+++ b/tests/10apidoc/01register.pl
@@ -1,11 +1,10 @@
 test "GET /register yields a set of flows",
-   requires => [ $main::API_CLIENTS ],
+   requires => [ $main::API_CLIENTS[0] ],
 
    proves => [qw( can_register_password_flow )],
 
    check => sub {
-      my ( $clients ) = @_;
-      my $http = $clients->[0];
+      my ( $http ) = @_;
 
       $http->do_request_json(
          uri => "/api/v1/register",
@@ -36,14 +35,13 @@ test "GET /register yields a set of flows",
    };
 
 test "POST /register can create a user",
-   requires => [ $main::API_CLIENTS,
+   requires => [ $main::API_CLIENTS[0],
                  qw( can_register_password_flow ) ],
 
    critical => 1,
 
    do => sub {
-      my ( $clients ) = @_;
-      my $http = $clients->[0];
+      my ( $http ) = @_;
 
       $http->do_request_json(
          method => "POST",
@@ -118,11 +116,10 @@ sub local_user_fixture
    my %args = @_;
 
    fixture(
-      requires => [ $main::API_CLIENTS ],
+      requires => [ $main::API_CLIENTS[0] ],
 
       setup => sub {
-         my ( $clients ) = @_;
-         my $http = $clients->[0];
+         my ( $http ) = @_;
 
          matrix_register_user( $http, undef,
             with_events => $args{with_events} // 1,
@@ -168,11 +165,10 @@ push @EXPORT, qw( remote_user_fixture );
 sub remote_user_fixture
 {
    fixture(
-      requires => [ $main::API_CLIENTS ],
+      requires => [ $main::API_CLIENTS[1] ],
 
       setup => sub {
-         my ( $clients ) = @_;
-         my $http = $clients->[1];
+         my ( $http ) = @_;
 
          matrix_register_user( $http )
       }
@@ -186,11 +182,10 @@ push @EXPORT, qw( SPYGLASS_USER );
 # don't mutate server-side state, so it's fairly safe to reüse this user among
 # different tests.
 our $SPYGLASS_USER = fixture(
-   requires => [ $main::API_CLIENTS ],
+   requires => [ $main::API_CLIENTS[0] ],
 
    setup => sub {
-      my ( $clients ) = @_;
-      my $http = $clients->[0];
+      my ( $http ) = @_;
 
       matrix_register_user( $http )
       ->on_done( sub {

--- a/tests/10apidoc/02login.pl
+++ b/tests/10apidoc/02login.pl
@@ -4,11 +4,10 @@ use JSON qw( decode_json );
 my $password = "s3kr1t";
 
 my $registered_user_fixture = fixture(
-   requires => [ $main::API_CLIENTS ],
+   requires => [ $main::API_CLIENTS[0] ],
 
    setup => sub {
-      my ( $clients ) = @_;
-      my $http = $clients->[0];
+      my ( $http ) = @_;
 
       $http->do_request_json(
          method => "POST",
@@ -28,13 +27,12 @@ my $registered_user_fixture = fixture(
 );
 
 test "GET /login yields a set of flows",
-   requires => [ $main::API_CLIENTS ],
+   requires => [ $main::API_CLIENTS[0] ],
 
    proves => [qw( can_login_password_flow )],
 
    check => sub {
-      my ( $clients ) = @_;
-      my $http = $clients->[0];
+      my ( $http ) = @_;
 
       $http->do_request_json(
          uri => "/api/v1/login",
@@ -67,14 +65,13 @@ test "GET /login yields a set of flows",
    };
 
 test "POST /login can log in as a user",
-   requires => [ $main::API_CLIENTS, $registered_user_fixture,
+   requires => [ $main::API_CLIENTS[0], $registered_user_fixture,
                  qw( can_login_password_flow )],
 
    proves => [qw( can_login )],
 
    do => sub {
-      my ( $clients, $user_id ) = @_;
-      my $http = $clients->[0];
+      my ( $http, $user_id ) = @_;
 
       $http->do_request_json(
          method => "POST",
@@ -98,12 +95,11 @@ test "POST /login can log in as a user",
    };
 
 test "POST /login wrong password is rejected",
-   requires => [ $main::API_CLIENTS, $registered_user_fixture,
+   requires => [ $main::API_CLIENTS[0], $registered_user_fixture,
                  qw( can_login_password_flow )],
 
    do => sub {
-      my ( $clients, $user_id ) = @_;
-      my $http = $clients->[0];
+      my ( $http, $user_id ) = @_;
 
       $http->do_request_json(
          method => "POST",
@@ -131,11 +127,10 @@ test "POST /login wrong password is rejected",
    };
 
 test "POST /tokenrefresh invalidates old refresh token",
-   requires => [ $main::API_CLIENTS, $registered_user_fixture ],
+   requires => [ $main::API_CLIENTS[0], $registered_user_fixture ],
 
    do => sub {
-      my ( $clients, $user_id ) = @_;
-      my $http = $clients->[0];
+      my ( $http, $user_id ) = @_;
 
       my $first_body;
 

--- a/tests/10apidoc/10profile-displayname.pl
+++ b/tests/10apidoc/10profile-displayname.pl
@@ -39,14 +39,13 @@ test "PUT /profile/:user_id/displayname sets my name",
    };
 
 test "GET /profile/:user_id/displayname publicly accessible",
-   requires => [ $main::API_CLIENTS, $user_fixture,
+   requires => [ $main::API_CLIENTS[0], $user_fixture,
                  qw( can_set_displayname )],
 
    proves => [qw( can_get_displayname )],
 
    check => sub {
-      my ( $clients, $user ) = @_;
-      my $http = $clients->[0];
+      my ( $http, $user ) = @_;
       my $user_id = $user->user_id;
 
       $http->do_request_json(

--- a/tests/10apidoc/11profile-avatar_url.pl
+++ b/tests/10apidoc/11profile-avatar_url.pl
@@ -39,12 +39,11 @@ test "PUT /profile/:user_id/avatar_url sets my avatar",
    };
 
 test "GET /profile/:user_id/avatar_url publicly accessible",
-   requires => [ $main::API_CLIENTS, $user_fixture,
+   requires => [ $main::API_CLIENTS[0], $user_fixture,
                  qw( can_set_avatar_url )],
 
    check => sub {
-      my ( $clients, $user ) = @_;
-      my $http = $clients->[0];
+      my ( $http, $user ) = @_;
       my $user_id = $user->user_id;
 
       $http->do_request_json(

--- a/tests/10apidoc/31room-state.pl
+++ b/tests/10apidoc/31room-state.pl
@@ -91,11 +91,10 @@ test "GET /rooms/:room_id/initialSync fetches initial sync state",
    };
 
 test "GET /publicRooms lists newly-created room",
-   requires => [ $main::API_CLIENTS, $room_fixture ],
+   requires => [ $main::API_CLIENTS[0], $room_fixture ],
 
    check => sub {
-      my ( $clients, $room_id, undef ) = @_;
-      my $http = $clients->[0];
+      my ( $http, $room_id, undef ) = @_;
 
       $http->do_request_json(
          method => "GET",

--- a/tests/10apidoc/40content.pl
+++ b/tests/10apidoc/40content.pl
@@ -6,13 +6,12 @@ my $content_type = "text/plain";
 my $content_id;
 
 test "POST /media/v1/upload can create an upload",
-   requires => [ $main::API_CLIENTS, local_user_fixture() ],
+   requires => [ $main::API_CLIENTS[0], local_user_fixture() ],
 
    proves => [qw( can_upload_media )],
 
    do => sub {
-      my ( $clients, $user ) = @_;
-      my $http = $clients->[0];
+      my ( $http, $user ) = @_;
 
       # Because we're POST'ing non-JSON
       $http->do_request(
@@ -37,14 +36,13 @@ test "POST /media/v1/upload can create an upload",
    };
 
 test "GET /media/v1/download can fetch the value again",
-   requires => [ $main::API_CLIENTS,
+   requires => [ $main::API_CLIENTS[0],
                  qw( can_upload_media )],
 
    proves => [qw( can_download_media )],
 
    check => sub {
-      my ( $clients ) = @_;
-      my $http = $clients->[0];
+      my ( $http ) = @_;
 
       $http->do_request(
          method   => "GET",

--- a/tests/11register.pl
+++ b/tests/11register.pl
@@ -2,11 +2,10 @@ use JSON qw( decode_json );
 use URI;
 
 multi_test "Register with a recaptcha",
-   requires => [ $main::API_CLIENTS ],
+   requires => [ $main::API_CLIENTS[0] ],
 
    do => sub {
-      my ( $clients ) = @_;
-      my $http = $clients->[0];
+      my ( $http ) = @_;
 
       Future->needs_all(
          await_http_request( "/recaptcha/api/siteverify", sub {1} )

--- a/tests/30rooms/12thirdpartyinvite.pl
+++ b/tests/30rooms/12thirdpartyinvite.pl
@@ -54,23 +54,23 @@ test "Can invite existing 3pid",
    };
 
 test "Can invite unbound 3pid",
-   requires => [ local_user_fixtures( 2 ), $main::HOMESERVER_INFO,
+   requires => [ local_user_fixtures( 2 ), $main::HOMESERVER_INFO[0],
                  id_server_fixture() ],
 
    do => sub {
       my ( $inviter, $invitee, $info, $id_server ) = @_;
-      my $hs_uribase = $info->[0]->client_location;
+      my $hs_uribase = $info->client_location;
 
       can_invite_unbound_3pid( $inviter, $invitee, $hs_uribase, $id_server );
    };
 
 test "Can invite unbound 3pid over federation",
-   requires => [ local_user_fixture(), remote_user_fixture(), $main::HOMESERVER_INFO,
-                    id_server_fixture() ],
+   requires => [ local_user_fixture(), remote_user_fixture(),
+                 $main::HOMESERVER_INFO[1], id_server_fixture() ],
 
    do => sub {
       my ( $inviter, $invitee, $info, $id_server ) = @_;
-      my $hs_uribase = $info->[1]->client_location;
+      my $hs_uribase = $info->client_location;
 
       can_invite_unbound_3pid( $inviter, $invitee, $hs_uribase, $id_server );
    };
@@ -99,12 +99,12 @@ sub can_invite_unbound_3pid
 }
 
 test "Can accept unbound 3pid invite after inviter leaves",
-   requires => [ local_user_fixtures( 3 ), $main::HOMESERVER_INFO,
+   requires => [ local_user_fixtures( 3 ), $main::HOMESERVER_INFO[0],
                     id_server_fixture() ],
 
    do => sub {
       my ( $inviter, $other_member, $invitee, $info, $id_server ) = @_;
-      my $hs_uribase = $info->[0]->client_location;
+      my $hs_uribase = $info->client_location;
 
       my $room_id;
 
@@ -132,12 +132,12 @@ test "Can accept unbound 3pid invite after inviter leaves",
    };
 
 test "3pid invite join with wrong but valid signature are rejected",
-   requires => [ local_user_fixtures( 2 ), $main::HOMESERVER_INFO,
+   requires => [ local_user_fixtures( 2 ), $main::HOMESERVER_INFO[0],
                     id_server_fixture() ],
 
    do => sub {
       my ( $inviter, $invitee, $info, $id_server ) = @_;
-      my $hs_uribase = $info->[0]->client_location;
+      my $hs_uribase = $info->client_location;
 
       invite_should_fail( $inviter, $invitee, $hs_uribase, $id_server, sub {
          $id_server->rotate_keys;
@@ -146,12 +146,12 @@ test "3pid invite join with wrong but valid signature are rejected",
    };
 
 test "3pid invite join valid signature but revoked keys are rejected",
-   requires => [ local_user_fixtures( 2 ), $main::HOMESERVER_INFO,
+   requires => [ local_user_fixtures( 2 ), $main::HOMESERVER_INFO[0],
                     id_server_fixture() ],
 
    do => sub {
       my ( $inviter, $invitee, $info, $id_server ) = @_;
-      my $hs_uribase = $info->[0]->client_location;
+      my $hs_uribase = $info->client_location;
 
       invite_should_fail( $inviter, $invitee, $hs_uribase, $id_server, sub {
          $id_server->bind_identity( $hs_uribase, "email", $invitee_email, $invitee,
@@ -160,12 +160,12 @@ test "3pid invite join valid signature but revoked keys are rejected",
    };
 
 test "3pid invite join valid signature but unreachable ID server are rejected",
-   requires => [ local_user_fixtures( 2 ), $main::HOMESERVER_INFO,
+   requires => [ local_user_fixtures( 2 ), $main::HOMESERVER_INFO[0],
                     id_server_fixture() ],
 
    do => sub {
       my ( $inviter, $invitee, $info, $id_server ) = @_;
-      my $hs_uribase = $info->[0]->client_location;
+      my $hs_uribase = $info->client_location;
 
       invite_should_fail( $inviter, $invitee, $hs_uribase, $id_server, sub {
          $id_server->bind_identity( $hs_uribase, "email", $invitee_email, $invitee, sub {

--- a/tests/30rooms/60anonymousaccess.pl
+++ b/tests/30rooms/60anonymousaccess.pl
@@ -586,11 +586,10 @@ test "Anonymous users are kicked from guest_access rooms on revocation of guest_
    };
 
 test "GET /publicRooms lists rooms",
-   requires => [ $main::API_CLIENTS, local_user_fixture() ],
+   requires => [ $main::API_CLIENTS[0], local_user_fixture() ],
 
    check => sub {
-      my ( $clients, $user ) = @_;
-      my $http = $clients->[0];
+      my ( $http, $user ) = @_;
 
       Future->needs_all(
          matrix_create_room( $user,
@@ -691,11 +690,10 @@ test "GET /publicRooms lists rooms",
 sub anonymous_user_fixture
 {
    fixture(
-      requires => [ $main::API_CLIENTS ],
+      requires => [ $main::API_CLIENTS[0] ],
 
       setup => sub {
-         my ( $clients ) = @_;
-         my $http = $clients->[0];
+         my ( $http ) = @_;
 
          $http->do_request_json(
             method  => "POST",

--- a/tests/50federation/01keys.pl
+++ b/tests/50federation/01keys.pl
@@ -7,11 +7,11 @@ use Protocol::Matrix qw( encode_json_for_signing );
 my $crypto_sign = Crypt::NaCl::Sodium->sign;
 
 test "Federation key API allows unsigned requests for keys",
-   requires => [ $main::HOMESERVER_INFO, $main::HTTP_CLIENT ],
+   requires => [ $main::HOMESERVER_INFO[0], $main::HTTP_CLIENT ],
 
    check => sub {
       my ( $info, $client ) = @_;
-      my $first_home_server = $info->[0]->server_name;
+      my $first_home_server = $info->server_name;
 
       # Key API specifically does not require a signed request to ask for the
       # server's own key
@@ -78,11 +78,11 @@ test "Federation key API allows unsigned requests for keys",
    };
 
 test "Federation key API can act as a notary server",
-   requires => [ $main::HOMESERVER_INFO, $main::INBOUND_SERVER, $main::OUTBOUND_CLIENT ],
+   requires => [ $main::HOMESERVER_INFO[0], $main::INBOUND_SERVER, $main::OUTBOUND_CLIENT ],
 
    check => sub {
       my ( $info, $inbound_server, $client ) = @_;
-      my $first_home_server = $info->[0]->server_name;
+      my $first_home_server = $info->server_name;
 
       my $key_id = $inbound_server->key_id;
       my $local_server_name = $inbound_server->server_name;

--- a/tests/50federation/10query-profile.pl
+++ b/tests/50federation/10query-profile.pl
@@ -36,7 +36,7 @@ test "Outbound federation can query profile data",
 my $dname = "Displayname Set For Federation Test";
 
 test "Inbound federation can query profile data",
-   requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO, local_user_fixture(),
+   requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0], local_user_fixture(),
                  qw( can_set_displayname )],
 
    do => sub {
@@ -52,7 +52,7 @@ test "Inbound federation can query profile data",
       )->then( sub {
          $outbound_client->do_request_json(
             method   => "GET",
-            hostname => $info->[0]->server_name,
+            hostname => $info->server_name,
             uri      => "/query/profile",
 
             params => {

--- a/tests/50federation/11query-directory.pl
+++ b/tests/50federation/11query-directory.pl
@@ -44,12 +44,12 @@ test "Inbound federation can query room alias directory",
    # TODO(paul): technically this doesn't need local_user_fixture(), if we had
    #   some user we could assert can perform media/directory/etc... operations
    #   but doesn't mutate any of its own state, or join rooms, etc...
-   requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO, local_user_fixture(),
+   requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0], local_user_fixture(),
                  qw( can_create_room_alias )],
 
    do => sub {
       my ( $outbound_client, $info, $user ) = @_;
-      my $first_home_server = $info->[0]->server_name;
+      my $first_home_server = $info->server_name;
 
       my $room_id;
       my $room_alias = "#50federation-11query-directory:$first_home_server";

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -129,12 +129,13 @@ test "Outbound federation can send room-join requests",
    };
 
 test "Inbound federation can receive room-join requests",
-   requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO,
+   requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
+                 $main::HOMESERVER_INFO[0],
                  room_fixture( requires_users => [ local_user_fixture() ] ) ],
 
    do => sub {
       my ( $outbound_client, $inbound_server, $info, $room_id ) = @_;
-      my $first_home_server = $info->[0]->server_name;
+      my $first_home_server = $info->server_name;
 
       my $local_server_name = $outbound_client->server_name;
 

--- a/tests/51media/01unicode.pl
+++ b/tests/51media/01unicode.pl
@@ -6,14 +6,13 @@ my $FILENAME_ENCODED = uc uri_escape( $FILENAME );
 my $content_id;
 
 test "Can upload with Unicode file name",
-   requires => [ $main::API_CLIENTS, local_user_fixture(),
+   requires => [ $main::API_CLIENTS[0], local_user_fixture(),
                  qw( can_upload_media )],
 
    proves => [qw( can_upload_media_unicode )],
 
    do => sub {
-      my ( $clients, $user ) = @_;
-      my $http = $clients->[0];
+      my ( $http, $user ) = @_;
 
       $http->do_request(
          method       => "POST",
@@ -62,30 +61,29 @@ sub test_using_client
 }
 
 test "Can download with Unicode file name locally",
-   requires => [ $main::API_CLIENTS,
+   requires => [ $main::API_CLIENTS[0],
                  qw( can_upload_media_unicode )],
 
    check => sub {
-      my ( $clients ) = @_;
-      test_using_client( $clients->[0] );
+      my ( $http ) = @_;
+      test_using_client( $http );
    };
 
 test "Can download with Unicode file name over federation",
-   requires => [ $main::API_CLIENTS,
+   requires => [ $main::API_CLIENTS[1],
                  qw( can_upload_media_unicode ) ],
 
    check => sub {
-      my ( $clients ) = @_;
-      test_using_client( $clients->[1] );
+      my ( $http ) = @_;
+      test_using_client( $http );
    };
 
 test "Can download specifying a different Unicode file name",
-   requires => [ $main::API_CLIENTS,
+   requires => [ $main::API_CLIENTS[0],
                  qw( can_upload_media_unicode )],
 
    check => sub {
-      my ( $clients ) = @_;
-      my $http = $clients->[0];
+      my ( $http ) = @_;
 
       my $alt_filename_encoded = "%E2%98%95";
 

--- a/tests/51media/02nofilename.pl
+++ b/tests/51media/02nofilename.pl
@@ -1,11 +1,10 @@
 my $content_id;
 
 test "Can upload without a file name",
-   requires => [ $main::API_CLIENTS, local_user_fixture() ],
+   requires => [ $main::API_CLIENTS[0], local_user_fixture() ],
 
    do => sub {
-      my ( $clients, $user ) = @_;
-      my $http = $clients->[0];
+      my ( $http, $user ) = @_;
 
       $http->do_request(
          method       => "POST",
@@ -53,17 +52,17 @@ sub test_using_client
 }
 
 test "Can download without a file name locally",
-   requires => [ $main::API_CLIENTS ],
+   requires => [ $main::API_CLIENTS[0] ],
 
    check => sub {
-      my ( $clients ) = @_;
-      test_using_client( $clients->[0] );
+      my ( $http ) = @_;
+      test_using_client( $http );
    };
 
 test "Can download without a file name over federation",
-   requires => [ $main::API_CLIENTS ],
+   requires => [ $main::API_CLIENTS[1] ],
 
    check => sub {
-      my ( $clients ) = @_;
-      test_using_client( $clients->[1] );
+      my ( $http ) = @_;
+      test_using_client( $http );
    };

--- a/tests/51media/03ascii.pl
+++ b/tests/51media/03ascii.pl
@@ -1,11 +1,10 @@
 my $content_id;
 
 test "Can upload with ASCII file name",
-   requires => [ $main::API_CLIENTS, local_user_fixture() ],
+   requires => [ $main::API_CLIENTS[0], local_user_fixture() ],
 
    do => sub {
-      my ( $clients, $user ) = @_;
-      my $http = $clients->[0];
+      my ( $http, $user ) = @_;
 
       $http->do_request(
          method       => "POST",
@@ -54,27 +53,26 @@ sub test_using_client
 }
 
 test "Can download with ASCII file name locally",
-   requires => [ $main::API_CLIENTS ],
+   requires => [ $main::API_CLIENTS[0] ],
 
    check => sub {
-      my ( $clients ) = @_;
-      test_using_client( $clients->[0] );
+      my ( $http ) = @_;
+      test_using_client( $http );
    };
 
 test "Can download with ASCII file name over federation",
-   requires => [ $main::API_CLIENTS ],
+   requires => [ $main::API_CLIENTS[1] ],
 
    check => sub {
-      my ( $clients ) = @_;
-      test_using_client( $clients->[1] );
+      my ( $http ) = @_;
+      test_using_client( $http );
    };
 
 test "Can download specifying a different ASCII file name",
-   requires => [ $main::API_CLIENTS ],
+   requires => [ $main::API_CLIENTS[0] ],
 
    check => sub {
-      my ( $clients ) = @_;
-      my $http = $clients->[0];
+      my ( $http ) = @_;
 
       $http->do_request(
          method   => "GET",

--- a/tests/51media/10thumbnail.pl
+++ b/tests/51media/10thumbnail.pl
@@ -4,12 +4,11 @@ use File::Slurper qw( read_binary );
 my $dir = dirname __FILE__;
 
 test "POSTed media can be thumbnailed",
-   requires => [ $main::API_CLIENTS, local_user_fixture(),
+   requires => [ $main::API_CLIENTS[0], local_user_fixture(),
                  qw( can_upload_media can_download_media )],
 
    do => sub {
-      my ( $clients, $user ) = @_;
-      my $http = $clients->[0];
+      my ( $http, $user ) = @_;
 
       my $pngdata = read_binary( "$dir/test.png" );
 

--- a/tests/60app-services/00prepare.pl
+++ b/tests/60app-services/00prepare.pl
@@ -3,11 +3,10 @@ use Future::Utils qw( repeat );
 push our @EXPORT, qw( AS_USER await_as_event );
 
 our $AS_USER = fixture(
-   requires => [ $main::API_CLIENTS, $main::AS_USER_INFO ],
+   requires => [ $main::API_CLIENTS[0], $main::AS_USER_INFO ],
 
    setup => sub {
-      my ( $clients, $as_user_info ) = @_;
-      my $http = $clients->[0];
+      my ( $http, $as_user_info ) = @_;
 
       Future->done( User( $http, $as_user_info->user_id, $as_user_info->as2hs_token,
             undef, undef, [], undef ) );

--- a/tests/60app-services/01as-create.pl
+++ b/tests/60app-services/01as-create.pl
@@ -47,11 +47,10 @@ test "AS cannot create users outside its own namespace",
    };
 
 test "Regular users cannot register within the AS namespace",
-   requires => [ $main::API_CLIENTS ],
+   requires => [ $main::API_CLIENTS[0] ],
 
    do => sub {
-      my ( $clients ) = @_;
-      my $http = $clients->[0];
+      my ( $http ) = @_;
 
       matrix_register_user( $http, "astest-01create-2" )
          ->main::expect_http_4xx;


### PR DESCRIPTION
By storing `HOMESERVER_INFO` and `API_CLIENTS` as an array of fixtures, rather than one fixture returning an array(ref) of items, we can lazily start only the relevant homeserver for local tests, in the case of running only a few files that only contain "local" tests it doesn't have to spin up a second HS that will sit idle and do nothing.