### PR TITLE
Fix tests of /initialSync to work when the response is being cached

### DIFF
--- a/tests/10apidoc/30room-create.pl
+++ b/tests/10apidoc/30room-create.pl
@@ -1,5 +1,8 @@
 my $user_fixture = local_user_fixture();
 
+# An incrementing parameter for initialSync to defeat the caching mechanism and ensure fresh results every time
+my $initial_sync_limit = 1;
+
 test "POST /createRoom makes a public room",
    requires => [ $user_fixture,
                  qw( can_initial_sync )],
@@ -32,7 +35,8 @@ test "POST /createRoom makes a public room",
    check => sub {
       my ( $user ) = @_;
 
-      matrix_initialsync( $user )->then( sub {
+      # Change the limit for each request to defeat caching
+      matrix_initialsync( $user, limit => $initial_sync_limit++ )->then( sub {
          my ( $body ) = @_;
 
          assert_json_list( $body->{rooms} );

--- a/tests/30rooms/21receipts.pl
+++ b/tests/30rooms/21receipts.pl
@@ -1,5 +1,8 @@
 use List::Util qw( first );
 
+# An incrementing parameter for initialSync to defeat the caching mechanism and ensure fresh results every time
+my $initial_sync_limit = 1;
+
 sub find_receipt
 {
    my ( $body, %args ) = @_;
@@ -48,7 +51,7 @@ multi_test "Read receipts are visible to /initialSync",
 
          matrix_advance_room_receipt( $user, $room_id, "m.read" => $member_event_id )
       })->then( sub {
-         matrix_initialsync( $user )
+         matrix_initialsync( $user, limit => $initial_sync_limit++ );  # Change the limit to defeat caching
       })->then( sub {
          my ( $body ) = @_;
 
@@ -78,7 +81,7 @@ multi_test "Read receipts are visible to /initialSync",
 
          matrix_advance_room_receipt( $user, $room_id, "m.read" => $message_event_id );
       })->then( sub {
-         matrix_initialsync( $user );
+         matrix_initialsync( $user, limit => $initial_sync_limit++ );  # Change the limit to defeat caching
       })->then( sub {
          my ( $body ) = @_;
 
@@ -96,7 +99,7 @@ multi_test "Read receipts are visible to /initialSync",
          # Now lets check that they are monotonically racheted
          matrix_advance_room_receipt( $user, $room_id, "m.read" => $member_event_id );
       })->then( sub {
-         matrix_initialsync( $user );
+         matrix_initialsync( $user, limit => $initial_sync_limit++ );  # Change the limit to defeat caching
       })->then( sub {
          my ( $body ) = @_;
 


### PR DESCRIPTION
Work around the changes in matrix-org/synapse#457