### PR TITLE
Allocate fake federation user IDs dynamically as fixtures instead of hardcoded constants

### DIFF
--- a/tests/50federation/00prepare.pl
+++ b/tests/50federation/00prepare.pl
@@ -138,6 +138,15 @@ push @EXPORT, qw( federation_user_id_fixture );
 
 my $next_user_id = 0;
 
+=head2 federation_user_id_fixture
+
+   $fixture = federation_user_id_fixture
+
+Returns a new Fixture, which when provisioned will allocate a new user ID
+within the "fake" internal federation context, and return it as a string.
+
+=cut
+
 sub federation_user_id_fixture
 {
    fixture(

--- a/tests/50federation/00prepare.pl
+++ b/tests/50federation/00prepare.pl
@@ -133,3 +133,21 @@ test "Checking local federation server",
          Future->done(1);
       });
    };
+
+push @EXPORT, qw( federation_user_id_fixture );
+
+my $next_user_id = 0;
+
+sub federation_user_id_fixture
+{
+   fixture(
+      requires => [ $INBOUND_SERVER ],
+
+      setup => sub {
+         my ( $inbound_server ) = @_;
+
+         my $user_id = sprintf "\@__ANON__-%d:%s", $next_user_id++, $inbound_server->server_name;
+         Future->done( $user_id );
+      },
+   );
+}

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -3,15 +3,14 @@ use List::UtilsBy qw( partition_by extract_by );
 use SyTest::Federation::Room;
 
 test "Outbound federation can send room-join requests",
-   requires => [ local_user_fixture(), $main::INBOUND_SERVER ],
+   requires => [ local_user_fixture(), $main::INBOUND_SERVER,
+                 federation_user_id_fixture() ],
 
    do => sub {
-      my ( $user, $inbound_server ) = @_;
+      my ( $user, $inbound_server, $creator_id ) = @_;
 
       my $local_server_name = $inbound_server->server_name;
       my $datastore         = $inbound_server->datastore;
-
-      my $creator = '@50fed:' . $local_server_name;
 
       my $room = SyTest::Federation::Room->new(
          datastore => $datastore,
@@ -19,7 +18,7 @@ test "Outbound federation can send room-join requests",
 
       $room->create_initial_events(
          server  => $inbound_server,
-         creator => $creator,
+         creator => $creator_id,
       );
 
       my $room_id = $room->room_id;
@@ -117,16 +116,15 @@ test "Outbound federation can send room-join requests",
 test "Inbound federation can receive room-join requests",
    requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
                  $main::HOMESERVER_INFO[0],
-                 room_fixture( requires_users => [ local_user_fixture() ] ) ],
+                 room_fixture( requires_users => [ local_user_fixture() ] ),
+                 federation_user_id_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $inbound_server, $info, $room_id ) = @_;
+      my ( $outbound_client, $inbound_server, $info, $room_id, $user_id ) = @_;
       my $first_home_server = $info->server_name;
 
       my $local_server_name = $outbound_client->server_name;
       my $datastore         = $inbound_server->datastore;
-
-      my $user_id = "\@50fed-user:$local_server_name";
 
       $outbound_client->do_request_json(
          method   => "GET",

--- a/tests/50federation/31room-send.pl
+++ b/tests/50federation/31room-send.pl
@@ -1,17 +1,16 @@
 test "Outbound federation can send events",
-   requires => [ local_user_fixture(), $main::INBOUND_SERVER ],
+   requires => [ local_user_fixture(), $main::INBOUND_SERVER, federation_user_id_fixture() ],
 
    do => sub {
-      my ( $user, $inbound_server ) = @_;
+      my ( $user, $inbound_server, $creator_id ) = @_;
 
       my $local_server_name = $inbound_server->server_name;
       my $datastore         = $inbound_server->datastore;
 
-      my $creator = '@50fed:' . $local_server_name;
       my $room_alias = "#50fed-31send:$local_server_name";
 
       my $room = $datastore->create_room(
-         creator => $creator,
+         creator => $creator_id,
          alias   => $room_alias,
       );
 
@@ -46,15 +45,14 @@ test "Outbound federation can send events",
 
 test "Inbound federation can receive events",
    requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures() ],
+                 local_user_and_room_fixtures(),
+                 federation_user_id_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $info, $user, $room_id ) = @_;
+      my ( $outbound_client, $info, $user, $room_id, $user_id ) = @_;
       my $first_home_server = $info->server_name;
 
       my $local_server_name = $outbound_client->server_name;
-
-      my $user_id = "\@50fed-user:$local_server_name";
 
       $outbound_client->join_room(
          server_name => $first_home_server,

--- a/tests/50federation/31room-send.pl
+++ b/tests/50federation/31room-send.pl
@@ -49,7 +49,7 @@ test "Inbound federation can receive events",
                  federation_user_id_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $info, $user, $room_id, $user_id ) = @_;
+      my ( $outbound_client, $info, $creator, $room_id, $user_id ) = @_;
       my $first_home_server = $info->server_name;
 
       my $local_server_name = $outbound_client->server_name;
@@ -75,7 +75,7 @@ test "Inbound federation can receive events",
             destination => $first_home_server,
          );
       })->then( sub {
-         await_event_for( $user, filter => sub {
+         await_event_for( $creator, filter => sub {
             my ( $event ) = @_;
             return unless $event->{type} eq "m.room.message";
             return unless $event->{room_id} eq $room_id;

--- a/tests/50federation/32room-getevent.pl
+++ b/tests/50federation/32room-getevent.pl
@@ -1,14 +1,12 @@
 test "Inbound federation can return events",
    requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures() ],
+                 local_user_and_room_fixtures(), federation_user_id_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $info, $user, $room_id ) = @_;
+      my ( $outbound_client, $info, $user, $room_id, $user_id ) = @_;
       my $first_home_server = $info->server_name;
 
       my $local_server_name = $outbound_client->server_name;
-
-      my $user_id = "\@50fed-user:$local_server_name";
 
       my $member_event;
 

--- a/tests/50federation/32room-getevent.pl
+++ b/tests/50federation/32room-getevent.pl
@@ -1,9 +1,10 @@
 test "Inbound federation can return events",
    requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures(), federation_user_id_fixture() ],
+                 room_fixture( requires_users => [ local_user_fixture() ] ),
+                 federation_user_id_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $info, $user, $room_id, $user_id ) = @_;
+      my ( $outbound_client, $info, $room_id, $user_id ) = @_;
       my $first_home_server = $info->server_name;
 
       my $local_server_name = $outbound_client->server_name;


### PR DESCRIPTION
As per Dan's comments in https://github.com/matrix-org/sytest/pull/114#discussion_r48003848