### PR TITLE
Test sending and receiving transactions containing room messages

### DIFF
--- a/lib/SyTest/Federation/Client.pm
+++ b/lib/SyTest/Federation/Client.pm
@@ -84,7 +84,7 @@ sub do_request_json
    );
 }
 
-sub send_edu
+sub send_transaction
 {
    my $self = shift;
    my %params = @_;
@@ -95,15 +95,8 @@ sub send_edu
       origin           => $self->server_name,
       origin_server_ts => JSON::number( $ts ),
       previous_ids     => [], # TODO
-      pdus             => [],
-      edus             => [
-         {
-            edu_type => $params{edu_type},
-            content  => $params{content},
-            origin   => $self->server_name,
-            destination => $params{destination},
-         }
-      ],
+      pdus             => $params{pdus} // [],
+      edus             => $params{edus} // [],
    );
 
    $self->do_request_json(
@@ -113,6 +106,35 @@ sub send_edu
 
       content => \%transaction,
    )->then_done(); # response body is empty
+}
+
+sub send_edu
+{
+   my $self = shift;
+   my %params = @_;
+
+   $self->send_transaction(
+      %params,
+      edus => [
+         {
+            edu_type => $params{edu_type},
+            content  => $params{content},
+            origin   => $self->server_name,
+            destination => $params{destination},
+         }
+      ],
+   );
+}
+
+sub send_event
+{
+   my $self = shift;
+   my %params = @_;
+
+   $self->send_transaction(
+      %params,
+      pdus => [ $params{event} ],
+   );
 }
 
 sub join_room

--- a/lib/SyTest/Federation/Client.pm
+++ b/lib/SyTest/Federation/Client.pm
@@ -188,9 +188,9 @@ sub join_room
          );
 
          my @events = uniq_by { $_->{event_id} } (
-            \%member_event,
             @{ $join_body->{auth_chain} },
-            @{ $join_body->{state} }
+            @{ $join_body->{state} },
+            \%member_event,
          );
 
          $room->insert_event( $_ ) for @events;

--- a/lib/SyTest/Federation/Datastore.pm
+++ b/lib/SyTest/Federation/Datastore.pm
@@ -301,16 +301,16 @@ sub create_room
    return $room;
 }
 
-=head2 get_alias
+=head2 lookup_alias
 
-   $room_id = $store->get_alias( $room_alias )
+   $room_id = $store->lookup_alias( $room_alias )
 
 Returns the room ID associated with the given room alias, if one exists, or
 C<undef> if not.
 
 =cut
 
-sub get_alias
+sub lookup_alias
 {
    my $self = shift;
    my ( $room_alias ) = @_;

--- a/lib/SyTest/Federation/Room.pm
+++ b/lib/SyTest/Federation/Room.pm
@@ -6,6 +6,7 @@ use warnings;
 use Carp;
 
 use List::Util qw( max );
+use List::UtilsBy qw( extract_by );
 
 =head1 NAME
 
@@ -184,8 +185,10 @@ sub insert_event
    my $prev_events = $self->{prev_events};
    push @$prev_events, $event;
 
-   my %remove = map { $_->[0] => 1 } @{ $event->{prev_events} };
-   @$prev_events = grep { !$remove{ $_->{event_id} } } @$prev_events;
+   # Remove from $self->{prev_events} any event IDs that are now recursively
+   # implied by this new event.
+   my %to_remove = map { $_->[0] => 1 } @{ $event->{prev_events} };
+   extract_by { $to_remove{ $_->{event_id} } } @$prev_events;
 }
 
 sub _insert_event

--- a/lib/SyTest/Federation/Room.pm
+++ b/lib/SyTest/Federation/Room.pm
@@ -167,14 +167,36 @@ sub create_event
       prev_events => make_event_refs( @{ $self->{prev_events} } ),
    );
 
+   $self->_insert_event( $event );
+
    $self->{prev_events} = [ $event ];
 
