### PR TITLE
Use a longer timeout, 60s, for test setup.

### DIFF
--- a/run-tests.pl
+++ b/run-tests.pl
@@ -434,9 +434,11 @@ sub _run_test
 
    my $success = eval {
       my @reqs;
-      my $f_test = Future->needs_all( @req_futures )
+      my $f_setup = Future->needs_all( @req_futures )
          ->on_done( sub { @reqs = @_ } )
          ->on_fail( sub { die "fixture failed - $_[0]\n" } );
+
+      my $f_test = $f_setup;
 
       my $check = $test->check;
       if( my $do = $test->do ) {
@@ -469,6 +471,12 @@ sub _run_test
             Future->done;
          });
       }
+
+      Future->wait_any(
+         $f_setup,
+         $loop->delay_future( after => 60 )
+            ->then_fail( "Timed out waiting for setup" )
+      )->get;
 
       Future->wait_any(
          $f_test,


### PR DESCRIPTION
Test setup can include starting synapse. On slower hardware, e.g my
workstation, this can take ~10s causing the first tests to timeout.

Using a separate timeout for the setup part of running a test and by
not counting the test setup time when tracking test exectuion should
prevent this from happening