### PR TITLE
Two-phase "load then run" split (SYT-42)

### DIFF
--- a/lib/SyTest/Output/TAP.pm
+++ b/lib/SyTest/Output/TAP.pm
@@ -10,8 +10,6 @@ STDOUT->autoflush(1);
 # File status
 sub run_file {}
 
-sub abort_file {}
-
 my $test_num;
 
 # General test status

--- a/lib/SyTest/Output/Term.pm
+++ b/lib/SyTest/Output/Term.pm
@@ -25,13 +25,6 @@ sub run_file
    print "${CYAN_B}Running $filename...${RESET}\n";
 }
 
-sub abort_file
-{
-   shift;
-   my ( $filename, $reason ) = @_;
-   print "${RED_B}ABORT${RESET} ${CYAN_B}$filename${RESET} because $reason\n";
-}
-
 # General test status
 sub enter_test
 {

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -545,25 +545,7 @@ TEST: {
 
          # Tell eval what the filename is so we get nicer warnings/errors that
          # give the filename instead of (eval 123)
-         my $died_during_compile;
-
-         my $success = do {
-            local $SIG{__DIE__} = sub {
-               return if $^S;
-               $died_during_compile = 1 if !defined $^S;
-               die @_;
-            };
-
-            eval( "#line 1 $filename\n" . $code . "; 1" );
-         };
-
-         if( !$success ) {
-            die $@ if $died_during_compile;
-
-            chomp( my $e = $@ );
-            $output->abort_file( $filename, $e );
-            $failed++;
-         }
+         eval( "#line 1 $filename\n" . $code . "; 1" ) or die $@;
 
          {
             no strict 'refs';

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -484,10 +484,6 @@ sub _run_test
       my $e = $@; chomp $e;
       $t->fail( $e );
    }
-
-   if( $t->failed ) {
-      $test->expect_fail ? $expected_fail++ : $failed++;
-   }
 }
 
 our $RUNNING_TEST;
@@ -612,6 +608,8 @@ foreach my $test ( @TESTS ) {
    }
 
    if( $t->failed ) {
+      $test->expect_fail ? $expected_fail++ : $failed++;
+
       $output->diag( $_ ) for @log_if_fail_lines;
 
       last if $STOP_ON_FAIL and not $test->expect_fail;


### PR DESCRIPTION
This change makes `run-tests.pl` load all the files (or at least, all the files up to the latest one named on the commandline in case of a partial run), before attempting to run any of them. It simplifies some of the internal logic of doing so, while at the same time giving the added convenience of instant notification of syntax errors before any of the slow tests have started. It also avoids having to print the filenames of files that contain only preparation steps and fixtures, but don't run any actual tests.