### PR TITLE
Neater handling of v2 'sync' batch tokens

### DIFF
--- a/tests/10apidoc/00prepare.pl
+++ b/tests/10apidoc/00prepare.pl
@@ -2,7 +2,8 @@ our @EXPORT = qw( User is_User do_request_json_for );
 
 # A handy little structure for other scripts to find in 'user' and 'more_users'
 struct User =>
-   [qw( http user_id access_token refresh_token eventstream_token saved_events pending_get_events )],
+   [qw( http user_id access_token refresh_token eventstream_token
+        sync_next_batch saved_events pending_get_events )],
    predicate => 'is_User';
 
 sub do_request_json_for

--- a/tests/10apidoc/01register.pl
+++ b/tests/10apidoc/01register.pl
@@ -84,7 +84,7 @@ sub matrix_register_user
       my ( $body ) = @_;
       my $access_token = $body->{access_token};
 
-      my $user = User( $http, $body->{user_id}, $access_token, undef, undef, [], undef );
+      my $user = User( $http, $body->{user_id}, $access_token, undef, undef, undef, [], undef );
 
       my $f = Future->done;
 

--- a/tests/10apidoc/03events-initial.pl
+++ b/tests/10apidoc/03events-initial.pl
@@ -103,7 +103,10 @@ sub GET_new_events_for
 
 # Some Matrix protocol helper functions
 
-push our @EXPORT, qw( matrix_initialsync matrix_sync flush_events_for await_event_for );
+push our @EXPORT, qw(
+   matrix_initialsync matrix_sync matrix_sync_again
+   flush_events_for await_event_for
+);
 
 sub flush_events_for
 {
@@ -189,4 +192,21 @@ sub matrix_sync
 
       $user->sync_next_batch = $body->{next_batch};
    });
+}
+
+=head2 matrix_sync_again
+
+   my ( $sync_body ) = matrix_sync_again( $user, %query_params )->get;
+
+A convenient wrapper around L</matrix_sync> which applies the user's
+C<sync_next_batch> field as the C<since> parameter, to perform an incremental
+sync since the last time the function was called.
+
+=cut
+
+sub matrix_sync_again
+{
+   my ( $user, %params ) = @_;
+
+   matrix_sync( $user, since => $user->sync_next_batch, %params );
 }

--- a/tests/10apidoc/03events-initial.pl
+++ b/tests/10apidoc/03events-initial.pl
@@ -167,7 +167,8 @@ sub await_event_for
    my ( $sync_body ) = matrix_sync( $user, %query_params )->get;
 
 Make a v2_alpha/sync request for the user. Returns the response body as a
-reference to a hash.
+reference to a hash. As a side-effect, this function updates the
+C<sync_next_batch> field of the user object.
 
 =cut
 
@@ -185,5 +186,7 @@ sub matrix_sync
       assert_json_keys( $body, qw( account_data rooms presence next_batch ) );
       assert_json_keys( $body->{presence}, qw( events ));
       assert_json_keys( $body->{rooms}, qw( join invite leave ) );
+
+      $user->sync_next_batch = $body->{next_batch};
    });
 }

--- a/tests/30rooms/60anonymousaccess.pl
+++ b/tests/30rooms/60anonymousaccess.pl
@@ -903,7 +903,7 @@ sub anonymous_user_fixture
             my ( $body ) = @_;
             my $access_token = $body->{access_token};
 
-            Future->done( User( $http, $body->{user_id}, $access_token, undef, undef, [], undef ) );
+            Future->done( User( $http, $body->{user_id}, $access_token, undef, undef, undef, [], undef ) );
          });
    })
 }

--- a/tests/31sync/03joined.pl
+++ b/tests/31sync/03joined.pl
@@ -26,7 +26,7 @@ test "Can sync a joined room",
          assert_json_keys( $room->{state}, qw( events ));
          assert_json_keys( $room->{ephemeral}, qw( events ));
 
