### PR TITLE
Fixtures for allocating room aliases (and localpart names)

### DIFF
--- a/tests/10apidoc/30room-create.pl
+++ b/tests/10apidoc/30room-create.pl
@@ -122,3 +122,31 @@ sub matrix_create_room
       Future->done( $body->{room_id}, $body->{room_alias} );
    });
 }
+
+push @EXPORT, qw( room_alias_name_fixture );
+
+my $next_alias_name = 0;
+
+=head2 room_alias_name_fixture
+
+   $fixture = room_alias_name_fixture
+
+Returns a new Fixture, which when provisioned will allocate a new room alias
+name (i.e. localpart, before the homeserver domain name, and return it as a
+string.
+
+=cut
+
+sub room_alias_name_fixture
+{
+   return fixture(
+      setup => sub {
+         my ( $info ) = @_;
+
+         my $alias_name = sprintf "__ANON__-%d", $next_alias_name++;
+
+         Future->done( $alias_name );
+      },
+   );
+}
+

--- a/tests/10apidoc/30room-create.pl
+++ b/tests/10apidoc/30room-create.pl
@@ -123,7 +123,7 @@ sub matrix_create_room
    });
 }
 
-push @EXPORT, qw( room_alias_name_fixture );
+push @EXPORT, qw( room_alias_name_fixture room_alias_fixture );
 
 my $next_alias_name = 0;
 
@@ -157,3 +157,33 @@ sub room_alias_name_fixture
    );
 }
 
+=head2 room_alias_fixture
+
+   $fixture = room_alias_fixture( prefix => $prefix )
+
+Returns a new Fixture, which when provisioned will allocate a name for a new
+room alias on the first homeserver, and return it as a string. Note that this
+does not actually create the alias on the server itself, it simply suggests a
+new unique name for one.
+
+An optional prefix string can be provided, which will be prepended onto the
+alias name.
+
+=cut
+
+sub room_alias_fixture
+{
+   my %args = @_;
+
+   return fixture(
+      requires => [
+         room_alias_name_fixture( prefix => $args{prefix} ), $main::HOMESERVER_INFO[0],
+      ],
+
+      setup => sub {
+         my ( $alias_name, $info ) = @_;
+
+         Future->done( sprintf "#%s:%s", $alias_name, $info->server_name );
+      },
+   );
+}

--- a/tests/10apidoc/30room-create.pl
+++ b/tests/10apidoc/30room-create.pl
@@ -129,21 +129,28 @@ my $next_alias_name = 0;
 
 =head2 room_alias_name_fixture
 
