### PR TITLE
Running status display in terminal output (SYT-41)

### DIFF
--- a/lib/SyTest/Federation/Server.pm
+++ b/lib/SyTest/Federation/Server.pm
@@ -233,7 +233,7 @@ sub _dispatch
       }
    }
 
-   print STDERR "TODO: Respond to request to /_matrix/${\join '/', @trial}\n";
+   warn "TODO: Respond to request to /_matrix/${\join '/', @trial}";
 
    return Future->done(
       response => HTTP::Response->new(
@@ -291,7 +291,7 @@ sub mk_await_request_pair
 
       return $self->{$okey}{$ikey} = Future->new
          ->on_cancel( sub {
-            print STDERR "Cancelling unused $shortname await for @paramvalues";
+            warn "Cancelling unused $shortname await for @paramvalues";
             delete $self->{$okey}{$ikey};
          });
    };
@@ -362,7 +362,7 @@ sub on_request_federation_v1_send
    foreach my $edu ( @{ $body->{edus} } ) {
       next if $self->on_edu( $edu, $origin );
 
-      print STDERR "TODO: Unhandled incoming EDU of type '$edu->{edu_type}'\n";
+      warn "TODO: Unhandled incoming EDU of type '$edu->{edu_type}'";
    }
 
    Future->done( json => {} );

--- a/lib/SyTest/Output/TAP.pm
+++ b/lib/SyTest/Output/TAP.pm
@@ -57,6 +57,8 @@ sub diag
    print "# $message\n";
 }
 
+sub status {}
+
 package SyTest::Output::TAP::Test {
    sub new { my $class = shift; bless { subnum => 0, @_ }, $class }
 

--- a/lib/SyTest/Output/TAP.pm
+++ b/lib/SyTest/Output/TAP.pm
@@ -36,38 +36,6 @@ sub enter_multi_test
    );
 }
 
