### PR TITLE
Split "data storage" out of SY:F:Server into new ::Datastore

### DIFF
--- a/lib/SyTest/Federation/Client.pm
+++ b/lib/SyTest/Federation/Client.pm
@@ -48,10 +48,8 @@ sub do_request_json
       $params{full_uri} = $uri;
    }
 
-   my $fedparams = $self->{federation_params};
-
-   my $origin = $fedparams->server_name;
-   my $key_id = $fedparams->key_id;
+   my $origin = $self->server_name;
+   my $key_id = $self->key_id;
 
    my %signing_block = (
       method => $params{method},

--- a/lib/SyTest/Federation/Datastore.pm
+++ b/lib/SyTest/Federation/Datastore.pm
@@ -52,8 +52,7 @@ sub key_id { $_[0]->{key_id} }
 
    $key = $store->secret_key
 
-Return the public or secret halves of the signing key the server is currently
-using
+Return the public or secret halves of the signing key of the local homeserver.
 
 =cut
 
@@ -89,7 +88,7 @@ sub sign_event
 
    $store->put_key( server_name => $name, key_id => $id, key => $key )
 
-Accessor and mutator for federation key storage
+Accessor and mutator for remote homeserver federation key storage.
 
 =cut
 

--- a/lib/SyTest/Federation/Datastore.pm
+++ b/lib/SyTest/Federation/Datastore.pm
@@ -11,6 +11,8 @@ sub new
    return bless {
       %args,
       keys => {},
+
+      next_event_id => 0,
    }, $class;
 }
 
@@ -82,6 +84,20 @@ sub put_key
    my $hk = "$params{server_name}:$params{key_id}";
 
    $self->{keys}{$hk} = $params{key};
+}
+
+=head2 next_event_id
+
+   $event_id = $store->next_event_id
+
+Allocates and returns a new string event ID for a unique event on this server.
+
+=cut
+
+sub next_event_id
+{
+   my $self = shift;
+   return sprintf "\$%d:%s", $self->{next_event_id}++, $self->server_name;
 }
 
 1;

--- a/lib/SyTest/Federation/Datastore.pm
+++ b/lib/SyTest/Federation/Datastore.pm
@@ -20,6 +20,7 @@ sub new
       keys => {},
 
       next_event_id => 0,
+      next_room_id => 0,
    }, $class;
 }
 
@@ -230,6 +231,20 @@ sub get_auth_chain_events
    }
 
    return @events_by_id{ @all_event_ids };
+}
+
+=head2 next_room_id
+
+   $room_id = $store->next_room_id
+
+Allocates and returns a new string room ID for a unique room.
+
+=cut
+
+sub next_room_id
+{
+   my $self = shift;
+   return sprintf "!%d:%s", $self->{next_room_id}++, $self->server_name;
 }
 
 1;

--- a/lib/SyTest/Federation/Datastore.pm
+++ b/lib/SyTest/Federation/Datastore.pm
@@ -1,0 +1,48 @@
+package SyTest::Federation::Datastore;
+
+use strict;
+use warnings;
+
+sub new
+{
+   my $class = shift;
+   return bless {
+      keys => {},
+   }, $class;
+}
+
+=head2 get_key
+
+   $key = $store->get_key( server_name => $name, key_id => $id )
+
+=head2 put_key
+
+   $store->put_key( server_name => $name, key_id => $id, key => $key )
+
+Accessor and mutator for federation key storage
+
+=cut
+
+sub get_key
+{
+   my $self = shift;
+   my %params = @_;
+
+   # hashes have keys. not the same as crypto keys. Grr.
+   my $hk = "$params{server_name}:$params{key_id}";
+
+   return $self->{keys}{$hk};
+}
+
+sub put_key
+{
+   my $self = shift;
+   my %params = @_;
+
+   # hashes have keys. not the same as crypto keys. Grr.
+   my $hk = "$params{server_name}:$params{key_id}";
+
+   $self->{keys}{$hk} = $params{key};
+}
+
+1;

--- a/lib/SyTest/Federation/Datastore.pm
+++ b/lib/SyTest/Federation/Datastore.pm
@@ -5,6 +5,8 @@ use warnings;
 
 use Carp;
 