-   $fixture = room_alias_name_fixture
+   $fixture = room_alias_name_fixture( prefix => $prefix )
 
 Returns a new Fixture, which when provisioned will allocate a new room alias
 name (i.e. localpart, before the homeserver domain name, and return it as a
 string.
 
+An optional prefix string can be provided, which will be prepended onto the
+alias name.
+
 =cut
 
 sub room_alias_name_fixture
 {
+   my %args = @_;
+
+   my $prefix = $args{prefix} // "";
+
    return fixture(
       setup => sub {
          my ( $info ) = @_;
 
-         my $alias_name = sprintf "__ANON__-%d", $next_alias_name++;
+         my $alias_name = sprintf "%s__ANON__-%d", $prefix, $next_alias_name++;
 
          Future->done( $alias_name );
       },

--- a/tests/10apidoc/31room-state.pl
+++ b/tests/10apidoc/31room-state.pl
@@ -6,13 +6,13 @@ my $user_fixture = local_user_fixture();
 
 # This provides $room_id *AND* $room_alias
 my $room_fixture = fixture(
-   requires => [ $user_fixture ],
+   requires => [ $user_fixture, room_alias_name_fixture() ],
 
    setup => sub {
-      my ( $user ) = @_;
+      my ( $user, $room_alias_name ) = @_;
 
       matrix_create_room( $user,
-         room_alias_name => "31room-state",
+         room_alias_name => $room_alias_name,
       );
    },
 );

--- a/tests/10apidoc/32room-alias.pl
+++ b/tests/10apidoc/32room-alias.pl
@@ -14,14 +14,12 @@ my $room_fixture = fixture(
 );
 
 test "PUT /directory/room/:room_alias creates alias",
-   requires => [ $user_fixture, $room_fixture, room_alias_name_fixture() ],
+   requires => [ $user_fixture, $room_fixture, room_alias_fixture() ],
 
    proves => [qw( can_create_room_alias can_lookup_room_alias )],
 
    do => sub {
-      my ( $user, $room_id, $room_alias_name ) = @_;
-      my $server_name = $user->http->server_name;
-      my $room_alias = "#${room_alias_name}:$server_name";
+      my ( $user, $room_id, $room_alias ) = @_;
 
       do_request_json_for( $user,
          method => "PUT",
@@ -34,9 +32,7 @@ test "PUT /directory/room/:room_alias creates alias",
    },
 
    check => sub {
-      my ( $user, $room_id, $room_alias_name ) = @_;
-      my $server_name = $user->http->server_name;
-      my $room_alias = "#${room_alias_name}:$server_name";
+      my ( $user, $room_id, $room_alias ) = @_;
 
       do_request_json_for( $user,
          method => "GET",

--- a/tests/10apidoc/33room-members.pl
+++ b/tests/10apidoc/33room-members.pl
@@ -6,13 +6,13 @@ my $creator_fixture = local_user_fixture();
 
 # This provides $room_id *AND* $room_alias
 my $room_fixture = fixture(
-   requires => [ $creator_fixture ],
+   requires => [ $creator_fixture, room_alias_name_fixture() ],
 
    setup => sub {
-      my ( $user ) = @_;
+      my ( $user, $room_alias_name ) = @_;
 
       matrix_create_room( $user,
-         room_alias_name => "33room-members",
+         room_alias_name => $room_alias_name,
       );
    },
 );

--- a/tests/30rooms/03members-remote.pl
+++ b/tests/30rooms/03members-remote.pl
@@ -11,13 +11,13 @@ my $creator_fixture = local_user_fixture(
 my $remote_user_fixture = remote_user_fixture();
 
 my $room_fixture = fixture(
-   requires => [ $creator_fixture ],
+   requires => [ $creator_fixture, room_alias_name_fixture() ],
 
    setup => sub {
-      my ( $user ) = @_;
+      my ( $user, $room_alias_name ) = @_;
 
       matrix_create_room( $user,
-         room_alias_name => "03members-remote"
+         room_alias_name => $room_alias_name,
       );
    },
 );
@@ -208,14 +208,14 @@ test "New room members see first user's profile information in per-room initialS
    };
 
 test "Remote users may not join unfederated rooms",
-   requires => [ local_user_fixture(), remote_user_fixture(),
+   requires => [ local_user_fixture(), remote_user_fixture(), room_alias_name_fixture(),
                  qw( can_create_room_with_creation_content )],
 
    check => sub {
-      my ( $creator, $remote_user ) = @_;
+      my ( $creator, $remote_user, $room_alias_name ) = @_;
 
       matrix_create_room( $creator,
-         room_alias_name  => "unfederated",
+         room_alias_name  => $room_alias_name,
          creation_content => {
             "m.federate" => JSON::false,
          },

--- a/tests/30rooms/05aliases.pl
+++ b/tests/30rooms/05aliases.pl
@@ -71,15 +71,15 @@ test "Remote room alias queries can handle Unicode",
    };
 
 multi_test "Canonical alias can be set",
-   requires => [ local_user_fixture() ],
+   requires => [ local_user_fixture(), room_alias_name_fixture() ],
 
    do => sub {
-      my ( $user ) = @_;
+      my ( $user, $room_alias_name ) = @_;
 
       my ( $room_id, $room_alias );
 
       matrix_create_room( $user,
-         room_alias_name => "is-this-canonical",
+         room_alias_name => $room_alias_name,
       )->then( sub {
          ( $room_id, $room_alias ) = @_;
 

--- a/tests/50federation/11query-directory.pl
+++ b/tests/50federation/11query-directory.pl
@@ -44,15 +44,16 @@ test "Inbound federation can query room alias directory",
    # TODO(paul): technically this doesn't need local_user_fixture(), if we had
    #   some user we could assert can perform media/directory/etc... operations
    #   but doesn't mutate any of its own state, or join rooms, etc...
-   requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0], local_user_fixture(),
+   requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
+                 local_user_fixture(), room_alias_name_fixture(),
                  qw( can_create_room_alias )],
 
    do => sub {
-      my ( $outbound_client, $info, $user ) = @_;
+      my ( $outbound_client, $info, $user, $room_alias_name ) = @_;
       my $first_home_server = $info->server_name;
 
       my $room_id;
-      my $room_alias = "#50federation-11query-directory:$first_home_server";
+      my $room_alias = "#${room_alias_name}:$first_home_server";
 
       matrix_create_room( $user )
       ->then( sub {

--- a/tests/50federation/11query-directory.pl
+++ b/tests/50federation/11query-directory.pl
@@ -45,15 +45,14 @@ test "Inbound federation can query room alias directory",
    #   some user we could assert can perform media/directory/etc... operations
    #   but doesn't mutate any of its own state, or join rooms, etc...
    requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
-                 local_user_fixture(), room_alias_name_fixture(),
+                 local_user_fixture(), room_alias_fixture(),
                  qw( can_create_room_alias )],
 
    do => sub {
-      my ( $outbound_client, $info, $user, $room_alias_name ) = @_;
+      my ( $outbound_client, $info, $user, $room_alias ) = @_;
       my $first_home_server = $info->server_name;
 
       my $room_id;
-      my $room_alias = "#${room_alias_name}:$first_home_server";
 
       matrix_create_room( $user )
       ->then( sub {

--- a/tests/60app-services/01as-create.pl
+++ b/tests/60app-services/01as-create.pl
@@ -59,15 +59,12 @@ test "Regular users cannot register within the AS namespace",
 test "AS can make room aliases",
    requires => [
       $main::AS_USER, $main::AS_USER_INFO, $room_fixture,
-      room_alias_name_fixture( prefix => "astest-" ),
+      room_alias_fixture( prefix => "astest-" ),
       qw( can_create_room_alias ),
    ],
 
    do => sub {
-      my ( $as_user, $as_user_info, $room_id,
-           $room_alias_name ) = @_;
-      my $server_name = $as_user->http->server_name;
-      my $room_alias = "#${room_alias_name}:$server_name";
+      my ( $as_user, $as_user_info, $room_id, $room_alias ) = @_;
 
       Future->needs_all(
          await_as_event( "m.room.aliases" )->then( sub {
@@ -132,14 +129,12 @@ test "AS can make room aliases",
 
 test "Regular users cannot create room aliases within the AS namespace",
    requires => [
-      $user_fixture, $room_fixture, room_alias_name_fixture( prefix => "astest-" ),
+      $user_fixture, $room_fixture, room_alias_fixture( prefix => "astest-" ),
       qw( can_create_room_alias ),
    ],
 
    do => sub {
-      my ( $user, $room_id, $room_alias_name ) = @_;
-      my $server_name = $user->http->server_name;
-      my $room_alias = "#${room_alias_name}:$server_name";
+      my ( $user, $room_id, $room_alias ) = @_;
 
       do_request_json_for( $user,
          method => "PUT",

--- a/tests/60app-services/01as-create.pl
+++ b/tests/60app-services/01as-create.pl
@@ -57,13 +57,17 @@ test "Regular users cannot register within the AS namespace",
    };
 
 test "AS can make room aliases",
-   requires => [ $main::AS_USER, $main::AS_USER_INFO, $room_fixture,
-                qw( can_create_room_alias )],
+   requires => [
+      $main::AS_USER, $main::AS_USER_INFO, $room_fixture,
+      room_alias_name_fixture( prefix => "astest-" ),
+      qw( can_create_room_alias ),
+   ],
 
    do => sub {
-      my ( $as_user, $as_user_info, $room_id ) = @_;
+      my ( $as_user, $as_user_info, $room_id,
+           $room_alias_name ) = @_;
       my $server_name = $as_user->http->server_name;
-      my $room_alias = "#astest-01create-1:$server_name";
+      my $room_alias = "#${room_alias_name}:$server_name";
 
       Future->needs_all(
          await_as_event( "m.room.aliases" )->then( sub {
@@ -127,13 +131,15 @@ test "AS can make room aliases",
    };
 
 test "Regular users cannot create room aliases within the AS namespace",
-   requires => [ $user_fixture, $room_fixture,
-                 qw( can_create_room_alias )],
+   requires => [
+      $user_fixture, $room_fixture, room_alias_name_fixture( prefix => "astest-" ),
+      qw( can_create_room_alias ),
+   ],
 
    do => sub {
-      my ( $user, $room_id ) = @_;
+      my ( $user, $room_id, $room_alias_name ) = @_;
       my $server_name = $user->http->server_name;
-      my $room_alias = "#astest-01create-2:$server_name";
+      my $room_alias = "#${room_alias_name}:$server_name";
 
       do_request_json_for( $user,
          method => "PUT",

--- a/tests/60app-services/03passive.pl
+++ b/tests/60app-services/03passive.pl
@@ -46,14 +46,15 @@ multi_test "Inviting an AS-hosted user asks the AS server",
 
 multi_test "Accesing an AS-hosted room alias asks the AS server",
    requires => [ $main::AS_USER, local_user_fixture(), $room_fixture,
+                 room_alias_name_fixture( prefix => "astest-" ),
 
                 qw( can_join_room_by_alias )],
 
    do => sub {
-      my ( $as_user, $local_user, $room_id ) = @_;
+      my ( $as_user, $local_user, $room_id, $room_alias_name ) = @_;
       my $server_name = $as_user->http->server_name;
 
-      my $room_alias = "#astest-03passive-1:$server_name";
+      my $room_alias = "#${room_alias_name}:$server_name";
 
       require_stub await_http_request( "/appserv/rooms/$room_alias", sub { 1 } )
          ->then( sub {

--- a/tests/60app-services/03passive.pl
+++ b/tests/60app-services/03passive.pl
@@ -46,15 +46,12 @@ multi_test "Inviting an AS-hosted user asks the AS server",
 
 multi_test "Accesing an AS-hosted room alias asks the AS server",
    requires => [ $main::AS_USER, local_user_fixture(), $room_fixture,
-                 room_alias_name_fixture( prefix => "astest-" ),
+                 room_alias_fixture( prefix => "astest-" ),
 
                 qw( can_join_room_by_alias )],
 
    do => sub {
-      my ( $as_user, $local_user, $room_id, $room_alias_name ) = @_;
-      my $server_name = $as_user->http->server_name;
-
-      my $room_alias = "#${room_alias_name}:$server_name";
+      my ( $as_user, $local_user, $room_id, $room_alias ) = @_;
 
       require_stub await_http_request( "/appserv/rooms/$room_alias", sub { 1 } )
          ->then( sub {


### PR DESCRIPTION
More robust tests by allocating aliases (and alias names) automatically rather than hardcoding them in the files and risking a collision, or a mismatch.