### PR TITLE
Use r0 not api/v1 or v2_alpha

### DIFF
--- a/tests/10apidoc/01register.pl
+++ b/tests/10apidoc/01register.pl
@@ -92,7 +92,7 @@ sub matrix_register_user
          $f = $f->then( sub {
             $http->do_request_json(
                method => "GET",
-               uri    => "/api/v1/events",
+               uri    => "/r0/events",
                params => { access_token => $access_token, timeout => 0 },
             )
          })->on_done( sub {
@@ -130,7 +130,7 @@ sub local_user_fixture
             my $user = $f->get;
             do_request_json_for( $user,
                method => "PUT",
-               uri    => "/api/v1/profile/:user_id/displayname",
+               uri    => "/r0/profile/:user_id/displayname",
 
                content => { displayname => $displayname },
             )->then_done( $user );
@@ -141,7 +141,7 @@ sub local_user_fixture
             my $user = $f->get;
             do_request_json_for( $user,
                method => "PUT",
-               uri    => "/api/v1/profile/:user_id/avatar_url",
+               uri    => "/r0/profile/:user_id/avatar_url",
 
                content => { avatar_url => $avatar_url },
             )->then_done( $user );
@@ -152,7 +152,7 @@ sub local_user_fixture
             my $user = $f->get;
             do_request_json_for( $user,
                method => "PUT",
-               uri    => "/api/v1/presence/:user_id/status",
+               uri    => "/r0/presence/:user_id/status",
 
                content => {
                   presence   => $presence,

--- a/tests/10apidoc/02login.pl
+++ b/tests/10apidoc/02login.pl
@@ -35,7 +35,7 @@ test "GET /login yields a set of flows",
       my ( $http ) = @_;
 
       $http->do_request_json(
-         uri => "/api/v1/login",
+         uri => "/r0/login",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -75,7 +75,7 @@ test "POST /login can log in as a user",
 
       $http->do_request_json(
          method => "POST",
-         uri    => "/api/v1/login",
+         uri    => "/r0/login",
 
          content => {
             type     => "m.login.password",
@@ -103,7 +103,7 @@ test "POST /login wrong password is rejected",
 
       $http->do_request_json(
          method => "POST",
-         uri    => "/api/v1/login",
+         uri    => "/r0/login",
 
          content => {
             type     => "m.login.password",
@@ -136,7 +136,7 @@ test "POST /tokenrefresh invalidates old refresh token",
 
       $http->do_request_json(
          method => "POST",
-         uri    => "/api/v1/login",
+         uri    => "/r0/login",
 
          content => {
             type     => "m.login.password",

--- a/tests/10apidoc/03events-initial.pl
+++ b/tests/10apidoc/03events-initial.pl
@@ -11,7 +11,7 @@ test "GET /events initially",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/api/v1/events",
+         uri    => "/r0/events",
          params => { timeout => 0 },
       )->then( sub {
          my ( $body ) = @_;
@@ -39,7 +39,7 @@ test "GET /initialSync initially",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/api/v1/initialSync",
+         uri    => "/r0/initialSync",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -63,7 +63,7 @@ sub matrix_initialsync
 
    do_request_json_for( $user,
       method => "GET",
-      uri    => "/api/v1/initialSync",
+      uri    => "/r0/initialSync",
 
       params => {
          ( map { defined $args{$_} ? ( $_ => $args{$_} ) : () }
@@ -82,7 +82,7 @@ sub GET_new_events_for
    return $user->pending_get_events //=
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/api/v1/events",
+         uri    => "/r0/events",
          params => {
             %params,
             from    => $user->eventstream_token,
@@ -114,7 +114,7 @@ sub flush_events_for
 
    do_request_json_for( $user,
       method => "GET",
-      uri    => "/api/v1/events",
+      uri    => "/r0/events",
       params => {
          timeout => 0,
       }
@@ -181,7 +181,7 @@ sub matrix_sync
 
    do_request_json_for( $user,
       method  => "GET",
-      uri     => "/v2_alpha/sync",
+      uri     => "/r0/sync",
       params  => \%params,
    )->on_done( sub {
       my ( $body ) = @_;

--- a/tests/10apidoc/10profile-displayname.pl
+++ b/tests/10apidoc/10profile-displayname.pl
@@ -12,7 +12,7 @@ test "PUT /profile/:user_id/displayname sets my name",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/api/v1/profile/:user_id/displayname",
+         uri    => "/r0/profile/:user_id/displayname",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -30,7 +30,7 @@ test "PUT /profile/:user_id/displayname sets my name",
 
       do_request_json_for( $user,
          method => "PUT",
-         uri    => "/api/v1/profile/:user_id/displayname",
+         uri    => "/r0/profile/:user_id/displayname",
 
          content => {
             displayname => $displayname,
@@ -50,7 +50,7 @@ test "GET /profile/:user_id/displayname publicly accessible",
 
       $http->do_request_json(
          method => "GET",
-         uri    => "/api/v1/profile/$user_id/displayname",
+         uri    => "/r0/profile/$user_id/displayname",
          # no access_token
       )->then( sub {
          my ( $body ) = @_;

--- a/tests/10apidoc/11profile-avatar_url.pl
+++ b/tests/10apidoc/11profile-avatar_url.pl
@@ -12,7 +12,7 @@ test "PUT /profile/:user_id/avatar_url sets my avatar",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/api/v1/profile/:user_id/avatar_url",
+         uri    => "/r0/profile/:user_id/avatar_url",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -30,7 +30,7 @@ test "PUT /profile/:user_id/avatar_url sets my avatar",
 
       do_request_json_for( $user,
          method => "PUT",
-         uri    => "/api/v1/profile/:user_id/avatar_url",
+         uri    => "/r0/profile/:user_id/avatar_url",
 
          content => {
             avatar_url => $avatar_url,
@@ -48,7 +48,7 @@ test "GET /profile/:user_id/avatar_url publicly accessible",
 
       $http->do_request_json(
          method => "GET",
-         uri    => "/api/v1/profile/$user_id/avatar_url",
+         uri    => "/r0/profile/$user_id/avatar_url",
          # no access_token
       )->then( sub {
          my ( $body ) = @_;

--- a/tests/10apidoc/20presence.pl
+++ b/tests/10apidoc/20presence.pl
@@ -18,7 +18,7 @@ sub matrix_get_presence_status
 
    do_request_json_for( $user,
       method => "GET",
-      uri    => "/api/v1/presence/:user_id/status",
+      uri    => "/r0/presence/:user_id/status",
    );
 }
 
@@ -37,7 +37,7 @@ sub matrix_set_presence_status
 
    do_request_json_for( $user,
       method => "PUT",
-      uri    => "/api/v1/presence/:user_id/status",
+      uri    => "/r0/presence/:user_id/status",
 
       content => { presence => $presence, %params }
    )->then_done();

--- a/tests/10apidoc/21presence-list.pl
+++ b/tests/10apidoc/21presence-list.pl
@@ -1,5 +1,5 @@
 # Eventually this will be changed; see SPEC-53
-my $PRESENCE_LIST_URI = "/api/v1/presence/list/:user_id";
+my $PRESENCE_LIST_URI = "/r0/presence/list/:user_id";
 
 my $fixture = local_user_fixture();
 my $friend_fixture = local_user_fixture();

--- a/tests/10apidoc/30room-create.pl
+++ b/tests/10apidoc/30room-create.pl
@@ -14,7 +14,7 @@ test "POST /createRoom makes a public room",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/api/v1/createRoom",
+         uri    => "/r0/createRoom",
 
          content => {
             visibility      => "public",
@@ -57,7 +57,7 @@ test "POST /createRoom makes a private room",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/api/v1/createRoom",
+         uri    => "/r0/createRoom",
 
          content => {
             visibility => "private",
@@ -83,7 +83,7 @@ test "POST /createRoom makes a private room with invites",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/api/v1/createRoom",
+         uri    => "/r0/createRoom",
 
          content => {
             visibility => "private",
@@ -109,7 +109,7 @@ sub matrix_create_room
 
    do_request_json_for( $user,
       method => "POST",
-      uri    => "/api/v1/createRoom",
+      uri    => "/r0/createRoom",
 
       content => {
          visibility => $opts{visibility} || "public",

--- a/tests/10apidoc/31room-state.pl
+++ b/tests/10apidoc/31room-state.pl
@@ -27,7 +27,7 @@ test "GET /rooms/:room_id/state/m.room.member/:user_id fetches my membership",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/api/v1/rooms/$room_id/state/m.room.member/:user_id",
+         uri    => "/r0/rooms/$room_id/state/m.room.member/:user_id",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -50,7 +50,7 @@ test "GET /rooms/:room_id/state/m.room.power_levels fetches powerlevels",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/api/v1/rooms/$room_id/state/m.room.power_levels",
+         uri    => "/r0/rooms/$room_id/state/m.room.power_levels",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -98,7 +98,7 @@ test "GET /publicRooms lists newly-created room",
 
       $http->do_request_json(
          method => "GET",
-         uri    => "/api/v1/publicRooms",
+         uri    => "/r0/publicRooms",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -129,7 +129,7 @@ test "GET /directory/room/:room_alias yields room ID",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/api/v1/directory/room/$room_alias",
+         uri    => "/r0/directory/room/$room_alias",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -153,7 +153,7 @@ test "POST /rooms/:room_id/state/m.room.name sets name",
 
       do_request_json_for( $user,
          method => "PUT",
-         uri    => "/api/v1/rooms/$room_id/state/m.room.name",
+         uri    => "/r0/rooms/$room_id/state/m.room.name",
 
          content => { name => $name },
       );
@@ -188,7 +188,7 @@ test "GET /rooms/:room_id/state/m.room.name gets name",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/api/v1/rooms/$room_id/state/m.room.name",
+         uri    => "/r0/rooms/$room_id/state/m.room.name",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -214,7 +214,7 @@ test "POST /rooms/:room_id/state/m.room.topic sets topic",
 
       do_request_json_for( $user,
          method => "PUT",
-         uri    => "/api/v1/rooms/$room_id/state/m.room.topic",
+         uri    => "/r0/rooms/$room_id/state/m.room.topic",
 
          content => { topic => $topic },
       );
@@ -249,7 +249,7 @@ test "GET /rooms/:room_id/state/m.room.topic gets topic",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/api/v1/rooms/$room_id/state/m.room.topic",
+         uri    => "/r0/rooms/$room_id/state/m.room.topic",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -272,7 +272,7 @@ test "GET /rooms/:room_id/state fetches entire room state",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/api/v1/rooms/$room_id/state",
+         uri    => "/r0/rooms/$room_id/state",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -299,7 +299,7 @@ test "POST /createRoom with creation content",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/api/v1/createRoom",
+         uri    => "/r0/createRoom",
 
          content => {
             creation_content => {
@@ -314,7 +314,7 @@ test "POST /createRoom with creation content",
 
          do_request_json_for( $user,
             method => "GET",
-            uri    => "/api/v1/rooms/$room_id/state/m.room.create",
+            uri    => "/r0/rooms/$room_id/state/m.room.create",
          )
       })->then( sub {
          my ( $state ) = @_;
@@ -343,7 +343,7 @@ sub matrix_get_room_state
    do_request_json_for( $user,
       method => "GET",
       uri    => join( "/",
-         "/api/v1/rooms/$room_id/state", grep { defined } $opts{type}, $opts{state_key}
+         "/r0/rooms/$room_id/state", grep { defined } $opts{type}, $opts{state_key}
       ),
    );
 }
@@ -362,7 +362,7 @@ sub matrix_put_room_state
    do_request_json_for( $user,
       method => "PUT",
       uri    => join( "/",
-         "/api/v1/rooms/$room_id/state", grep { defined } $opts{type}, $opts{state_key}
+         "/r0/rooms/$room_id/state", grep { defined } $opts{type}, $opts{state_key}
       ),
 
       content => $opts{content},
@@ -392,7 +392,7 @@ sub matrix_initialsync_room
 
    do_request_json_for( $user,
       method => "GET",
-      uri    => "/api/v1/rooms/$room_id/initialSync",
+      uri    => "/r0/rooms/$room_id/initialSync",
       params => \%params,
    );
 }

--- a/tests/10apidoc/32room-alias.pl
+++ b/tests/10apidoc/32room-alias.pl
@@ -23,7 +23,7 @@ test "PUT /directory/room/:room_alias creates alias",
 
       do_request_json_for( $user,
          method => "PUT",
-         uri    => "/api/v1/directory/room/$room_alias",
+         uri    => "/r0/directory/room/$room_alias",
 
          content => {
             room_id => $room_id,
@@ -36,7 +36,7 @@ test "PUT /directory/room/:room_alias creates alias",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/api/v1/directory/room/$room_alias",
+         uri    => "/r0/directory/room/$room_alias",
       )->then( sub {
          my ( $body ) = @_;
 

--- a/tests/10apidoc/33room-members.pl
+++ b/tests/10apidoc/33room-members.pl
@@ -28,7 +28,7 @@ test "POST /rooms/:room_id/join can join a room",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/api/v1/rooms/$room_id/join",
+         uri    => "/r0/rooms/$room_id/join",
 
          content => {},
       );
@@ -59,7 +59,7 @@ sub matrix_join_room
 
    do_request_json_for( $user,
       method => "POST",
-      uri    => "/api/v1/join/$room",
+      uri    => "/r0/join/$room",
 
       content => {},
    )->then_done(1);
@@ -76,7 +76,7 @@ test "POST /join/:room_alias can join a room",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/api/v1/join/$room_alias",
+         uri    => "/r0/join/$room_alias",
 
          content => {},
       )->then( sub {
@@ -114,7 +114,7 @@ test "POST /join/:room_id can join a room",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/api/v1/join/$room_id",
+         uri    => "/r0/join/$room_id",
 
          content => {},
       )->then( sub {
@@ -157,7 +157,7 @@ test "POST /rooms/:room_id/leave can leave a room",
       ->then( sub {
          do_request_json_for( $joiner_to_leave,
             method => "POST",
-            uri    => "/api/v1/rooms/$room_id/leave",
+            uri    => "/r0/rooms/$room_id/leave",
 
             content => {},
          );
@@ -195,7 +195,7 @@ sub matrix_leave_room
 
    do_request_json_for( $user,
       method => "POST",
-      uri    => "/api/v1/rooms/$room_id/leave",
+      uri    => "/r0/rooms/$room_id/leave",
 
       content => {},
    )->then_done(1);
@@ -212,7 +212,7 @@ test "POST /rooms/:room_id/invite can send an invite",
 
       do_request_json_for( $creator,
          method => "POST",
-         uri    => "/api/v1/rooms/$room_id/invite",
+         uri    => "/r0/rooms/$room_id/invite",
 
          content => { user_id => $invited_user->user_id },
       );
@@ -255,7 +255,7 @@ sub matrix_invite_user_to_room
 
    do_request_json_for( $user,
       method => "POST",
-      uri    => "/api/v1/rooms/$room_id/invite",
+      uri    => "/r0/rooms/$room_id/invite",
 
       content => { user_id => $invitee_id }
    )->then_done(1);
@@ -272,7 +272,7 @@ test "POST /rooms/:room_id/ban can ban a user",
 
       do_request_json_for( $creator,
          method => "POST",
-         uri    => "/api/v1/rooms/$room_id/ban",
+         uri    => "/r0/rooms/$room_id/ban",
 
          content => {
             user_id => $banned_user->user_id,
@@ -336,7 +336,7 @@ sub matrix_create_and_join_room
             my $user = shift;
             do_request_json_for( $user,
                method => "POST",
-               uri    => "/api/v1/join/$room_alias_fullname",
+               uri    => "/r0/join/$room_alias_fullname",
 
                content => {},
             )
@@ -346,7 +346,7 @@ sub matrix_create_and_join_room
             my $user = $_;
             do_request_json_for( $user,
                method => "POST",
-               uri    => "/api/v1/join/$room_alias_fullname",
+               uri    => "/r0/join/$room_alias_fullname",
 
                content => {},
             )

--- a/tests/10apidoc/34room-messages.pl
+++ b/tests/10apidoc/34room-messages.pl
@@ -8,7 +8,7 @@ test "POST /rooms/:room_id/send/:event_type sends a message",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/api/v1/rooms/$room_id/send/m.room.message",
+         uri    => "/r0/rooms/$room_id/send/m.room.message",
 
          content => { msgtype => "m.message", body => "Here is the message content" },
       )->then( sub {
@@ -34,7 +34,7 @@ sub matrix_send_room_message
    my $type = $opts{type} // "m.room.message";
 
    my $method = "POST";
-   my $uri = "/api/v1/rooms/$room_id/send/$type";
+   my $uri = "/r0/rooms/$room_id/send/$type";
 
    if( defined $opts{txn_id} ) {
       $method = "PUT";
@@ -84,7 +84,7 @@ test "GET /rooms/:room_id/messages returns a message",
       )->then( sub {
          do_request_json_for( $user,
             method => "GET",
-            uri    => "/api/v1/rooms/$room_id/messages",
+            uri    => "/r0/rooms/$room_id/messages",
 
             # With no params this does "forwards from END"; i.e. nothing useful
             params => { dir => "b" },
@@ -113,7 +113,7 @@ sub matrix_get_room_messages
 
    do_request_json_for( $user,
       method => "GET",
-      uri    => "/api/v1/rooms/$room_id/messages",
+      uri    => "/r0/rooms/$room_id/messages",
 
       params => \%params,
    );

--- a/tests/10apidoc/35room-typing.pl
+++ b/tests/10apidoc/35room-typing.pl
@@ -8,7 +8,7 @@ test "PUT /rooms/:room_id/typing/:user_id sets typing notification",
 
       do_request_json_for( $user,
          method => "PUT",
-         uri    => "/api/v1/rooms/$room_id/typing/:user_id",
+         uri    => "/r0/rooms/$room_id/typing/:user_id",
 
          content => { typing => 1 },
       )->then( sub {

--- a/tests/10apidoc/36room-levels.pl
+++ b/tests/10apidoc/36room-levels.pl
@@ -10,7 +10,7 @@ test "GET /rooms/:room_id/state/m.room.power_levels can fetch levels",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/api/v1/rooms/$room_id/state/m.room.power_levels",
+         uri    => "/r0/rooms/$room_id/state/m.room.power_levels",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -52,7 +52,7 @@ test "PUT /rooms/:room_id/state/m.room.power_levels can set levels",
 
          do_request_json_for( $user,
             method => "PUT",
-            uri    => "/api/v1/rooms/$room_id/state/m.room.power_levels",
+            uri    => "/r0/rooms/$room_id/state/m.room.power_levels",
             content => $levels,
          )
       })->then( sub {

--- a/tests/10apidoc/37room-receipts.pl
+++ b/tests/10apidoc/37room-receipts.pl
@@ -14,7 +14,7 @@ test "POST /rooms/:room_id/receipt can create receipts",
 
          do_request_json_for( $user,
             method => "POST",
-            uri    => "/v2_alpha/rooms/$room_id/receipt/m.read/$event_id",
+            uri    => "/r0/rooms/$room_id/receipt/m.read/$event_id",
 
             content => {},
          );
@@ -29,7 +29,7 @@ sub matrix_advance_room_receipt
 
    do_request_json_for( $user,
       method => "POST",
-      uri    => "/v2_alpha/rooms/$room_id/receipt/$type/$event_id",
+      uri    => "/r0/rooms/$room_id/receipt/$type/$event_id",
 
       content => {},
    )->then_done();

--- a/tests/11register.pl
+++ b/tests/11register.pl
@@ -30,7 +30,7 @@ multi_test "Register with a recaptcha",
 
          $http->do_request_json(
             method  => "POST",
-            uri     => "/v2_alpha/register",
+            uri     => "/r0/register",
             content => {
                username => "SYT-8-username",
                password => "my secret",

--- a/tests/20profile-events.pl
+++ b/tests/20profile-events.pl
@@ -13,7 +13,7 @@ test "Displayname change reports an event to myself",
       ->then( sub {
          do_request_json_for( $user,
             method => "PUT",
-            uri    => "/api/v1/profile/:user_id/displayname",
+            uri    => "/r0/profile/:user_id/displayname",
 
             content => { displayname => $displayname },
          )
@@ -43,7 +43,7 @@ test "Avatar URL change reports an event to myself",
 
       do_request_json_for( $user,
          method => "PUT",
-         uri    => "/api/v1/profile/:user_id/avatar_url",
+         uri    => "/r0/profile/:user_id/avatar_url",
 
          content => { avatar_url => $avatar_url },
       )->then( sub {

--- a/tests/21presence-events.pl
+++ b/tests/21presence-events.pl
@@ -1,5 +1,5 @@
 # Eventually this will be changed; see SPEC-53
-my $PRESENCE_LIST_URI = "/api/v1/presence/list/:user_id";
+my $PRESENCE_LIST_URI = "/r0/presence/list/:user_id";
 
 my $fixture = local_user_fixture();
 

--- a/tests/30rooms/03members-remote.pl
+++ b/tests/30rooms/03members-remote.pl
@@ -34,7 +34,7 @@ test "Remote users can join room by alias",
       flush_events_for( $user )->then( sub {
          do_request_json_for( $user,
             method => "POST",
-            uri    => "/api/v1/join/$room_alias",
+            uri    => "/r0/join/$room_alias",
 
             content => {},
          );

--- a/tests/30rooms/04messages.pl
+++ b/tests/30rooms/04messages.pl
@@ -62,7 +62,7 @@ test "Fetching eventstream a second time doesn't yield the message again",
 
          do_request_json_for( $recvuser,
             method => "GET",
-            uri    => "/api/v1/events",
+            uri    => "/r0/events",
             params => {
                from    => $recvuser->eventstream_token,
                timeout => 0,

--- a/tests/30rooms/05aliases.pl
+++ b/tests/30rooms/05aliases.pl
@@ -24,7 +24,7 @@ test "Room aliases can contain Unicode",
 
       do_request_json_for( $user,
          method => "PUT",
-         uri    => "/api/v1/directory/room/$room_alias",
+         uri    => "/r0/directory/room/$room_alias",
 
          content => { room_id => $room_id },
       );
@@ -37,7 +37,7 @@ test "Room aliases can contain Unicode",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/api/v1/directory/room/$room_alias",
+         uri    => "/r0/directory/room/$room_alias",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -60,7 +60,7 @@ test "Remote room alias queries can handle Unicode",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/api/v1/directory/room/$room_alias",
+         uri    => "/r0/directory/room/$room_alias",
       )->then( sub {
          my ( $body ) = @_;
 

--- a/tests/30rooms/07ban.pl
+++ b/tests/30rooms/07ban.pl
@@ -12,7 +12,7 @@ test "Banned user is kicked and may not rejoin until unbanned",
 
       do_request_json_for( $creator,
          method => "POST",
-         uri    => "/api/v1/rooms/$room_id/ban",
+         uri    => "/r0/rooms/$room_id/ban",
 
          content => { user_id => $banned_user->user_id, reason => "testing" },
       )->then( sub {
@@ -30,28 +30,28 @@ test "Banned user is kicked and may not rejoin until unbanned",
       })->then( sub {
          do_request_json_for( $creator,
             method => "POST",
-            uri    => "/api/v1/rooms/$room_id/invite",
+            uri    => "/r0/rooms/$room_id/invite",
 
             content => { user_id => $banned_user->user_id },
          )->main::expect_http_403;  # Must be unbanned first
       })->then( sub {
          do_request_json_for( $creator,
             method => "POST",
-            uri    => "/api/v1/rooms/$room_id/kick",
+            uri    => "/r0/rooms/$room_id/kick",
 
             content => { user_id => $banned_user->user_id },
          )->main::expect_http_403;  # Must be unbanned first
       })->then( sub {
          do_request_json_for( $creator,
             method => "POST",
-            uri    => "/api/v1/rooms/$room_id/unban",
+            uri    => "/r0/rooms/$room_id/unban",
 
             content => { user_id => $banned_user->user_id },
          );
       })->then( sub {
          do_request_json_for( $banned_user,
             method => "POST",
-            uri    => "/api/v1/rooms/$room_id/join",
+            uri    => "/r0/rooms/$room_id/join",
 
             content => {},
          );

--- a/tests/30rooms/08levels.pl
+++ b/tests/30rooms/08levels.pl
@@ -75,7 +75,7 @@ test_powerlevel "'ban' event respects room powerlevel",
 
       do_request_json_for( $test_user,
          method => "POST",
-         uri    => "/api/v1/rooms/$room_id/ban",
+         uri    => "/r0/rooms/$room_id/ban",
 
          content => { user_id => '@random_dude:test', reason => "testing" },
       );

--- a/tests/30rooms/10redactions.pl
+++ b/tests/30rooms/10redactions.pl
@@ -29,7 +29,7 @@ test "POST /rooms/:room_id/redact/:event_id as power user redacts message",
 
          do_request_json_for( $creator,
             method => "POST",
-            uri    => "/api/v1/rooms/$room_id/redact/$to_redact",
+            uri    => "/r0/rooms/$room_id/redact/$to_redact",
             content => {},
          );
       });
@@ -48,7 +48,7 @@ test "POST /rooms/:room_id/redact/:event_id as original message sender redacts m
 
          do_request_json_for( $sender,
                method => "POST",
-               uri    => "/api/v1/rooms/$room_id/redact/$to_redact",
+               uri    => "/r0/rooms/$room_id/redact/$to_redact",
                content => {},
          );
       });
@@ -67,7 +67,7 @@ test "POST /rooms/:room_id/redact/:event_id as random user does not redact messa
 
          do_request_json_for( $redactor,
                method => "POST",
-               uri    => "/api/v1/rooms/$room_id/redact/$to_redact",
+               uri    => "/r0/rooms/$room_id/redact/$to_redact",
                content => {},
          )->main::expect_http_403;
       });

--- a/tests/30rooms/11leaving.pl
+++ b/tests/30rooms/11leaving.pl
@@ -159,7 +159,7 @@ test "Can get rooms/{roomId}/members for a departed room (SPEC-216)",
 
         do_request_json_for( $user,
             method => "GET",
-            uri => "/api/v1/rooms/$room_id/members",
+            uri => "/r0/rooms/$room_id/members",
         )->then( sub {
             my ( $body ) = @_;
 

--- a/tests/30rooms/12thirdpartyinvite.pl
+++ b/tests/30rooms/12thirdpartyinvite.pl
@@ -30,7 +30,7 @@ test "Can invite existing 3pid",
 
          do_request_json_for( $inviter,
             method => "POST",
-            uri    => "/api/v1/rooms/$room_id/invite",
+            uri    => "/r0/rooms/$room_id/invite",
 
             content => {
                id_server    => $id_server->name,
@@ -267,7 +267,7 @@ sub do_3pid_invite {
 
    do_request_json_for( $inviter,
       method  => "POST",
-      uri     => "/api/v1/rooms/$room_id/invite",
+      uri     => "/r0/rooms/$room_id/invite",
       content => {
          id_server    => $id_server,
          medium       => "email",

--- a/tests/30rooms/14forget.pl
+++ b/tests/30rooms/14forget.pl
@@ -233,7 +233,7 @@ sub matrix_forget_room
 
    do_request_json_for( $user,
       method => "POST",
-      uri    => "/api/v1/rooms/$room_id/forget",
+      uri    => "/r0/rooms/$room_id/forget",
 
       content => {},
    )->then_done(1);

--- a/tests/30rooms/20typing.pl
+++ b/tests/30rooms/20typing.pl
@@ -16,7 +16,7 @@ sub matrix_typing
 
    do_request_json_for( $user,
       method => "PUT",
-      uri    => "/api/v1/rooms/$room_id/typing/:user_id",
+      uri    => "/r0/rooms/$room_id/typing/:user_id",
       content => \%params,
    );
 }

--- a/tests/30rooms/60anonymousaccess.pl
+++ b/tests/30rooms/60anonymousaccess.pl
@@ -75,7 +75,7 @@ foreach my $i (
          })->then( sub {
             do_request_json_for( $nonjoined_user,
                method => "GET",
-               uri    => "/api/v1/events",
+               uri    => "/r0/events",
                params => {
                   room_id => $room_id,
                },
@@ -145,7 +145,7 @@ foreach my $i (
                Future->needs_all(
                   do_request_json_for( $user,
                      method  => "POST",
-                     uri     => "/v2_alpha/rooms/$room_id/receipt/m.read/$sent_event_id",
+                     uri     => "/r0/rooms/$room_id/receipt/m.read/$sent_event_id",
                      content => {},
                   ),
 
@@ -166,7 +166,7 @@ foreach my $i (
                Future->needs_all(
                   do_request_json_for( $user,
                      method  => "PUT",
-                     uri     => "/api/v1/rooms/$room_id/typing/:user_id",
+                     uri     => "/r0/rooms/$room_id/typing/:user_id",
                      content => {
                         typing => JSON::true,
                         timeout => 5000,
@@ -245,7 +245,7 @@ foreach my $i (
 
          do_request_json_for( $nonjoined_user,
             method => "GET",
-            uri    => "/api/v1/rooms/$room_id/state",
+            uri    => "/r0/rooms/$room_id/state",
          );
       },
    );
@@ -266,7 +266,7 @@ foreach my $i (
 
          do_request_json_for( $nonjoined_user,
             method => "GET",
-            uri    => "/api/v1/rooms/$room_id/state/m.room.member/".$user->user_id,
+            uri    => "/r0/rooms/$room_id/state/m.room.member/".$user->user_id,
          );
       },
    );
@@ -357,7 +357,7 @@ foreach my $i (
          })->then( sub {
             do_request_json_for( $nonjoined_user,
                method => "GET",
-               uri    => "/api/v1/rooms/$room_id/state/m.room.member/".$user->user_id,
+               uri    => "/r0/rooms/$room_id/state/m.room.member/".$user->user_id,
             );
          });
       },
@@ -388,7 +388,7 @@ test "Anonymous user cannot call /events globally",
 
       do_request_json_for( $anonymous_user,
          method => "GET",
-         uri    => "/api/v1/events",
+         uri    => "/r0/events",
       )->followed_by( \&expect_4xx_or_empty_chunk );
    };
 
@@ -482,7 +482,7 @@ test "Annonymous user calling /events doesn't tightloop",
       })->then( sub {
          do_request_json_for( $anonymous_user,
             method => "GET",
-            uri    => "/api/v1/rooms/$room_id/initialSync",
+            uri    => "/r0/rooms/$room_id/initialSync",
          );
       })->then( sub {
          my ( $sync_body ) = @_;
@@ -518,7 +518,7 @@ sub get_events_no_timeout
 
    do_request_json_for( $user,
       method => "GET",
-      uri    => "/api/v1/events",
+      uri    => "/r0/events",
       params => {
          room_id => $room_id,
          timeout => 0,
@@ -534,7 +534,7 @@ sub check_events
 
    do_request_json_for( $user,
       method => "GET",
-      uri    => "/api/v1/events",
+      uri    => "/r0/events",
       params => {
          limit   => "3",
          dir     => "b",
@@ -596,7 +596,7 @@ test "Anonymous user can set display names",
    do => sub {
       my ( $anonymous_user, $user, $room_id ) = @_;
 
-      my $displayname_uri = "/api/v1/profile/:user_id/displayname";
+      my $displayname_uri = "/r0/profile/:user_id/displayname";
 
       matrix_set_room_guest_access( $user, $room_id, "can_join" )->then( sub {
          matrix_join_room( $anonymous_user, $room_id );
@@ -627,7 +627,7 @@ test "Anonymous user can set display names",
             }),
             do_request_json_for( $anonymous_user,
                method => "GET",
-               uri    => "/api/v1/rooms/$room_id/state/m.room.member/:user_id",
+               uri    => "/r0/rooms/$room_id/state/m.room.member/:user_id",
             )->then( sub {
                my ( $body ) = @_;
                $body->{displayname} eq "creeper" or die "Wrong displayname";
@@ -801,7 +801,7 @@ test "GET /publicRooms lists rooms",
       )->then( sub {
          $http->do_request_json(
             method => "GET",
-            uri    => "/api/v1/publicRooms",
+            uri    => "/r0/publicRooms",
       )})->then( sub {
          my ( $body ) = @_;
 
@@ -892,7 +892,7 @@ test "GET /publicRooms includes avatar URLs",
       )->then( sub {
          $http->do_request_json(
             method => "GET",
-            uri    => "/api/v1/publicRooms",
+            uri    => "/r0/publicRooms",
       )})->then( sub {
          my ( $body ) = @_;
 
@@ -941,7 +941,7 @@ sub anonymous_user_fixture
 
          $http->do_request_json(
             method  => "POST",
-            uri     => "/v2_alpha/register",
+            uri     => "/r0/register",
             content => {},
             params  => {
                kind => "guest",

--- a/tests/31sync/01filter.pl
+++ b/tests/31sync/01filter.pl
@@ -14,7 +14,7 @@ sub matrix_create_filter
 
    do_request_json_for( $user,
       method  => "POST",
-      uri     => "/v2_alpha/user/:user_id/filter",
+      uri     => "/r0/user/:user_id/filter",
       content => $filter,
    )->then( sub {
       my ( $body ) = @_;
@@ -56,7 +56,7 @@ test "Can download filter",
 
          do_request_json_for( $user,
             method  => "GET",
-            uri     => "/v2_alpha/user/:user_id/filter/$filter_id",
+            uri     => "/r0/user/:user_id/filter/$filter_id",
          )
       })->then( sub {
          my ( $body ) = @_;

--- a/tests/31sync/10archived-ban.pl
+++ b/tests/31sync/10archived-ban.pl
@@ -24,7 +24,7 @@ test "Banned rooms appear in the leave section of sync",
 
          do_request_json_for( $user_a,
             method => "POST",
-            uri    => "/api/v1/rooms/$room_id/ban",
+            uri    => "/r0/rooms/$room_id/ban",
             content => { user_id => $user_b->user_id, reason => "testing" },
          );
       })->then( sub {
@@ -67,7 +67,7 @@ test "Newly banned rooms appear in the leave section of incremental sync",
       })->then( sub {
          do_request_json_for( $user_a,
             method => "POST",
-            uri    => "/api/v1/rooms/$room_id/ban",
+            uri    => "/r0/rooms/$room_id/ban",
             content => { user_id => $user_b->user_id, reason => "testing" },
          );
       })->then( sub {
@@ -110,7 +110,7 @@ test "Newly banned rooms appear in the leave section of incremental sync",
       })->then( sub {
          do_request_json_for( $user_a,
             method => "POST",
-            uri    => "/api/v1/rooms/$room_id/ban",
+            uri    => "/r0/rooms/$room_id/ban",
             content => { user_id => $user_b->user_id, reason => "testing" },
          );
       })->then( sub {

--- a/tests/42tags.pl
+++ b/tests/42tags.pl
@@ -14,7 +14,7 @@ sub matrix_add_tag
 
    do_request_json_for( $user,
       method  => "PUT",
-      uri     => "/v2_alpha/user/:user_id/rooms/$room_id/tags/$tag",
+      uri     => "/r0/user/:user_id/rooms/$room_id/tags/$tag",
       content => $content
    );
 }
@@ -34,7 +34,7 @@ sub matrix_remove_tag
 
    do_request_json_for( $user,
       method  => "DELETE",
-      uri     => "/v2_alpha/user/:user_id/rooms/$room_id/tags/$tag",
+      uri     => "/r0/user/:user_id/rooms/$room_id/tags/$tag",
       content => {}
    );
 }
@@ -54,7 +54,7 @@ sub matrix_list_tags
 
    do_request_json_for( $user,
       method  => "GET",
-      uri     => "/v2_alpha/user/:user_id/rooms/$room_id/tags",
+      uri     => "/r0/user/:user_id/rooms/$room_id/tags",
    )->then( sub {
       my ( $body ) = @_;
 

--- a/tests/43search.pl
+++ b/tests/43search.pl
@@ -17,7 +17,7 @@ test "Can search for an event by body",
 
          do_request_json_for( $user,
             method  => "POST",
-            uri     => "/api/v1/search",
+            uri     => "/r0/search",
             content => {
                search_categories => {
                   room_events => {
@@ -82,7 +82,7 @@ test "Can back-paginate search results",
         }, foreach => [ 0 .. 19 ] )->then( sub {
             do_request_json_for( $user,
                                  method  => "POST",
-                                 uri     => "/api/v1/search",
+                                 uri     => "/r0/search",
                                  content => $search_query,
             );
         })->then( sub {
@@ -109,7 +109,7 @@ test "Can back-paginate search results",
 
             do_request_json_for( $user,
                                  method  => "POST",
-                                 uri     => "/api/v1/search",
+                                 uri     => "/r0/search",
                                  params  => { next_batch => $next_batch },
                                  content => $search_query,
             );
@@ -137,7 +137,7 @@ test "Can back-paginate search results",
 
             do_request_json_for( $user,
                                  method  => "POST",
-                                 uri     => "/api/v1/search",
+                                 uri     => "/r0/search",
                                  params  => { next_batch => $next_batch },
                                  content => $search_query,
             );

--- a/tests/44account_data.pl
+++ b/tests/44account_data.pl
@@ -14,7 +14,7 @@ sub matrix_add_account_data
 
    do_request_json_for( $user,
       method  => "PUT",
-      uri     => "/v2_alpha/user/:user_id/account_data/$type",
+      uri     => "/r0/user/:user_id/account_data/$type",
       content => $content
    );
 }
@@ -33,7 +33,7 @@ sub matrix_add_room_account_data
 
    do_request_json_for( $user,
       method  => "PUT",
-      uri     => "/v2_alpha/user/:user_id/rooms/$room_id/account_data/$type",
+      uri     => "/r0/user/:user_id/rooms/$room_id/account_data/$type",
       content => $content
    );
 }

--- a/tests/48admin.pl
+++ b/tests/48admin.pl
@@ -16,7 +16,7 @@ test "/whois",
 
          do_request_json_for( $user,
             method => "GET",
-            uri    => "/api/v1/admin/whois/".$user->user_id,
+            uri    => "/r0/admin/whois/".$user->user_id,
          )
       })->then( sub {
          my ( $body ) = @_;

--- a/tests/50federation/10query-profile.pl
+++ b/tests/50federation/10query-profile.pl
@@ -19,7 +19,7 @@ test "Outbound federation can query profile data",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/api/v1/profile/\@user:$local_server_name/displayname",
+         uri    => "/r0/profile/\@user:$local_server_name/displayname",
       )->then( sub {
          my ( $body ) = @_;
          log_if_fail "Query response", $body;
@@ -44,7 +44,7 @@ test "Inbound federation can query profile data",
 
       do_request_json_for( $user,
          method => "PUT",
-         uri    => "/api/v1/profile/:user_id/displayname",
+         uri    => "/r0/profile/:user_id/displayname",
 
          content => {
             displayname => $dname,

--- a/tests/50federation/11query-directory.pl
+++ b/tests/50federation/11query-directory.pl
@@ -22,7 +22,7 @@ test "Outbound federation can query room alias directory",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/api/v1/directory/room/$room_alias",
+         uri    => "/r0/directory/room/$room_alias",
       )->then( sub {
          my ( $body ) = @_;
          log_if_fail "Query response", $body;
@@ -60,7 +60,7 @@ test "Inbound federation can query room alias directory",
 
          do_request_json_for( $user,
             method => "PUT",
-            uri    => "/api/v1/directory/room/$room_alias",
+            uri    => "/r0/directory/room/$room_alias",
 
             content => {
                room_id => $room_id,

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -87,7 +87,7 @@ test "Outbound federation can send room-join requests",
 
          do_request_json_for( $user,
             method => "POST",
-            uri    => "/api/v1/join/$room_alias",
+            uri    => "/r0/join/$room_alias",
 
             content => {},
          )->then( sub {

--- a/tests/50federation/31room-send.pl
+++ b/tests/50federation/31room-send.pl
@@ -16,7 +16,7 @@ test "Outbound federation can send events",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/api/v1/join/$room_alias",
+         uri    => "/r0/join/$room_alias",
 
          content => {},
       )->then( sub {

--- a/tests/50federation/34room-backfill.pl
+++ b/tests/50federation/34room-backfill.pl
@@ -57,7 +57,7 @@ test "Outbound federation can backfill events",
 
          do_request_json_for( $user,
             method => "POST",
-            uri    => "/api/v1/join/$room_alias",
+            uri    => "/r0/join/$room_alias",
 
             content => {},
          )->then( sub {

--- a/tests/60app-services/01as-create.pl
+++ b/tests/60app-services/01as-create.pl
@@ -100,7 +100,7 @@ test "AS can make room aliases",
 
          do_request_json_for( $as_user,
             method => "PUT",
-            uri    => "/api/v1/directory/room/$room_alias",
+            uri    => "/r0/directory/room/$room_alias",
 
             content => {
                room_id => $room_id,
@@ -111,7 +111,7 @@ test "AS can make room aliases",
 
          do_request_json_for( $as_user,
             method => "GET",
-            uri    => "/api/v1/directory/room/$room_alias",
+            uri    => "/r0/directory/room/$room_alias",
          )
       })->then( sub {
          my ( $body ) = @_;
@@ -138,7 +138,7 @@ test "Regular users cannot create room aliases within the AS namespace",
 
       do_request_json_for( $user,
          method => "PUT",
-         uri    => "/api/v1/directory/room/$room_alias",
+         uri    => "/r0/directory/room/$room_alias",
 
          content => {
             room_id => $room_id,

--- a/tests/60app-services/02ghost.pl
+++ b/tests/60app-services/02ghost.pl
@@ -31,7 +31,7 @@ multi_test "AS-ghosted users can use rooms via AS",
 
          do_request_json_for( $as_user,
             method => "POST",
-            uri    => "/api/v1/rooms/$room_id/join",
+            uri    => "/r0/rooms/$room_id/join",
             params => {
                user_id => $ghost->user_id,
             },
@@ -58,7 +58,7 @@ multi_test "AS-ghosted users can use rooms via AS",
 
             do_request_json_for( $as_user,
                method => "POST",
-               uri    => "/api/v1/rooms/$room_id/send/m.room.message",
+               uri    => "/r0/rooms/$room_id/send/m.room.message",
                params => {
                   user_id => $ghost->user_id,
                },
@@ -168,7 +168,7 @@ test "Ghost user must register before joining room",
 
       do_request_json_for( $as_user,
          method => "POST",
-         uri    => "/api/v1/rooms/$room_id/join",
+         uri    => "/r0/rooms/$room_id/join",
          params => {
             user_id => "@".$unregistered_as_user_localpart.":".$hs_info->server_name,
          },

--- a/tests/60app-services/03passive.pl
+++ b/tests/60app-services/03passive.pl
@@ -61,7 +61,7 @@ multi_test "Accesing an AS-hosted room alias asks the AS server",
 
             do_request_json_for( $as_user,
                method => "PUT",
-               uri    => "/api/v1/directory/room/$room_alias",
+               uri    => "/r0/directory/room/$room_alias",
 
                content => {
                   room_id => $room_id,
@@ -115,7 +115,7 @@ multi_test "Accesing an AS-hosted room alias asks the AS server",
 
          do_request_json_for( $local_user,
             method => "POST",
-            uri    => "/api/v1/join/$room_alias",
+            uri    => "/r0/join/$room_alias",
 
             content => {},
          )

--- a/tests/61push/01message-pushed.pl
+++ b/tests/61push/01message-pushed.pl
@@ -51,7 +51,7 @@ multi_test "Test that a message is pushed",
          # message that Bob sent.
          do_request_json_for( $alice,
             method  => "POST",
-            uri     => "/api/v1/pushers/set",
+            uri     => "/r0/pushers/set",
             content => {
                profile_tag         => "tag",
                kind                => "http",

--- a/tests/80torture/03events.pl
+++ b/tests/80torture/03events.pl
@@ -7,7 +7,7 @@ test "GET /initialSync with non-numeric 'limit'",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/api/v1/initialSync",
+         uri    => "/r0/initialSync",
 
          params => { limit => "hello" },
       )->main::expect_http_4xx;
@@ -21,7 +21,7 @@ test "GET /events with non-numeric 'limit'",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/api/v1/events",
+         uri    => "/r0/events",
 
          params => { from => $user->eventstream_token, limit => "hello" },
       )->main::expect_http_4xx;
@@ -35,7 +35,7 @@ test "GET /events with negative 'limit'",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/api/v1/events",
+         uri    => "/r0/events",
 
          params => { from => $user->eventstream_token, limit => -2 },
       )->main::expect_http_4xx;
@@ -49,7 +49,7 @@ test "GET /events with non-numeric 'timeout'",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/api/v1/events",
+         uri    => "/r0/events",
 
          params => { from => $user->eventstream_token, timeout => "hello" },
       )->main::expect_http_4xx;
@@ -64,7 +64,7 @@ test "Event size limits",
       Future->needs_all(
          do_request_json_for( $user,
             method  => "POST",
-            uri     => "/api/v1/rooms/$room_id/send/m.room.message",
+            uri     => "/r0/rooms/$room_id/send/m.room.message",
             content => {
                msgtype => "m.text",
                body    => "A" x 70000,
@@ -73,7 +73,7 @@ test "Event size limits",
 
          do_request_json_for( $user,
             method  => "PUT",
-            uri     => "/api/v1/rooms/$room_id/state/oooooooh/",
+            uri     => "/r0/rooms/$room_id/state/oooooooh/",
             content => {
                key => "O" x 70000,
             }

--- a/tests/90jira/SYN-115.pl
+++ b/tests/90jira/SYN-115.pl
@@ -57,7 +57,7 @@ multi_test "New federated private chats get full presence information (SYN-115)"
 
                do_request_json_for( $user,
                   method => "GET",
-                  uri    => $is_initial ? "/api/v1/initialSync" : "/api/v1/events",
+                  uri    => $is_initial ? "/r0/initialSync" : "/r0/events",
                   params => { from => $user->eventstream_token, timeout => 500 }
                )->then( sub {
                   my ( $body ) = @_;

--- a/tests/90jira/SYN-328.pl
+++ b/tests/90jira/SYN-328.pl
@@ -14,7 +14,7 @@ multi_test "Typing notifications don't leak",
 
          do_request_json_for( $creator,
             method => "PUT",
-            uri    => "/api/v1/rooms/$room_id/typing/:user_id",
+            uri    => "/r0/rooms/$room_id/typing/:user_id",
 
             content => { typing => 1, timeout => 30000 }, # msec
          );

--- a/tests/90jira/SYN-343.pl
+++ b/tests/90jira/SYN-343.pl
@@ -20,7 +20,7 @@ multi_test "Non-present room members cannot ban others",
 
          do_request_json_for( $testuser,
             method => "POST",
-            uri    => "/api/v1/rooms/$room_id/ban",
+            uri    => "/r0/rooms/$room_id/ban",
 
             content => { user_id => '@random_dude:test', reason => "testing" },
          )->main::expect_http_403

--- a/tests/90jira/SYN-390.pl
+++ b/tests/90jira/SYN-390.pl
@@ -6,20 +6,20 @@ multi_test "Getting push rules doesn't corrupt the cache SYN-390",
 
       do_request_json_for( $user,
          method  => "PUT",
-         uri     => "/api/v1/pushrules/global/sender/%40a_user%3Amatrix.org",
+         uri     => "/r0/pushrules/global/sender/%40a_user%3Amatrix.org",
          content => { "actions" => ["dont_notify"] }
       )->SyTest::pass_on_done("Set push rules for user" )
       ->then( sub {
 
          do_request_json_for( $user,
             method => "GET",
-            uri    => "/api/v1/pushrules/",
+            uri    => "/r0/pushrules/",
          )->SyTest::pass_on_done("Got push rules the first time" )
       })->then( sub {
 
          do_request_json_for( $user,
             method => "GET",
-            uri    => "/api/v1/pushrules/",
+            uri    => "/r0/pushrules/",
          )->SyTest::pass_on_done("Got push rules the second time" )
       })->then_done(1);
    }


### PR DESCRIPTION
This covers everything except /register calls, which use v1 registration