+use Protocol::Matrix qw( sign_event_json );
+
 sub new
 {
    my $class = shift;
@@ -53,6 +55,27 @@ using
 
 sub public_key { $_[0]->{public_key} }
 sub secret_key { $_[0]->{secret_key} }
+
+=head2 sign_event
+
+   $store->sign_event( $event )
+
+Applies the event signing algorithm to the given event, adding the result to
+the C<signatures> key.
+
+=cut
+
+sub sign_event
+{
+   my $self = shift;
+   my ( $event ) = @_;
+
+   sign_event_json( $event,
+      secret_key => $self->secret_key,
+      origin     => $self->server_name,
+      key_id     => $self->key_id,
+   );
+}
 
 =head2 get_key
 

--- a/lib/SyTest/Federation/Datastore.pm
+++ b/lib/SyTest/Federation/Datastore.pm
@@ -6,10 +6,49 @@ use warnings;
 sub new
 {
    my $class = shift;
+   my %args = @_;
+
    return bless {
+      %args,
       keys => {},
    }, $class;
 }
+
+=head2 server_name
+
+   $name = $store->server_name
+
+Returns the federation name of the server
+
+=cut
+
+sub server_name { $_[0]->{server_name} }
+
+=head2 key_id
+
+   $id = $store->key_id
+
+Returns the key ID of the signing key the server is currently using
+
+=cut
+
+sub key_id { $_[0]->{key_id} }
+
+=head2 public_key
+
+   $key = $store->public_key
+
+=head2 secret_key
+
+   $key = $store->secret_key
+
+Return the public or secret halves of the signing key the server is currently
+using
+
+=cut
+
+sub public_key { $_[0]->{public_key} }
+sub secret_key { $_[0]->{secret_key} }
 
 =head2 get_key
 

--- a/lib/SyTest/Federation/Datastore.pm
+++ b/lib/SyTest/Federation/Datastore.pm
@@ -3,6 +3,8 @@ package SyTest::Federation::Datastore;
 use strict;
 use warnings;
 
+use Carp;
+
 sub new
 {
    my $class = shift;
@@ -98,6 +100,37 @@ sub next_event_id
 {
    my $self = shift;
    return sprintf "\$%d:%s", $self->{next_event_id}++, $self->server_name;
+}
+
+=head2 get_event
+
+   $event = $store->get_event( $event_id )
+
+=head2 put_event
+
+   $store->put_event( $event )
+
+Accessor and mutator for event storage
+
+=cut
+
+sub get_event
+{
+   my $self = shift;
+   my ( $event_id ) = @_;
+
+   my $event = $self->{events_by_id}{$event_id} or
+      croak "$self has no event id '$event_id'";
+
+   return $event;
+}
+
+sub put_event
+{
+   my $self = shift;
+   my ( $event ) = @_;
+
+   $self->{events_by_id}{ $event->{event_id} } = $event;
 }
 
 1;

--- a/lib/SyTest/Federation/Room.pm
+++ b/lib/SyTest/Federation/Room.pm
@@ -24,7 +24,7 @@ sub make_event_refs
 
 =head2 new
 
-   $room = SyTest::Federation::Room->new( room_id => $room_id )
+   $room = SyTest::Federation::Room->new( room_id => $room_id, datastore => $store )
 
 Constructs a new Room instance, initially blank containing no state or events.
 
@@ -37,9 +37,12 @@ sub new
 
    my $room_id = $args{room_id} or
       croak "Require a 'room_id'";
+   my $datastore = $args{datastore} or
+      croak "Require a 'datastore'";
 
    return bless {
-      room_id => $room_id,
+      room_id   => $room_id,
+      datastore => $datastore,
 
       current_state => {},
       prev_events => [],
@@ -87,15 +90,12 @@ sub next_depth
 
 =head2 create_initial_events
 
-   $room->create_initial_events( server => $server, creator => $creator )
+   $room->create_initial_events( creator => $creator )
 
 Convenience helper method to create all the initial state events required at
 room creation time. It supplies the C<m.room.create> event with the given
 C<$creator> user ID as the room's creator, the C<m.room.member> event for this
 user, and a C<m.room.join_rules> to set the room join permission as C<public>.
-
-C<$server> is an instance of L<SyTest::Federation::Server> required to
-actually create and persist the individual events.
 
 =cut
 
@@ -104,15 +104,11 @@ sub create_initial_events
    my $self = shift;
    my %args = @_;
 
-   my $server = $args{server} or
-      croak "Require a 'server'";
-
    my $creator = $args{creator} or
       croak "Require a 'creator'";
 
    $self->create_event(
-      server => $server,
-      type   => "m.room.create",
+      type => "m.room.create",
 
       content     => { creator => $creator },
       sender      => $creator,
@@ -120,8 +116,7 @@ sub create_initial_events
    );
 
    $self->create_event(
-      server => $server,
-      type   => "m.room.member",
+      type => "m.room.member",
 
       content     => { membership => "join" },
       sender      => $creator,
@@ -129,8 +124,7 @@ sub create_initial_events
    );
 
    $self->create_event(
-      server => $server,
-      type   => "m.room.join_rules",
+      type => "m.room.join_rules",
 
       content     => { join_rule => "public" },
       sender      => $creator,
@@ -140,14 +134,11 @@ sub create_initial_events
 
 =head2 create_event
 
-   $event = $room->create_event( server => $server, %fields )
+   $event = $room->create_event( %fields )
 
 Constructs a new event in the room and updates the current state, if it is a
 state event. This helper also fills in the C<depth>, C<prev_events> and
 C<auth_events> lists, meaning the caller does not have to.
-
-C<$server> is an instance of L<SyTest::Federation::Server> required to
-actually create and persist the event.
 
 =cut
 
@@ -155,9 +146,6 @@ sub create_event
 {
    my $self = shift;
    my %fields = @_;
-
-   my $server = delete $fields{server} or
-      croak "Require a 'server'";
 
    $fields{prev_state} = [] if defined $fields{state_key}; # TODO: give it a better value
 
@@ -168,7 +156,7 @@ sub create_event
 
    $fields{depth} //= $self->next_depth;
 
-   my $event = $server->create_event(
+   my $event = $self->{datastore}->create_event(
       %fields,
 
       auth_events => make_event_refs( @auth_events ),

--- a/lib/SyTest/Federation/Room.pm
+++ b/lib/SyTest/Federation/Room.pm
@@ -28,6 +28,9 @@ sub make_event_refs
 
 Constructs a new Room instance, initially blank containing no state or events.
 
+C<room_id> may be left undefined, and a new room ID will be allocated from the
+datastore if so.
+
 =cut
 
 sub new
@@ -35,10 +38,10 @@ sub new
    my $class = shift;
    my %args = @_;
 
-   my $room_id = $args{room_id} or
-      croak "Require a 'room_id'";
    my $datastore = $args{datastore} or
       croak "Require a 'datastore'";
+
+   my $room_id = $args{room_id} // $datastore->next_room_id;
 
    return bless {
       room_id   => $room_id,

--- a/lib/SyTest/Federation/Server.pm
+++ b/lib/SyTest/Federation/Server.pm
@@ -69,30 +69,7 @@ sub next_room_id
 sub create_event
 {
    my $self = shift;
-   my %fields = @_;
-
-   defined $fields{$_} or croak "Every event needs a '$_' field"
-      for qw( type auth_events content depth prev_events room_id sender );
-
-   if( defined $fields{state_key} ) {
-      defined $fields{$_} or croak "Every state event needs a '$_' field"
-         for qw( prev_state );
-   }
-
-   my $event = {
-      %fields,
-
-      event_id         => $self->next_event_id,
-      origin           => $self->server_name,
-      origin_server_ts => $self->time_ms,
-   };
-
-   my $store = $self->{datastore};
-
-   $store->sign_event( $event );
-   $store->put_event( $event );
-
-   return $event;
+   return $self->{datastore}->create_event( @_ );
 }
 
 sub get_auth_chain

--- a/lib/SyTest/Federation/Server.pm
+++ b/lib/SyTest/Federation/Server.pm
@@ -291,17 +291,15 @@ sub on_request_key_v2_server
    my $algo = "sha256";
    my $fingerprint = Net::SSLeay::X509_digest( $cert, Net::SSLeay::EVP_get_digestbyname( $algo ) );
 
-   my $fedparams = $self->{federation_params};
-
    Future->done( json => $self->signed_data( {
-      server_name => $fedparams->server_name,
+      server_name => $self->server_name,
       tls_fingerprints => [
          { $algo => encode_base64_unpadded( $fingerprint ) },
       ],
       valid_until_ts => ( time + 86400 ) * 1000, # +24h in msec
       verify_keys => {
-         $fedparams->key_id => {
-            key => encode_base64_unpadded( $fedparams->public_key ),
+         $self->key_id => {
+            key => encode_base64_unpadded( $self->{datastore}->public_key ),
          },
       },
       old_verify_keys => {},

--- a/lib/SyTest/Federation/Server.pm
+++ b/lib/SyTest/Federation/Server.pm
@@ -66,12 +66,6 @@ sub next_room_id
    return sprintf "!%d:%s", $self->{next_room_id}++, $self->server_name;
 }
 
-sub create_event
-{
-   my $self = shift;
-   return $self->{datastore}->create_event( @_ );
-}
-
 sub get_auth_chain
 {
    my $self = shift;

--- a/lib/SyTest/Federation/Server.pm
+++ b/lib/SyTest/Federation/Server.pm
@@ -89,17 +89,7 @@ sub create_event
 
    $self->sign_event( $event );
 
-   return $self->{events_by_id}{ $event->{event_id} } = $event;
-}
-
-sub get_event
-{
-   my $self = shift;
-   my ( $id ) = @_;
-
-   my $event = $self->{events_by_id}{$id} or
-      croak "$self has no event id '$id'";
-
+   $self->{datastore}->put_event( $event );
    return $event;
 }
 
@@ -108,7 +98,9 @@ sub get_auth_chain
    my $self = shift;
    my @event_ids = @_;
 
-   my %events_by_id = map { $_ => $self->get_event( $_ ) } @event_ids;
+   my $store = $self->{datastore};
+
+   my %events_by_id = map { $_ => $store->get_event( $_ ) } @event_ids;
 
    my @all_event_ids = @event_ids;
 
@@ -120,7 +112,7 @@ sub get_auth_chain
       foreach my $id ( @auth_ids ) {
          next if $events_by_id{$id};
 
-         $events_by_id{$id} = $self->get_event( $id );
+         $events_by_id{$id} = $store->get_event( $id );
          push @event_ids, $id;
       }
 

--- a/lib/SyTest/Federation/Server.pm
+++ b/lib/SyTest/Federation/Server.pm
@@ -53,12 +53,6 @@ sub client
    return $self->{client};
 }
 
-sub next_event_id
-{
-   my $self = shift;
-   return $self->{datastore}->next_event_id;
-}
-
 sub next_room_id
 {
    my $self = shift;

--- a/lib/SyTest/Federation/Server.pm
+++ b/lib/SyTest/Federation/Server.pm
@@ -25,8 +25,6 @@ sub _init
    my $self = shift;
    my ( $params ) = @_;
 
-   $self->{next_room_id} = 0;
-
    # Use 'on_request' as a configured parameter rather than a subclass method
    # so that the '$CLIENT_LOG' logic in run-tests.pl can properly put
    # debug-printing wrapping logic around it.
@@ -51,12 +49,6 @@ sub client
 {
    my $self = shift;
    return $self->{client};
-}
-
-sub next_room_id
-{
-   my $self = shift;
-   return sprintf "!%d:%s", $self->{next_room_id}++, $self->server_name;
 }
 
 sub _fetch_key

--- a/lib/SyTest/Federation/Server.pm
+++ b/lib/SyTest/Federation/Server.pm
@@ -26,7 +26,6 @@ sub _init
    my $self = shift;
    my ( $params ) = @_;
 
-   $self->{next_event_id} = 0;
    $self->{next_room_id} = 0;
 
    # Use 'on_request' as a configured parameter rather than a subclass method
@@ -58,7 +57,7 @@ sub client
 sub next_event_id
 {
    my $self = shift;
-   return sprintf "\$%d:%s", $self->{next_event_id}++, $self->server_name;
+   return $self->{datastore}->next_event_id;
 }
 
 sub next_room_id

--- a/lib/SyTest/Federation/Server.pm
+++ b/lib/SyTest/Federation/Server.pm
@@ -87,9 +87,11 @@ sub create_event
       origin_server_ts => $self->time_ms,
    };
 
-   $self->sign_event( $event );
+   my $store = $self->{datastore};
 
-   $self->{datastore}->put_event( $event );
+   $store->sign_event( $event );
+   $store->put_event( $event );
+
    return $event;
 }
 

--- a/lib/SyTest/Federation/_Base.pm
+++ b/lib/SyTest/Federation/_Base.pm
@@ -13,7 +13,7 @@ sub configure
    my $self = shift;
    my %params = @_;
 
-   foreach (qw( federation_params datastore )) {
+   foreach (qw( datastore )) {
       $self->{$_} = delete $params{$_} if exists $params{$_};
    }
 
@@ -23,13 +23,13 @@ sub configure
 sub server_name
 {
    my $self = shift;
-   return $self->{federation_params}->server_name;
+   return $self->{datastore}->server_name;
 }
 
 sub key_id
 {
    my $self = shift;
-   return $self->{federation_params}->key_id;
+   return $self->{datastore}->key_id;
 }
 
 # mutates the data
@@ -38,12 +38,12 @@ sub sign_data
    my $self = shift;
    my ( $data ) = @_;
 
-   my $fedparams = $self->{federation_params};
+   my $store = $self->{datastore};
 
    sign_json( $data,
-      secret_key => $fedparams->secret_key,
-      origin     => $fedparams->server_name,
-      key_id     => $fedparams->key_id,
+      secret_key => $store->secret_key,
+      origin     => $store->server_name,
+      key_id     => $store->key_id,
    );
 }
 
@@ -63,12 +63,12 @@ sub sign_event
    my $self = shift;
    my ( $event ) = @_;
 
-   my $fedparams = $self->{federation_params};
+   my $store = $self->{datastore};
 
    sign_event_json( $event,
-      secret_key => $fedparams->secret_key,
-      origin     => $fedparams->server_name,
-      key_id     => $fedparams->key_id,
+      secret_key => $store->secret_key,
+      origin     => $store->server_name,
+      key_id     => $store->key_id,
    );
 }
 

--- a/lib/SyTest/Federation/_Base.pm
+++ b/lib/SyTest/Federation/_Base.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 use mro 'c3';
-use Protocol::Matrix qw( sign_json sign_event_json encode_base64_unpadded );
+use Protocol::Matrix qw( sign_json encode_base64_unpadded );
 
 use Time::HiRes qw( time );
 
@@ -56,20 +56,6 @@ sub signed_data
    $self->sign_data( my $copy = { %$orig } );
 
    return $copy;
-}
-
-sub sign_event
-{
-   my $self = shift;
-   my ( $event ) = @_;
-
-   my $store = $self->{datastore};
-
-   sign_event_json( $event,
-      secret_key => $store->secret_key,
-      origin     => $store->server_name,
-      key_id     => $store->key_id,
-   );
 }
 
 sub get_key

--- a/lib/SyTest/Federation/_Base.pm
+++ b/lib/SyTest/Federation/_Base.pm
@@ -20,6 +20,12 @@ sub configure
    $self->next::method( %params );
 }
 
+sub datastore
+{
+   my $self = shift;
+   return $self->{datastore};
+}
+
 sub server_name
 {
    my $self = shift;

--- a/tests/50federation/00prepare.pl
+++ b/tests/50federation/00prepare.pl
@@ -11,8 +11,6 @@ use SyTest::Federation::Server;
 
 my $DIR = dirname( __FILE__ );
 
-struct FederationParams => [qw( server_name key_id public_key secret_key )];
-
 push our @EXPORT, qw( INBOUND_SERVER OUTBOUND_CLIENT );
 
 our $INBOUND_SERVER = fixture(
@@ -39,21 +37,22 @@ our $INBOUND_SERVER = fixture(
 
          my ( $pkey, $skey ) = Crypt::NaCl::Sodium->sign->keypair;
 
-         my $fedparams = FederationParams( $server_name, "ed25519:1", $pkey, $skey );
-
-         my $datastore = SyTest::Federation::Datastore->new();
+         my $datastore = SyTest::Federation::Datastore->new(
+            server_name => $server_name,
+            key_id      => "ed25519:1",
+            public_key  => $pkey,
+            secret_key  => $skey,
+         );
 
          my $outbound_client = SyTest::Federation::Client->new(
-            federation_params => $fedparams,
-            datastore         => $datastore,
-            uri_base          => "/_matrix/federation/v1",
+            datastore => $datastore,
+            uri_base  => "/_matrix/federation/v1",
          );
          $loop->add( $outbound_client );
 
          $inbound_server->configure(
-            federation_params => $fedparams,
-            datastore         => $datastore,
-            client            => $outbound_client,
+            datastore => $datastore,
+            client    => $outbound_client,
          );
       });
    },

--- a/tests/50federation/00prepare.pl
+++ b/tests/50federation/00prepare.pl
@@ -5,6 +5,7 @@ Net::Async::HTTP->VERSION( '0.39' ); # ->GET with 'headers'
 
 use Crypt::NaCl::Sodium;
 
+use SyTest::Federation::Datastore;
 use SyTest::Federation::Client;
 use SyTest::Federation::Server;
 
@@ -40,19 +41,18 @@ our $INBOUND_SERVER = fixture(
 
          my $fedparams = FederationParams( $server_name, "ed25519:1", $pkey, $skey );
 
-         # For now, the federation keystore is just a hash keyed on "origin/keyid"
-         my $keystore = {};
+         my $datastore = SyTest::Federation::Datastore->new();
 
          my $outbound_client = SyTest::Federation::Client->new(
             federation_params => $fedparams,
-            keystore          => $keystore,
+            datastore         => $datastore,
             uri_base          => "/_matrix/federation/v1",
          );
          $loop->add( $outbound_client );
 
          $inbound_server->configure(
             federation_params => $fedparams,
-            keystore          => $keystore,
+            datastore         => $datastore,
             client            => $outbound_client,
          );
       });

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -12,7 +12,8 @@ test "Outbound federation can send room-join requests",
       my $creator = '@50fed:' . $local_server_name;
 
       my $room = SyTest::Federation::Room->new(
-         room_id => $inbound_server->next_room_id,
+         room_id   => $inbound_server->next_room_id,
+         datastore => $inbound_server->datastore,
       );
 
       $room->create_initial_events(

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -14,7 +14,6 @@ test "Outbound federation can send room-join requests",
       my $creator = '@50fed:' . $local_server_name;
 
       my $room = SyTest::Federation::Room->new(
-         room_id   => $datastore->next_room_id,
          datastore => $datastore,
       );
 

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -14,7 +14,7 @@ test "Outbound federation can send room-join requests",
       my $creator = '@50fed:' . $local_server_name;
 
       my $room = SyTest::Federation::Room->new(
-         room_id   => $inbound_server->next_room_id,
+         room_id   => $datastore->next_room_id,
          datastore => $datastore,
       );
 

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -7,13 +7,15 @@ test "Outbound federation can send room-join requests",
 
    do => sub {
       my ( $user, $inbound_server ) = @_;
+
       my $local_server_name = $inbound_server->server_name;
+      my $datastore         = $inbound_server->datastore;
 
       my $creator = '@50fed:' . $local_server_name;
 
       my $room = SyTest::Federation::Room->new(
          room_id   => $inbound_server->next_room_id,
-         datastore => $inbound_server->datastore,
+         datastore => $datastore,
       );
 
       $room->create_initial_events(
@@ -68,7 +70,7 @@ test "Outbound federation can send room-join requests",
             my $event = $req->body_from_json;
             log_if_fail "send_join event", $event;
 
-            my @auth_chain = $inbound_server->get_auth_chain(
+            my @auth_chain = $datastore->get_auth_chain_events(
                map { $_->[0] } @{ $event->{auth_events} }
             );
 

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -125,6 +125,7 @@ test "Inbound federation can receive room-join requests",
       my $first_home_server = $info->server_name;
 
       my $local_server_name = $outbound_client->server_name;
+      my $datastore         = $inbound_server->datastore;
 
       my $user_id = "\@50fed-user:$local_server_name";
 
@@ -180,7 +181,7 @@ test "Inbound federation can receive room-join requests",
                auth_events content depth prev_events prev_state room_id sender
                state_key type ) ),
 
-            event_id         => $inbound_server->next_event_id,
+            event_id         => $datastore->next_event_id,
             origin           => $local_server_name,
             origin_server_ts => $inbound_server->time_ms,
          );


### PR DESCRIPTION
The `::Server` class was getting increasingly messy, storing events and rooms, allocating event and room IDs, associating room aliases, etc... This series of commits makes a new `::Datastore` object to store all the mocked testing data, and returns `::Server` to the simpler state of just being a server.

What's more, the new methods even have docs *gasp* *applause* etc...