### PR TITLE
Bugfix presence+sync test

### DIFF
--- a/tests/10apidoc/20presence.pl
+++ b/tests/10apidoc/20presence.pl
@@ -1,5 +1,28 @@
 my $fixture = local_user_fixture();
 
+push our @EXPORT, qw( matrix_set_presence_status );
+
+=head2 matrix_set_presence_status
+
+   matrix_set_presence_status( $user, $presence, %params )
+
+Sets the presence status of the given C<$user> to C<$presence>, with optional
+additional parameters (such as C<status_msg>) given in C<%params>.
+
+=cut
+
+sub matrix_set_presence_status
+{
+   my ( $user, $presence, %params ) = @_;
+
+   do_request_json_for( $user,
+      method => "PUT",
+      uri    => "/api/v1/presence/:user_id/status",
+
+      content => { presence => $presence, %params }
+   )->then_done();
+}
+
 test "GET /presence/:user_id/status fetches initial status",
    requires => [ $fixture ],
 
@@ -34,14 +57,8 @@ test "PUT /presence/:user_id/status updates my presence",
    do => sub {
       my ( $user ) = @_;
 
-      do_request_json_for( $user,
-         method => "PUT",
-         uri    => "/api/v1/presence/:user_id/status",
-
-         content => {
-            presence   => "online",
-            status_msg => $status_msg,
-         },
+      matrix_set_presence_status( $user, "online",
+         status_msg => $status_msg,
       )
    },
 

--- a/tests/10apidoc/20presence.pl
+++ b/tests/10apidoc/20presence.pl
@@ -1,6 +1,26 @@
 my $fixture = local_user_fixture();
 
-push our @EXPORT, qw( matrix_set_presence_status );
+push our @EXPORT, qw( matrix_get_presence_status matrix_set_presence_status );
+
+=head2 matrix_get_presence_status
+
+   $status = matrix_get_presence_status( $user )
+
+Returns a HASH reference containing the user's presence status. This will
+contain a C<presence> field, and optionally a C<status_msg> field as well if
+the user has one set.
+
+=cut
+
+sub matrix_get_presence_status
+{
+   my ( $user ) = @_;
+
+   do_request_json_for( $user,
+      method => "GET",
+      uri    => "/api/v1/presence/:user_id/status",
+   );
+}
 
 =head2 matrix_set_presence_status
 
@@ -29,10 +49,7 @@ test "GET /presence/:user_id/status fetches initial status",
    check => sub {
       my ( $user ) = @_;
 
-      do_request_json_for( $user,
-         method => "GET",
-         uri    => "/api/v1/presence/:user_id/status",
-      )->then( sub {
+      matrix_get_presence_status( $user )->then( sub {
          my ( $body ) = @_;
 
          assert_json_keys( $body, qw( presence ));
@@ -65,10 +82,7 @@ test "PUT /presence/:user_id/status updates my presence",
    check => sub {
       my ( $user ) = @_;
 
-      do_request_json_for( $user,
-         method => "GET",
-         uri    => "/api/v1/presence/:user_id/status",
-      )->then( sub {
+      matrix_get_presence_status( $user )->then( sub {
          my ( $body ) = @_;
 
          ( $body->{status_msg} // "" ) eq $status_msg or

--- a/tests/21presence-events.pl
+++ b/tests/21presence-events.pl
@@ -42,11 +42,8 @@ test "Presence change reports an event to myself",
    do => sub {
       my ( $user ) = @_;
 
-      do_request_json_for( $user,
-         method => "PUT",
-         uri    => "/api/v1/presence/:user_id/status",
-
-         content => { presence => "online", status_msg => $status_msg },
+      matrix_set_presence_status( $user, "online",
+         status_msg => $status_msg,
       )->then( sub {
          await_event_for( $user, filter => sub {
             my ( $event ) = @_;
@@ -79,11 +76,8 @@ test "Friends presence changes reports events",
             invite => [ $friend->user_id ],
          }
       )->then( sub {
-         do_request_json_for( $friend,
-            method => "PUT",
-            uri    => "/api/v1/presence/:user_id/status",
-
-            content => { presence => "online", status_msg => $friend_status },
+         matrix_set_presence_status( $friend, "online",
+            status_msg => $friend_status,
          );
       })->then( sub {
          await_event_for( $user, filter => sub {

--- a/tests/30rooms/60anonymousaccess.pl
+++ b/tests/30rooms/60anonymousaccess.pl
@@ -132,15 +132,11 @@ test "Anonymous user can call /events on world_readable room",
             my ( $stream_token ) = @_;
 
             Future->needs_all(
-               do_request_json_for( $user_not_in_room,
-                  method  => "PUT",
-                  uri     => "/api/v1/presence/:user_id/status",
-                  content => { presence => "online", status_msg => "Worshiping lemurs' tails" },
+               matrix_set_presence_status( $user_not_in_room, "online",
+                  status_msg => "Worshiping lemurs' tails",
                ),
-               do_request_json_for( $user,
-                  method  => "PUT",
-                  uri     => "/api/v1/presence/:user_id/status",
-                  content => { presence => "online", status_msg => "Worshiping lemurs' tails" },
+               matrix_set_presence_status( $user, "online",
+                  status_msg => "Worshiping lemurs' tails",
                ),
 
                await_event_not_presence_for( $anonymous_user, $room_id, [ $user ] )->then( sub {

--- a/tests/31sync/05presence.pl
+++ b/tests/31sync/05presence.pl
@@ -60,6 +60,15 @@ test "User is offline if they set_presence=offline in their sync",
                or die "Expected to be offline";
          }
 
+         # Additionally my presence should still be "offline"
+         # But we can't assert on that yet - see SYT-34
+         #
+         # matrix_get_presence_status( $user );
+         #    ->then( sub {
+         #    my ( $status ) = @_;
+         #    assert_eq( $status->{presence}, "offline" );
+         # });
+
          Future->done(1);
       })
    };

--- a/tests/31sync/05presence.pl
+++ b/tests/31sync/05presence.pl
@@ -34,8 +34,6 @@ test "User sees their own presence in a sync",
 test "User is offline if they set_presence=offline in their sync",
    requires => [ local_user_fixture( with_events => 0 ),
                  qw( can_sync ) ],
-   # This test passes if we set a displayname for the user.
-   bug => "SYT-47",
 
    check => sub {
       my ( $user ) = @_;
@@ -51,13 +49,16 @@ test "User is offline if they set_presence=offline in their sync",
       })->then( sub {
          my ( $body ) = @_;
 
-         my $events = $body->{presence}{events};
-         my $presence = first { $_->{type} eq "m.presence" } @$events
-            or die "Expected to see our own presence";
+         # Either I'm absent entirely, or I'm present in state "offline"; but
+         # I shouldn't be "online"
 
-         $presence->{sender} eq $user->user_id or die "Unexpected sender";
-         $presence->{content}{presence} eq "offline"
-            or die "Expected to be offline";
+         my $events = $body->{presence}{events};
+
+         if( my $presence = first { $_->{type} eq "m.presence" } @$events ) {
+            $presence->{sender} eq $user->user_id or die "Unexpected sender";
+            $presence->{content}{presence} eq "offline"
+               or die "Expected to be offline";
+         }
 
          Future->done(1);
       })

--- a/tests/31sync/05presence.pl
+++ b/tests/31sync/05presence.pl
@@ -54,8 +54,11 @@ test "User is offline if they set_presence=offline in their sync",
 
          my $events = $body->{presence}{events};
 
-         if( my $presence = first { $_->{type} eq "m.presence" } @$events ) {
-            $presence->{sender} eq $user->user_id or die "Unexpected sender";
+         my $presence = first {
+            $_->{type} eq "m.presence" and $_->{sender} eq $user->user_id
+         } @$events;
+
+         if( $presence ) {
             $presence->{content}{presence} eq "offline"
                or die "Expected to be offline";
          }

--- a/tests/40presence.pl
+++ b/tests/40presence.pl
@@ -21,11 +21,8 @@ test "Presence changes are reported to local room members",
    do => sub {
       my ( $senduser, $local_user, undef ) = @_;
 
-      do_request_json_for( $senduser,
-         method => "PUT",
-         uri    => "/api/v1/presence/:user_id/status",
-
-         content => { presence => "online", status_msg => $status_msg },
+      matrix_set_presence_status( $senduser, "online",
+         status_msg => $status_msg,
       )->then( sub {
          Future->needs_all( map {
             my $recvuser = $_;
@@ -86,12 +83,7 @@ test "Presence changes to OFFLINE are reported to local room members",
    do => sub {
       my ( $senduser, $local_user, undef ) = @_;
 
-      do_request_json_for( $senduser,
-         method => "PUT",
-         uri    => "/api/v1/presence/:user_id/status",
-
-         content => { presence => "offline" },
-      )->then( sub {
+      matrix_set_presence_status( $senduser, "offline" )->then( sub {
          Future->needs_all( map {
             my $recvuser = $_;
 


### PR DESCRIPTION
This fix removes an expected-fail condition. The previous test logic was in fact broken, and the synapse behaviour seems to be correct.

This PR actually contains two independent changes - the added helper functions, and a change to the test that would use them but doesn't yet due to a different bug. I hope to fix that one next.