-# General preparation status
-my $running;
-sub start_prepare
-{
-   shift;
-   ( $running ) = @_;
-}
-
-sub skip_prepare
-{
-   shift;
-   my ( $name, $req ) = @_;
-   ++$test_num;
-   print "ok $test_num $name # skip Missing requirement $req\n";
-}
-
-sub pass_prepare
-{
-   ++$test_num;
-   print "ok $test_num prepared $running\n";
-}
-
-sub fail_prepare
-{
-   shift;
-   my ( $failure ) = @_;
-   ++$test_num;
-   print "not ok $test_num prepared $running\n";
-
-   print "# $_\n" for split m/\n/, $failure;
-}
-
 # Overall summary
 sub final_pass
 {

--- a/lib/SyTest/Output/TAP.pm
+++ b/lib/SyTest/Output/TAP.pm
@@ -71,8 +71,6 @@ package SyTest::Output::TAP::Test {
 
    sub start {}
 
-   sub progress {}
-
    sub pass { }
 
    sub fail

--- a/lib/SyTest/Output/Term.pm
+++ b/lib/SyTest/Output/Term.pm
@@ -87,17 +87,6 @@ package SyTest::Output::Term::Test {
       print "\n" if $self->multi;
    }
 
-   sub progress
-   {
-      my $self = shift;
-      my ( $message ) = @_;
-
-      $self->{progress_printed} = 1;
-
-      # TODO: handle multiline messages
-      print "\r\e[K$message";
-   }
-
    sub pass { }
 
    sub fail
@@ -113,8 +102,6 @@ package SyTest::Output::Term::Test {
    {
       my $self = shift;
       my ( $ok, $stepname ) = @_;
-
-      $self->progress( "" ) if $self->{progress_printed};
 
       $ok ?
          print "   ${CYAN}| $stepname... ${GREEN}OK${RESET}\n" :
@@ -136,8 +123,6 @@ package SyTest::Output::Term::Test {
       my $self = shift;
 
       return if $self->skipped;
-
-      $self->progress( "" ) if $self->{progress_printed};
 
       print "   ${CYAN}+--- " if $self->multi;
 

--- a/lib/SyTest/Output/Term.pm
+++ b/lib/SyTest/Output/Term.pm
@@ -40,37 +40,6 @@ sub enter_multi_test
    return SyTest::Output::Term::Test->new( name => $name, expect_fail => $expect_fail, multi => 1 );
 }
 
-# General preparation status
-sub start_prepare
-{
-   shift;
-   my ( $name ) = @_;
-   print "  ${CYAN}Preparing: $name${RESET}... ";
-}
-
-sub skip_prepare
-{
-   shift;
-   my ( $name, $req ) = @_;
-   print "  ${YELLOW_B}SKIP${RESET} '$name' prepararation due to lack of $req\n";
-}
-
-sub pass_prepare
-{
-   shift;
-   print "DONE\n";
-}
-
-sub fail_prepare
-{
-   shift;
-   my ( $failure ) = @_;
-
-   print "${RED_B}FAIL${RESET}:\n";
-   print " | $_\n" for split m/\n/, $failure;
-   print " +----------------------\n";
-}
-
 # Overall summary
 sub final_pass
 {

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -572,9 +572,17 @@ TEST: {
    );
 }
 
-my $failed_count;
-my $expected_fail_count;
+my $done_count = 0;
+my $failed_count = 0;
+my $expected_fail_count = 0;
 my $skipped_count = 0;
+
+$OUTPUT->status(
+   tests   => scalar @TESTS,
+   done    => $done_count,
+   failed  => $failed_count,
+   skipped => $skipped_count,
+);
 
 # Now run the tests
 my $prev_filename;
@@ -592,6 +600,8 @@ foreach my $test ( @TESTS ) {
 
    $t->leave;
 
+   $done_count++;
+
    if( $t->skipped ) {
       $skipped_count++;
    }
@@ -608,7 +618,16 @@ foreach my $test ( @TESTS ) {
          last;
       }
    }
+
+   $OUTPUT->status(
+      tests   => scalar @TESTS,
+      done    => $done_count,
+      failed  => $failed_count,
+      skipped => $skipped_count,
+   );
 }
+
+$OUTPUT->status();
 
 if( $WAIT_AT_END ) {
    print STDERR "Waiting... (hit ENTER to end)\n";

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -145,7 +145,7 @@ EOF
    exit $exitcode;
 }
 
-my $output = first { $_->can( "FORMAT") and $_->FORMAT eq $OUTPUT_FORMAT } output_formats()
+my $OUTPUT = first { $_->can( "FORMAT") and $_->FORMAT eq $OUTPUT_FORMAT } output_formats()
    or die "Unrecognised output format $OUTPUT_FORMAT\n";
 
 if( $CLIENT_LOG ) {
@@ -408,7 +408,7 @@ sub _run_test
             $t->skip( "lack of $req" );
             return;
          }
-         $output->diag( "Presuming ability '$req'" ) if $proven{$req} == PRESUMED;
+         $OUTPUT->diag( "Presuming ability '$req'" ) if $proven{$req} == PRESUMED;
       }
    }
 
@@ -573,12 +573,12 @@ foreach my $test ( @TESTS ) {
    }
 
    if( !$prev_filename or $prev_filename ne $test->file ) {
-      $output->run_file( $prev_filename = $test->file );
+      $OUTPUT->run_file( $prev_filename = $test->file );
    }
 
    my $m = $test->multi ? "enter_multi_test" : "enter_test";
 
-   my $t = $output->$m( $test->name, $test->expect_fail );
+   my $t = $OUTPUT->$m( $test->name, $test->expect_fail );
    local $RUNNING_TEST = $t;
 
    _run_test( $t, $test );
@@ -592,7 +592,7 @@ foreach my $test ( @TESTS ) {
    if( $t->failed ) {
       $test->expect_fail ? $expected_fail++ : $failed++;
 
-      $output->diag( $_ ) for @log_if_fail_lines;
+      $OUTPUT->diag( $_ ) for @log_if_fail_lines;
 
       last if $STOP_ON_FAIL and not $test->expect_fail;
 
@@ -610,7 +610,7 @@ if( $WAIT_AT_END ) {
 }
 
 if( $failed ) {
-   $output->final_fail( $failed );
+   $OUTPUT->final_fail( $failed );
 
    # TODO: umh.. this apparently broke some time ago. Should fix it
    #my @f;
@@ -625,7 +625,7 @@ if( $failed ) {
    exit 1;
 }
 else {
-   $output->final_pass( $expected_fail, $skipped_count );
+   $OUTPUT->final_pass( $expected_fail, $skipped_count );
    exit 0;
 }
 

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -148,6 +148,14 @@ EOF
 my $OUTPUT = first { $_->can( "FORMAT") and $_->FORMAT eq $OUTPUT_FORMAT } output_formats()
    or die "Unrecognised output format $OUTPUT_FORMAT\n";
 
+# Turn warnings into $OUTPUT->diag calls
+$SIG{__WARN__} = sub {
+   my $message = join "", @_;
+   chomp $message;
+
+   $OUTPUT->diag( $message );
+};
+
 if( $CLIENT_LOG ) {
    require Net::Async::HTTP;
    require Net::Async::HTTP::Server;

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -338,10 +338,6 @@ sub fixture
    );
 }
 
-my $failed;
-my $expected_fail;
-my $skipped_count = 0;
-
 use constant { PROVEN => 1, PRESUMED => 2 };
 my %proven;
 
@@ -571,6 +567,10 @@ TEST: {
    );
 }
 
+my $failed_count;
+my $expected_fail_count;
+my $skipped_count = 0;
+
 # Now run the tests
 my $prev_filename;
 foreach my $test ( @TESTS ) {
@@ -598,7 +598,7 @@ foreach my $test ( @TESTS ) {
    }
 
    if( $t->failed ) {
-      $test->expect_fail ? $expected_fail++ : $failed++;
+      $test->expect_fail ? $expected_fail_count++ : $failed_count++;
 
       $OUTPUT->diag( $_ ) for @log_if_fail_lines;
 
@@ -617,8 +617,8 @@ if( $WAIT_AT_END ) {
    $stdin->read_until( "\n" )->get;
 }
 
-if( $failed ) {
-   $OUTPUT->final_fail( $failed );
+if( $failed_count ) {
+   $OUTPUT->final_fail( $failed_count );
 
    # TODO: umh.. this apparently broke some time ago. Should fix it
    #my @f;
@@ -633,7 +633,7 @@ if( $failed ) {
    exit 1;
 }
 else {
-   $OUTPUT->final_pass( $expected_fail, $skipped_count );
+   $OUTPUT->final_pass( $expected_fail_count, $skipped_count );
    exit 0;
 }
 

--- a/tests/05synapse.pl
+++ b/tests/05synapse.pl
@@ -19,7 +19,7 @@ sub extract_extra_args
 my @synapses;
 
 END {
-   $output->diag( "Killing synapse servers " ) if @synapses;
+   $OUTPUT->diag( "Killing synapse servers " ) if @synapses;
 
    foreach my $synapse ( values @synapses ) {
       $synapse->kill( 'INT' );
@@ -75,7 +75,7 @@ our @HOMESERVER_INFO = map {
             synapse_dir   => $SYNAPSE_ARGS{directory},
             port          => $secure_port,
             unsecure_port => $unsecure_port,
-            output        => $output,
+            output        => $OUTPUT,
             print_output  => $SYNAPSE_ARGS{log},
             extra_args    => \@extra_args,
             python        => $SYNAPSE_ARGS{python},

--- a/tests/60app-services/00prepare.pl
+++ b/tests/60app-services/00prepare.pl
@@ -54,7 +54,7 @@ my $f = repeat {
             $f->done( $event, $request );
          }
          else {
-            print "Ignoring incoming AS event of type $type\n";
+            warn "Ignoring incoming AS event of type $type\n";
          }
       }
 


### PR DESCRIPTION
With the (default) terminal output format, show a running progress display at the bottom line.
This progress display shows the number of completed vs. total tests, and the count of any failed or skipped ones.

(Also contains some miscellaneous cleanup; deleting some unused methods I found on the way)