-   if( defined $fields{state_key} ) {
-      $self->{current_state}{ join "\0", $fields{type}, $fields{state_key} }
+   return $event;
+}
+
+sub insert_event
+{
+   my $self = shift;
+   my ( $event ) = @_;
+
+   $self->_insert_event( $event );
+
+   my $prev_events = $self->{prev_events};
+   push @$prev_events, $event;
+
+   my %remove = map { $_->[0] => 1 } @{ $event->{prev_events} };
+   @$prev_events = grep { !$remove{ $_->{event_id} } } @$prev_events;
+}
+
+sub _insert_event
+{
+   my $self = shift;
+   my ( $event ) = @_;
+
+   if( defined $event->{state_key} ) {
+      $self->{current_state}{ join "\0", $event->{type}, $event->{state_key} }
          = $event;
    }
-
-   return $event;
 }
 
 =head2 current_state_events

--- a/lib/SyTest/Federation/Server.pm
+++ b/lib/SyTest/Federation/Server.pm
@@ -231,7 +231,7 @@ sub on_request_federation_v1_query_directory
    my $self = shift;
    my ( $req, $alias ) = @_;
 
-   my $room_id = $self->{datastore}->get_alias( $alias ) or
+   my $room_id = $self->{datastore}->lookup_alias( $alias ) or
       return Future->done( response => HTTP::Response->new(
          404, "Not found", [ Content_length => 0 ], "",
       ) );

--- a/tests/50federation/31room-send.pl
+++ b/tests/50federation/31room-send.pl
@@ -1,0 +1,45 @@
+test "Outbound federation can send events",
+   requires => [ local_user_fixture(), $main::INBOUND_SERVER ],
+
+   do => sub {
+      my ( $user, $inbound_server ) = @_;
+
+      my $local_server_name = $inbound_server->server_name;
+      my $datastore         = $inbound_server->datastore;
+
+      my $creator = '@50fed:' . $local_server_name;
+      my $room_alias = "#50fed-31send:$local_server_name";
+
+      my $room = $datastore->create_room(
+         creator => $creator,
+         alias   => $room_alias,
+      );
+
+      do_request_json_for( $user,
+         method => "POST",
+         uri    => "/api/v1/join/$room_alias",
+
+         content => {},
+      )->then( sub {
+         my ( $body ) = @_;
+
+         my $room_id = $body->{room_id};
+
+         Future->needs_all(
+            $inbound_server->await_event( "m.room.message", $room_id, sub {1} )
+            ->then( sub {
+               my ( $event ) = @_;
+               log_if_fail "Received event", $event;
+
+               assert_eq( $event->{sender}, $user->user_id,
+                  'event sender' );
+               assert_eq( $event->{content}{body}, "Hello",
+                  'event content body' );
+
+               Future->done(1);
+            }),
+
+            matrix_send_room_text_message( $user, $room_id, body => "Hello" ),
+         );
+      });
+   };

--- a/tests/50federation/31room-send.pl
+++ b/tests/50federation/31room-send.pl
@@ -43,3 +43,51 @@ test "Outbound federation can send events",
          );
       });
    };
+
+test "Inbound federation can receive events",
+   requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
+                 local_user_and_room_fixtures() ],
+
+   do => sub {
+      my ( $outbound_client, $info, $user, $room_id ) = @_;
+      my $first_home_server = $info->server_name;
+
+      my $local_server_name = $outbound_client->server_name;
+
+      my $user_id = "\@50fed-user:$local_server_name";
+
+      $outbound_client->join_room(
+         server_name => $first_home_server,
+         room_id     => $room_id,
+         user_id     => $user_id,
+      )->then( sub {
+         my ( $room ) = @_;
+
+         my $event = $room->create_event(
+            type => "m.room.message",
+
+            sender  => $user_id,
+            content => {
+               body => "Hello",
+            },
+         );
+
+         $outbound_client->send_event(
+            event => $event,
+            destination => $first_home_server,
+         );
+      })->then( sub {
+         await_event_for( $user, filter => sub {
+            my ( $event ) = @_;
+            return unless $event->{type} eq "m.room.message";
+            return unless $event->{room_id} eq $room_id;
+
+            assert_eq( $event->{sender}, $user_id,
+               'event sender' );
+            assert_eq( $event->{content}{body}, "Hello",
+               'event content body' );
+
+            Future->done(1);
+         });
+      });
+   };


### PR DESCRIPTION
An initial hack at a pair of tests to send or receive a transaction containing an `m.room.message` for a federated room. Deliberately engineered with most of the fancy parts in the reusable library implementation so that we can have lots more tests without too much more fuss.