-         matrix_sync( $user, filter => $filter_id, since => $body->{next_batch} );
+         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -60,7 +60,7 @@ test "Full state sync includes joined rooms",
       })->then( sub {
          my ( $body ) = @_;
 
-         matrix_sync( $user, filter => $filter_id, since => $body->{next_batch},
+         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch,
              full_state => 'true');
       })->then( sub {
          my ( $body ) = @_;
@@ -84,7 +84,7 @@ test "Newly joined room is included in an incremental sync",
    check => sub {
       my ( $user ) = @_;
 
-      my ( $filter_id, $room_id, $next_batch );
+      my ( $filter_id, $room_id );
 
       my $filter = { room => { timeline => { limit => 10 } } };
 
@@ -93,15 +93,11 @@ test "Newly joined room is included in an incremental sync",
 
          matrix_sync( $user, filter => $filter_id );
       })->then( sub {
-         my ( $body ) = @_;
-
-         $next_batch = $body->{next_batch};
-
          matrix_create_room( $user );
       })->then( sub {
          ( $room_id ) = @_;
 
-         matrix_sync( $user, filter => $filter_id, since => $next_batch );
+         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -111,7 +107,7 @@ test "Newly joined room is included in an incremental sync",
          assert_json_keys( $room->{state}, qw( events ));
          assert_json_keys( $room->{ephemeral}, qw( events ));
 
-         matrix_sync( $user, filter => $filter_id, since => $body->{next_batch} );
+         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -130,7 +126,7 @@ test "Newly joined room has correct timeline in incremental sync",
    check => sub {
       my ( $user_a, $user_b ) = @_;
 
-      my ( $filter_id_a, $filter_id_b, $room_id, $next_b );
+      my ( $filter_id_a, $filter_id_b, $room_id );
 
       my $filter = {
          room => {
@@ -151,11 +147,7 @@ test "Newly joined room has correct timeline in incremental sync",
             matrix_send_room_text_message( $user_a, $room_id, body => "test" );
          } 0 .. 3 );
       })->then( sub {
-         matrix_sync( $user_b, filter => $filter_id_b )->on_done( sub {
-            my ( $body ) = @_;
-
-            $next_b = $body->{next_batch};
-         });
+         matrix_sync( $user_b, filter => $filter_id_b );
       })->then( sub {
          Future->needs_all( map {
             matrix_send_room_text_message( $user_a, $room_id, body => "test" );
@@ -163,7 +155,7 @@ test "Newly joined room has correct timeline in incremental sync",
       })->then( sub {
          matrix_join_room( $user_b, $room_id );
       })->then( sub {
-         matrix_sync( $user_b, filter => $filter_id_b, since => $next_b );
+         matrix_sync( $user_b, filter => $filter_id_b, since => $user_b->sync_next_batch );
       })->then( sub {
          my ( $body ) = @_;
          my $room = $body->{rooms}{join}{$room_id};

--- a/tests/31sync/03joined.pl
+++ b/tests/31sync/03joined.pl
@@ -26,7 +26,7 @@ test "Can sync a joined room",
          assert_json_keys( $room->{state}, qw( events ));
          assert_json_keys( $room->{ephemeral}, qw( events ));
 
-         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
+         matrix_sync_again( $user, filter => $filter_id );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -60,8 +60,7 @@ test "Full state sync includes joined rooms",
       })->then( sub {
          my ( $body ) = @_;
 
-         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch,
-             full_state => 'true');
+         matrix_sync_again( $user, filter => $filter_id, full_state => 'true' );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -97,7 +96,7 @@ test "Newly joined room is included in an incremental sync",
       })->then( sub {
          ( $room_id ) = @_;
 
-         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
+         matrix_sync_again( $user, filter => $filter_id );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -107,7 +106,7 @@ test "Newly joined room is included in an incremental sync",
          assert_json_keys( $room->{state}, qw( events ));
          assert_json_keys( $room->{ephemeral}, qw( events ));
 
-         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
+         matrix_sync_again( $user, filter => $filter_id );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -155,7 +154,7 @@ test "Newly joined room has correct timeline in incremental sync",
       })->then( sub {
          matrix_join_room( $user_b, $room_id );
       })->then( sub {
-         matrix_sync( $user_b, filter => $filter_id_b, since => $user_b->sync_next_batch );
+         matrix_sync_again( $user_b, filter => $filter_id_b );
       })->then( sub {
          my ( $body ) = @_;
          my $room = $body->{rooms}{join}{$room_id};

--- a/tests/31sync/04timeline.pl
+++ b/tests/31sync/04timeline.pl
@@ -113,7 +113,7 @@ test "A message sent after an initial sync appears in the timeline of an increme
    check => sub {
       my ( $user ) = @_;
 
-      my ( $filter_id, $room_id, $event_id, $next_batch );
+      my ( $filter_id, $room_id, $event_id );
 
       my $filter = {
          room => {
@@ -134,14 +134,13 @@ test "A message sent after an initial sync appears in the timeline of an increme
       })->then( sub {
          my ( $body ) = @_;
 
-         $next_batch = $body->{next_batch};
          matrix_send_room_text_message( $user, $room_id,
             body => "A test message", txn_id => "my_transaction_id"
          );
       })->then( sub {
          ( $event_id ) = @_;
 
-         matrix_sync( $user, filter => $filter_id, since => $next_batch );
+         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -267,7 +266,7 @@ test "A full_state incremental update returns only recent timeline",
    check => sub {
       my ( $user ) = @_;
 
-      my ( $filter_id, $room_id, $next_batch );
+      my ( $filter_id, $room_id );
 
       my $filter = { room => { timeline => { limit => 1 } } };
 
@@ -282,7 +281,6 @@ test "A full_state incremental update returns only recent timeline",
       })->then( sub {
          my ( $body ) = @_;
 
-         $next_batch = $body->{next_batch};
          Future->needs_all( map {
             matrix_send_room_message( $user, $room_id,
                content => { "filler" => $_ },
@@ -295,7 +293,7 @@ test "A full_state incremental update returns only recent timeline",
                type    => "another.filler.type",
              );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $next_batch,
+         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch,
              full_state => 'true');
       })->then( sub {
          my ( $body ) = @_;

--- a/tests/31sync/04timeline.pl
+++ b/tests/31sync/04timeline.pl
@@ -140,7 +140,7 @@ test "A message sent after an initial sync appears in the timeline of an increme
       })->then( sub {
          ( $event_id ) = @_;
 
-         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
+         matrix_sync_again( $user, filter => $filter_id );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -293,8 +293,7 @@ test "A full_state incremental update returns only recent timeline",
                type    => "another.filler.type",
              );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch,
-             full_state => 'true');
+         matrix_sync_again( $user, filter => $filter_id, full_state => 'true' );
       })->then( sub {
          my ( $body ) = @_;
 

--- a/tests/31sync/05presence.pl
+++ b/tests/31sync/05presence.pl
@@ -94,7 +94,7 @@ test "User sees updates to presence from other users in the incremental sync.",
          # Set user B's presence to online by syncing.
          matrix_sync( $user_b, filter => $filter_id_b );
       })->then( sub {
-         matrix_sync( $user_a, filter => $filter_id_a, since => $user_a->sync_next_batch );
+         matrix_sync_again( $user_a, filter => $filter_id_a );
       })->then( sub {
          my ( $body ) = @_;
 

--- a/tests/31sync/05presence.pl
+++ b/tests/31sync/05presence.pl
@@ -71,7 +71,7 @@ test "User sees updates to presence from other users in the incremental sync.",
    check => sub {
       my ( $user_a, $user_b ) = @_;
 
-      my ( $filter_id_a, $filter_id_b, $next_a );
+      my ( $filter_id_a, $filter_id_b );
 
       my $filter = { presence => { types => [ "m.presence" ] } };
 
@@ -91,13 +91,10 @@ test "User sees updates to presence from other users in the incremental sync.",
       })->then( sub {
          matrix_sync( $user_a, filter => $filter_id_a );
       })->then( sub {
-         my ( $body ) = @_;
-
-         $next_a = $body->{next_batch};
          # Set user B's presence to online by syncing.
          matrix_sync( $user_b, filter => $filter_id_b );
       })->then( sub {
-         matrix_sync( $user_a, filter => $filter_id_a, since => $next_a );
+         matrix_sync( $user_a, filter => $filter_id_a, since => $user_a->sync_next_batch );
       })->then( sub {
          my ( $body ) = @_;
 

--- a/tests/31sync/06state.pl
+++ b/tests/31sync/06state.pl
@@ -143,7 +143,7 @@ test "Changes to state are included in an incremental sync",
    check => sub {
       my ( $user ) = @_;
 
-      my ( $filter_id, $room_id, $next_batch );
+      my ( $filter_id, $room_id );
 
       my $filter = {
          room => {
@@ -175,16 +175,13 @@ test "Changes to state are included in an incremental sync",
       })->then( sub {
          matrix_sync( $user, filter => $filter_id );
       })->then( sub {
-         my ( $body ) = @_;
-
-         $next_batch = $body->{next_batch};
          matrix_put_room_state( $user, $room_id,
             type      => "a.madeup.test.state",
             content   => { "my_key" => 2 },
             state_key => "this_state_changes",
          );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $next_batch );
+         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -211,7 +208,7 @@ test "Changes to state are included in an gapped incremental sync",
    check => sub {
       my ( $user ) = @_;
 
-      my ( $filter_id, $room_id, $next_batch );
+      my ( $filter_id, $room_id );
 
       my $filter = {
          room => {
@@ -245,7 +242,6 @@ test "Changes to state are included in an gapped incremental sync",
       })->then( sub {
          my ( $body ) = @_;
 
-         $next_batch = $body->{next_batch};
          @{ $body->{rooms}{join}{$room_id}{state}{events} } == 2
             or die "Expected two state events";
 
@@ -262,7 +258,7 @@ test "Changes to state are included in an gapped incremental sync",
             )
          } 0 .. 20 );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $next_batch );
+         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -289,7 +285,7 @@ test "State from remote users is included in the timeline in an incremental sync
     check => sub {
         my ( $user, $remote_user ) = @_;
 
-        my ( $filter_id, $room_id, $next_batch );
+        my ( $filter_id, $room_id );
 
         my $filter = {
             room => {
@@ -312,16 +308,13 @@ test "State from remote users is included in the timeline in an incremental sync
         })->then( sub {
             matrix_sync( $user, filter => $filter_id );
         })->then( sub {
-            my ( $body ) = @_;
-            $next_batch = $body->{next_batch};
-
             matrix_put_room_state( $remote_user, $room_id,
                                    type    => "a.madeup.test.state",
                                    content => { "my_key" => 1 });
         })->then( sub {
             # wait for the event to turn up on the other side
             wait_for_event_in_room( $user, $room_id, 
-               sync_params => { filter => $filter_id, since => $next_batch },
+               sync_params => { filter => $filter_id, since => $user->sync_next_batch },
             );
         })->then( sub {
             my ( $body ) = @_;
@@ -352,7 +345,7 @@ test "A full_state incremental update returns all state",
    check => sub {
       my ( $user ) = @_;
 
-      my ( $filter_id, $room_id, $next_batch );
+      my ( $filter_id, $room_id );
 
       my $filter = { room => {
           timeline => { limit => 2 },
@@ -382,7 +375,6 @@ test "A full_state incremental update returns all state",
       })->then( sub {
          my ( $body ) = @_;
 
-         $next_batch = $body->{next_batch};
          assert_json_empty_list( $body->{rooms}{join}{$room_id}{state}{events} );
 
          @{ $body->{rooms}{join}{$room_id}{timeline}{events} } == 2
@@ -401,7 +393,7 @@ test "A full_state incremental update returns all state",
             )
          } 0 .. 10 );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $next_batch,
+         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch,
              full_state => 'true');
       })->then( sub {
          my ( $body ) = @_;
@@ -452,7 +444,7 @@ test "When user joins a room the state is included in the next sync",
    check => sub {
       my ( $user_a, $user_b ) = @_;
 
-      my ( $filter_id_a, $filter_id_b, $room_id, $next_b );
+      my ( $filter_id_a, $filter_id_b, $room_id );
 
       my $filter = {
          room => {
@@ -483,12 +475,9 @@ test "When user joins a room the state is included in the next sync",
       })->then( sub {
          matrix_sync( $user_b, filter => $filter_id_b );
       })->then( sub {
-         my ( $body ) = @_;
-
-         $next_b = $body->{next_batch};
          matrix_join_room( $user_b, $room_id );
       })->then( sub {
-         matrix_sync( $user_b, filter => $filter_id_b, since => $next_b );
+         matrix_sync( $user_b, filter => $filter_id_b, since => $user_b->sync_next_batch );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -516,7 +505,7 @@ test "A change to displayname should not result in a full state sync",
    check => sub {
       my ( $user ) = @_;
 
-      my ( $filter_id, $room_id, $next_batch );
+      my ( $filter_id, $room_id );
 
       my $filter = {
          room => {
@@ -544,7 +533,6 @@ test "A change to displayname should not result in a full state sync",
       })->then( sub {
          my ( $body ) = @_;
 
-         $next_batch = $body->{next_batch};
          @{ $body->{rooms}{join}{$room_id}{state}{events} } == 1
             or die "Expected one state event";
 
@@ -555,7 +543,7 @@ test "A change to displayname should not result in a full state sync",
             state_key => $user->user_id,
          );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $next_batch );
+         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -576,7 +564,7 @@ test "When user joins a room the state is included in a gapped sync",
    check => sub {
       my ( $user_a, $user_b ) = @_;
 
-      my ( $filter_id_a, $filter_id_b, $room_id, $next_b );
+      my ( $filter_id_a, $filter_id_b, $room_id );
 
       my $filter = {
          room => {
@@ -606,9 +594,6 @@ test "When user joins a room the state is included in a gapped sync",
       })->then( sub {
          matrix_sync( $user_b, filter => $filter_id_b);
       })->then( sub {
-         my ( $body ) = @_;
-
-         $next_b = $body->{next_batch};
          matrix_join_room( $user_b, $room_id );
       })->then( sub {
          Future->needs_all( map {
@@ -618,7 +603,7 @@ test "When user joins a room the state is included in a gapped sync",
             )
          } 0 .. 20 );
       })->then( sub {
-         matrix_sync( $user_b, filter => $filter_id_b, since => $next_b );
+         matrix_sync( $user_b, filter => $filter_id_b, since => $user_b->sync_next_batch );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -646,7 +631,7 @@ test "When user joins and leaves a room in the same batch, the full state is sti
    check => sub {
       my ( $user_a, $user_b ) = @_;
 
-      my ( $filter_id_a, $filter_id_b, $room_id, $next_b );
+      my ( $filter_id_a, $filter_id_b, $room_id );
 
       my $filter = {
          room => {
@@ -677,14 +662,11 @@ test "When user joins and leaves a room in the same batch, the full state is sti
       })->then( sub {
          matrix_sync( $user_b, filter => $filter_id_b );
       })->then( sub {
-         my ( $body ) = @_;
-
-         $next_b = $body->{next_batch};
          matrix_join_room( $user_b, $room_id );
       })->then( sub {
          matrix_leave_room( $user_b, $room_id );
       })->then( sub {
-         matrix_sync( $user_b, filter => $filter_id_b, since => $next_b );
+         matrix_sync( $user_b, filter => $filter_id_b, since => $user_b->sync_next_batch );
       })->then( sub {
          my ( $body ) = @_;
 

--- a/tests/31sync/06state.pl
+++ b/tests/31sync/06state.pl
@@ -181,7 +181,7 @@ test "Changes to state are included in an incremental sync",
             state_key => "this_state_changes",
          );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
+         matrix_sync_again( $user, filter => $filter_id );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -258,7 +258,7 @@ test "Changes to state are included in an gapped incremental sync",
             )
          } 0 .. 20 );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
+         matrix_sync_again( $user, filter => $filter_id );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -393,8 +393,7 @@ test "A full_state incremental update returns all state",
             )
          } 0 .. 10 );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch,
-             full_state => 'true');
+         matrix_sync_again( $user, filter => $filter_id, full_state => 'true' );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -477,7 +476,7 @@ test "When user joins a room the state is included in the next sync",
       })->then( sub {
          matrix_join_room( $user_b, $room_id );
       })->then( sub {
-         matrix_sync( $user_b, filter => $filter_id_b, since => $user_b->sync_next_batch );
+         matrix_sync_again( $user_b, filter => $filter_id_b );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -543,7 +542,7 @@ test "A change to displayname should not result in a full state sync",
             state_key => $user->user_id,
          );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
+         matrix_sync_again( $user, filter => $filter_id );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -603,7 +602,7 @@ test "When user joins a room the state is included in a gapped sync",
             )
          } 0 .. 20 );
       })->then( sub {
-         matrix_sync( $user_b, filter => $filter_id_b, since => $user_b->sync_next_batch );
+         matrix_sync_again( $user_b, filter => $filter_id_b );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -666,7 +665,7 @@ test "When user joins and leaves a room in the same batch, the full state is sti
       })->then( sub {
          matrix_leave_room( $user_b, $room_id );
       })->then( sub {
-         matrix_sync( $user_b, filter => $filter_id_b, since => $user_b->sync_next_batch );
+         matrix_sync_again( $user_b, filter => $filter_id_b );
       })->then( sub {
          my ( $body ) = @_;
 

--- a/tests/31sync/07invited.pl
+++ b/tests/31sync/07invited.pl
@@ -68,7 +68,7 @@ test "Rooms a user is invited to appear in an incremental sync",
 
          matrix_invite_user_to_room( $user_a, $user_b, $room_id );
       })->then( sub {
-         matrix_sync( $user_b, filter => $filter_id_b, since => $user_b->sync_next_batch );
+         matrix_sync_again( $user_b, filter => $filter_id_b );
       })->then( sub {
          my ( $body ) = @_;
          my $room = $body->{rooms}{invite}{$room_id};

--- a/tests/31sync/07invited.pl
+++ b/tests/31sync/07invited.pl
@@ -52,7 +52,7 @@ test "Rooms a user is invited to appear in an incremental sync",
    check => sub {
       my ( $user_a, $user_b ) = @_;
 
-      my ( $filter_id_a, $filter_id_b, $room_id, $next_b );
+      my ( $filter_id_a, $filter_id_b, $room_id );
 
       Future->needs_all(
          matrix_create_filter( $user_a, {} ),
@@ -62,16 +62,13 @@ test "Rooms a user is invited to appear in an incremental sync",
 
          matrix_sync( $user_b, filter => $filter_id_b );
       })->then( sub {
-         my ( $body ) = @_;
-
-         $next_b = $body->{next_batch};
          matrix_create_room( $user_a );
       })->then( sub {
          ( $room_id ) = @_;
 
          matrix_invite_user_to_room( $user_a, $user_b, $room_id );
       })->then( sub {
-         matrix_sync( $user_b, filter => $filter_id_b, since => $next_b );
+         matrix_sync( $user_b, filter => $filter_id_b, since => $user_b->sync_next_batch );
       })->then( sub {
          my ( $body ) = @_;
          my $room = $body->{rooms}{invite}{$room_id};

--- a/tests/31sync/08polling.pl
+++ b/tests/31sync/08polling.pl
@@ -19,9 +19,7 @@ test "Sync can be polled for updates",
          my ( $body ) = @_;
 
          Future->needs_all(
-            matrix_sync( $user,
-               filter => $filter_id, since => $user->sync_next_batch, timeout => 10000
-            ),
+            matrix_sync_again( $user, filter => $filter_id, timeout => 10000 ),
 
             delay( 0.1 )->then( sub {
                matrix_send_room_text_message(
@@ -65,9 +63,7 @@ test "Sync is woken up for leaves",
          matrix_sync( $user, filter => $filter_id );
       })->then( sub {
          Future->needs_all(
-            matrix_sync( $user,
-               filter => $filter_id, since => $user->sync_next_batch, timeout => 10000
-            ),
+            matrix_sync_again( $user, filter => $filter_id, timeout => 10000 ),
 
             delay( 0.1 )->then( sub {
                matrix_leave_room(

--- a/tests/31sync/08polling.pl
+++ b/tests/31sync/08polling.pl
@@ -5,7 +5,7 @@ test "Sync can be polled for updates",
    check => sub {
       my ( $user ) = @_;
 
-      my ( $filter_id, $room_id, $next );
+      my ( $filter_id, $room_id );
 
       matrix_create_filter( $user, {} )->then( sub {
          ( $filter_id ) = @_;
@@ -18,10 +18,9 @@ test "Sync can be polled for updates",
       })->then( sub {
          my ( $body ) = @_;
 
-         $next = $body->{next_batch};
          Future->needs_all(
             matrix_sync( $user,
-               filter => $filter_id, since => $next, timeout => 10000
+               filter => $filter_id, since => $user->sync_next_batch, timeout => 10000
             ),
 
             delay( 0.1 )->then( sub {
@@ -54,7 +53,7 @@ test "Sync is woken up for leaves",
    check => sub {
       my ( $user ) = @_;
 
-      my ( $filter_id, $room_id, $next );
+      my ( $filter_id, $room_id );
 
       matrix_create_filter( $user, {} )->then( sub {
          ( $filter_id ) = @_;
@@ -65,12 +64,9 @@ test "Sync is woken up for leaves",
 
          matrix_sync( $user, filter => $filter_id );
       })->then( sub {
-         my ( $body ) = @_;
-
-         $next = $body->{next_batch};
          Future->needs_all(
             matrix_sync( $user,
-               filter => $filter_id, since => $next, timeout => 10000
+               filter => $filter_id, since => $user->sync_next_batch, timeout => 10000
             ),
 
             delay( 0.1 )->then( sub {

--- a/tests/31sync/09archived.pl
+++ b/tests/31sync/09archived.pl
@@ -120,7 +120,7 @@ test "Previously left rooms don't appear in the leave section of sync",
    check => sub {
       my ( $user, $user2 ) = @_;
 
-      my ( $filter_id, $room_id_1, $room_id_2, $next );
+      my ( $filter_id, $room_id_1, $room_id_2 );
 
       my $filter = {
          room => { timeline => { limit => 1 }, include_leave => JSON::true }
@@ -140,18 +140,10 @@ test "Previously left rooms don't appear in the leave section of sync",
       })->then( sub {
          matrix_sync( $user, filter => $filter_id );
       })->then( sub {
-         my ( $body ) = @_;
-
-         $next = $body->{next_batch};
-
          matrix_leave_room( $user, $room_id_1 );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $next );
+         matrix_sync_again( $user, filter => $filter_id );
       })->then( sub {
-         my ( $body ) = @_;
-
-         $next = $body->{next_batch};
-
          matrix_put_room_state( $user2, $room_id_1,
             content  => { "filler" => $_, membership => "join" },
             type      => "m.room.member",
@@ -167,7 +159,7 @@ test "Previously left rooms don't appear in the leave section of sync",
             )
          }  0 .. 5 );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $next );
+         matrix_sync_again( $user, filter => $filter_id );
       })->then( sub {
          my ( $body ) = @_;
 

--- a/tests/31sync/09archived.pl
+++ b/tests/31sync/09archived.pl
@@ -37,7 +37,7 @@ test "Newly left rooms appear in the leave section of incremental sync",
    check => sub {
       my ( $user ) = @_;
 
-      my ( $filter_id, $room_id, $next );
+      my ( $filter_id, $room_id );
 
      matrix_create_filter( $user,
          { room => { include_leave => JSON::true } }
@@ -50,13 +50,9 @@ test "Newly left rooms appear in the leave section of incremental sync",
 
          matrix_sync( $user, filter => $filter_id );
       })->then( sub {
-         my ( $body ) = @_;
-
-         $next = $body->{next_batch};
-
          matrix_leave_room( $user, $room_id );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $next );
+         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -75,7 +71,7 @@ test "Newly left rooms appear in the leave section of gapped sync",
    check => sub {
       my ( $user ) = @_;
 
-      my ( $filter_id, $room_id_1, $room_id_2, $next );
+      my ( $filter_id, $room_id_1, $room_id_2 );
 
       my $filter = {
          room => { timeline => { limit => 1 }, include_leave => JSON::true }
@@ -91,10 +87,6 @@ test "Newly left rooms appear in the leave section of gapped sync",
       })->then( sub {
          matrix_sync( $user, filter => $filter_id );
       })->then( sub {
-         my ( $body ) = @_;
-
-         $next = $body->{next_batch};
-
          matrix_leave_room( $user, $room_id_1 );
       })->then( sub {
          # Pad out the timeline with filler messages to create a "gap" between
@@ -109,7 +101,7 @@ test "Newly left rooms appear in the leave section of gapped sync",
             )
          } 0 .. 20 );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $next );
+         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -128,7 +120,7 @@ test "Left rooms appear in the leave section of full state sync",
    check => sub {
       my ( $user ) = @_;
 
-      my ( $filter_id, $room_id, $next );
+      my ( $filter_id, $room_id );
 
       matrix_create_filter( $user,
          { room => { include_leave => JSON::true } }
@@ -141,14 +133,10 @@ test "Left rooms appear in the leave section of full state sync",
 
          matrix_sync( $user, filter => $filter_id );
       })->then( sub {
-         my ( $body ) = @_;
-
-         $next = $body->{next_batch};
-
          matrix_leave_room( $user, $room_id );
       })->then( sub {
          matrix_sync( $user, filter => $filter_id,
-             since => $next, full_state => 'true');
+             since => $user->sync_next_batch, full_state => 'true');
       })->then( sub {
          my ( $body ) = @_;
 

--- a/tests/31sync/09archived.pl
+++ b/tests/31sync/09archived.pl
@@ -52,7 +52,7 @@ test "Newly left rooms appear in the leave section of incremental sync",
       })->then( sub {
          matrix_leave_room( $user, $room_id );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
+         matrix_sync_again( $user, filter => $filter_id );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -101,7 +101,7 @@ test "Newly left rooms appear in the leave section of gapped sync",
             )
          } 0 .. 20 );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
+         matrix_sync_again( $user, filter => $filter_id );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -135,8 +135,7 @@ test "Left rooms appear in the leave section of full state sync",
       })->then( sub {
          matrix_leave_room( $user, $room_id );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id,
-             since => $user->sync_next_batch, full_state => 'true');
+         matrix_sync_again( $user, filter => $filter_id, full_state => 'true' );
       })->then( sub {
          my ( $body ) = @_;
 

--- a/tests/31sync/10archived-ban.pl
+++ b/tests/31sync/10archived-ban.pl
@@ -71,7 +71,7 @@ test "Newly banned rooms appear in the leave section of incremental sync",
             content => { user_id => $user_b->user_id, reason => "testing" },
          );
       })->then( sub {
-         matrix_sync( $user_b, filter => $filter_id_b, since => $user_b->sync_next_batch );
+         matrix_sync_again( $user_b, filter => $filter_id_b );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -121,7 +121,7 @@ test "Newly banned rooms appear in the leave section of incremental sync",
             )
          } 0 .. 20 );
       })->then( sub {
-         matrix_sync( $user_b, filter => $filter_id_b, since => $user_b->sync_next_batch );
+         matrix_sync_again( $user_b, filter => $filter_id_b );
       })->then( sub {
          my ( $body ) = @_;
 

--- a/tests/31sync/10archived-ban.pl
+++ b/tests/31sync/10archived-ban.pl
@@ -47,7 +47,7 @@ test "Newly banned rooms appear in the leave section of incremental sync",
    check => sub {
       my ( $user_a, $user_b ) = @_;
 
-      my ( $filter_id_a, $filter_id_b, $room_id, $next_b );
+      my ( $filter_id_a, $filter_id_b, $room_id );
 
       my $filter = { room => { include_leave => JSON::true } };
 
@@ -65,17 +65,13 @@ test "Newly banned rooms appear in the leave section of incremental sync",
       })->then( sub {
          matrix_sync( $user_b, filter => $filter_id_b );
       })->then( sub {
-         my ( $body ) = @_;
-
-         $next_b = $body->{next_batch};
-
          do_request_json_for( $user_a,
             method => "POST",
             uri    => "/api/v1/rooms/$room_id/ban",
             content => { user_id => $user_b->user_id, reason => "testing" },
          );
       })->then( sub {
-         matrix_sync( $user_b, filter => $filter_id_b, since => $next_b );
+         matrix_sync( $user_b, filter => $filter_id_b, since => $user_b->sync_next_batch );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -94,7 +90,7 @@ test "Newly banned rooms appear in the leave section of incremental sync",
    check => sub {
       my ( $user_a, $user_b ) = @_;
 
-      my ( $filter_id_a, $filter_id_b, $room_id, $next_b );
+      my ( $filter_id_a, $filter_id_b, $room_id );
 
       my $filter = { room => { include_leave => JSON::true } };
 
@@ -112,10 +108,6 @@ test "Newly banned rooms appear in the leave section of incremental sync",
       })->then( sub {
          matrix_sync( $user_b, filter => $filter_id_b );
       })->then( sub {
-         my ( $body ) = @_;
-
-         $next_b = $body->{next_batch};
-
          do_request_json_for( $user_a,
             method => "POST",
             uri    => "/api/v1/rooms/$room_id/ban",
@@ -129,7 +121,7 @@ test "Newly banned rooms appear in the leave section of incremental sync",
             )
          } 0 .. 20 );
       })->then( sub {
-         matrix_sync( $user_b, filter => $filter_id_b, since => $next_b );
+         matrix_sync( $user_b, filter => $filter_id_b, since => $user_b->sync_next_batch );
       })->then( sub {
          my ( $body ) = @_;
 

--- a/tests/31sync/11typing.pl
+++ b/tests/31sync/11typing.pl
@@ -55,7 +55,7 @@ test "Typing events appear in incremental sync",
    check => sub {
       my ( $user ) = @_;
 
-      my ( $filter_id, $room_id, $next );
+      my ( $filter_id, $room_id );
 
       my $filter = {
          room => {
@@ -75,13 +75,9 @@ test "Typing events appear in incremental sync",
 
          matrix_sync( $user, filter => $filter_id );
       })->then( sub {
-         my ( $body ) = @_;
-
-         $next = $body->{next_batch};
-
          matrix_typing( $user, $room_id, typing => 1, timeout => 30000 );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $next );
+         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -110,7 +106,7 @@ test "Typing events appear in gapped sync",
    check => sub {
       my ( $user ) = @_;
 
-      my ( $filter_id, $room_id, $next );
+      my ( $filter_id, $room_id );
 
       my $filter = {
          room => {
@@ -130,10 +126,6 @@ test "Typing events appear in gapped sync",
 
          matrix_sync( $user, filter => $filter_id );
       })->then( sub {
-         my ( $body ) = @_;
-
-         $next = $body->{next_batch};
-
          matrix_typing( $user, $room_id, typing => 1, timeout => 30000 );
       })->then( sub {
          Future->needs_all( map {
@@ -143,7 +135,7 @@ test "Typing events appear in gapped sync",
             )
          } 0 .. 20 );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $next );
+         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
       })->then( sub {
          my ( $body ) = @_;
 

--- a/tests/31sync/11typing.pl
+++ b/tests/31sync/11typing.pl
@@ -77,7 +77,7 @@ test "Typing events appear in incremental sync",
       })->then( sub {
          matrix_typing( $user, $room_id, typing => 1, timeout => 30000 );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
+         matrix_sync_again( $user, filter => $filter_id );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -135,7 +135,7 @@ test "Typing events appear in gapped sync",
             )
          } 0 .. 20 );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
+         matrix_sync_again( $user, filter => $filter_id );
       })->then( sub {
          my ( $body ) = @_;
 

--- a/tests/31sync/12receipts.pl
+++ b/tests/31sync/12receipts.pl
@@ -85,7 +85,7 @@ test "New read receipts appear in incremental v2 /sync",
       })->then( sub {
          matrix_advance_room_receipt( $user, $room_id, "m.read", $event_id );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
+         matrix_sync_again( $user, filter => $filter_id );
       })->then( sub {
          my ( $body ) = @_;
 

--- a/tests/31sync/12receipts.pl
+++ b/tests/31sync/12receipts.pl
@@ -59,7 +59,7 @@ test "New read receipts appear in incremental v2 /sync",
    check => sub {
       my ( $user ) = @_;
 
-      my ( $filter_id, $room_id, $event_id, $next_batch );
+      my ( $filter_id, $room_id, $event_id );
 
       my $filter = {
          presence => { types => [] },
@@ -83,13 +83,9 @@ test "New read receipts appear in incremental v2 /sync",
 
          matrix_sync( $user, filter => $filter_id );
       })->then( sub {
-         my ( $body ) = @_;
-
-         $next_batch = $body->{next_batch};
-
          matrix_advance_room_receipt( $user, $room_id, "m.read", $event_id );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $next_batch );
+         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
       })->then( sub {
          my ( $body ) = @_;
 

--- a/tests/42tags.pl
+++ b/tests/42tags.pl
@@ -327,7 +327,7 @@ test "Newly updated tags appear in an incremental v2 /sync",
    do => sub {
       my ( $user ) = @_;
 
-      my ( $room_id, $filter_id, $next_batch );
+      my ( $room_id, $filter_id );
 
       my $filter = {};
 
@@ -340,13 +340,9 @@ test "Newly updated tags appear in an incremental v2 /sync",
 
          matrix_sync( $user, $filter => $filter_id );
       })->then( sub {
-         my ( $body ) = @_;
-
-         $next_batch = $body->{next_batch};
-
          matrix_add_tag( $user, $room_id, "test_tag", { order => 1 } );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $next_batch );
+         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -366,7 +362,7 @@ test "Deleted tags appear in an incremental v2 /sync",
    do => sub {
       my ( $user ) = @_;
 
-      my ( $room_id, $filter_id, $next_batch );
+      my ( $room_id, $filter_id );
 
       my $filter = {};
 
@@ -379,21 +375,13 @@ test "Deleted tags appear in an incremental v2 /sync",
 
          matrix_sync( $user, $filter => $filter_id );
       })->then( sub {
-         my ( $body ) = @_;
-
-         $next_batch = $body->{next_batch};
-
          matrix_add_tag( $user, $room_id, "test_tag", { order => 1 } );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $next_batch );
+         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
       })->then( sub {
-         my ( $body ) = @_;
-
-         $next_batch = $body->{next_batch};
-
          matrix_remove_tag( $user, $room_id, "test_tag" );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $next_batch );
+         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
       })->then( sub {
          my ( $body ) = @_;
 

--- a/tests/42tags.pl
+++ b/tests/42tags.pl
@@ -342,7 +342,7 @@ test "Newly updated tags appear in an incremental v2 /sync",
       })->then( sub {
          matrix_add_tag( $user, $room_id, "test_tag", { order => 1 } );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
+         matrix_sync_again( $user, filter => $filter_id );
       })->then( sub {
          my ( $body ) = @_;
 
@@ -377,11 +377,11 @@ test "Deleted tags appear in an incremental v2 /sync",
       })->then( sub {
          matrix_add_tag( $user, $room_id, "test_tag", { order => 1 } );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
+         matrix_sync_again( $user, filter => $filter_id );
       })->then( sub {
          matrix_remove_tag( $user, $room_id, "test_tag" );
       })->then( sub {
-         matrix_sync( $user, filter => $filter_id, since => $user->sync_next_batch );
+         matrix_sync_again( $user, filter => $filter_id );
       })->then( sub {
          my ( $body ) = @_;
 

--- a/tests/44account_data.pl
+++ b/tests/44account_data.pl
@@ -245,7 +245,7 @@ test "New account data appears in incremental v2 /sync",
             $user, $room_id, "my.changing.type", "cats", "rats"
          ),
       })->then( sub {
-         matrix_sync( $user, since => $user->sync_next_batch );
+         matrix_sync_again( $user );
       })->then( sub {
          my ( $body ) = @_;
 

--- a/tests/44account_data.pl
+++ b/tests/44account_data.pl
@@ -231,8 +231,6 @@ test "New account data appears in incremental v2 /sync",
    check => sub {
       my ( $user, $room_id ) = @_;
 
-      my ( $next_batch );
-
       Future->needs_all(
          setup_incremental_account_data(
             $user, $room_id, "my.unchanging.type", "lions", "tigers"
@@ -243,15 +241,11 @@ test "New account data appears in incremental v2 /sync",
       )->then( sub {
          matrix_sync( $user );
       })->then( sub {
-         my ( $body ) = @_;
-
-         $next_batch = $body->{next_batch};
-
          setup_incremental_account_data(
             $user, $room_id, "my.changing.type", "cats", "rats"
          ),
       })->then( sub {
-         matrix_sync( $user, since => $next_batch );
+         matrix_sync( $user, since => $user->sync_next_batch );
       })->then( sub {
          my ( $body ) = @_;
 

--- a/tests/60app-services/00prepare.pl
+++ b/tests/60app-services/00prepare.pl
@@ -9,7 +9,7 @@ our $AS_USER = fixture(
       my ( $http, $as_user_info ) = @_;
 
       Future->done( User( $http, $as_user_info->user_id, $as_user_info->as2hs_token,
-            undef, undef, [], undef ) );
+            undef, undef, undef, [], undef ) );
    },
 );
 

--- a/tests/60app-services/01as-create.pl
+++ b/tests/60app-services/01as-create.pl
@@ -166,7 +166,7 @@ sub matrix_register_as_ghost
 
       # TODO: user has no event stream yet. Should they?
       Future->done(
-         User( $as_user->http, $body->{user_id}, $body->{access_token}, undef, undef, [], undef )
+         User( $as_user->http, $body->{user_id}, $body->{access_token}, undef, undef, undef, [], undef )
       );
    });
 }


### PR DESCRIPTION
Abstract away the manual handling of sync batch tokens into the `matrix_sync` and newly-added `matrix_sync_again` helper functions. Avoids having to capture and share a lexical to store the token between multiple stages of a test.