### PR TITLE
Fix warning in 50federation/34room-backfill.pl

### DIFF
--- a/tests/50federation/34room-backfill.pl
+++ b/tests/50federation/34room-backfill.pl
@@ -135,8 +135,6 @@ test "Inbound federation can backfill events",
 
       my $local_server_name = $outbound_client->server_name;
 
-      my $user_id = "\@50fed-user:$local_server_name";
-
       my $join_event;
 
       # Create some past messages to backfill from


### PR DESCRIPTION
$user_id got defined twice accidentally.