### PR TITLE
Use exists test on a hash key instead of 'all' iteration

### DIFF
--- a/tests/30rooms/60anonymousaccess.pl
+++ b/tests/30rooms/60anonymousaccess.pl
@@ -563,10 +563,11 @@ sub check_events
 
       my $found = 0;
       foreach my $event ( @{ $body->{chunk} } ) {
-         next if all { $_ ne "content" } keys %{ $event };
-         next if all { $_ ne "body" } keys %{ $event->{content} };
-         $found = 1 if $event->{content}->{body} eq "public";
-         die "Should not have found private" if $event->{content}->{body} eq "private";
+         next if !exists $event->{content};
+         next if !exists $event->{content}{body};
+
+         $found = 1 if $event->{content}{body} eq "public";
+         die "Should not have found private" if $event->{content}{body} eq "private";
       }
 
       Future->done( $found );


### PR DESCRIPTION
Rewrote test logic (I just found it because I was looking for other places where `all { ... }` is used).

Also adjusted formatting of later lines to elide the implied `->` deref arrow