### PR TITLE
Adjust AS code so it could support multiple instances

### DIFF
--- a/lib/SyTest/ApplicationService.pm
+++ b/lib/SyTest/ApplicationService.pm
@@ -6,11 +6,12 @@ use warnings;
 sub new
 {
    my $class = shift;
-   my ( $info, $await_http ) = @_;
+   my ( $info, $await_http, $await_event ) = @_;
 
    return bless {
       info       => $info,
       await_http => $await_http,
+      await_event => $await_event,
    }, $class;
 }
 
@@ -20,6 +21,13 @@ sub await_http_request
    my ( $path, @args ) = @_;
 
    $self->{await_http}->( $self->{info}->path . $path, @args );
+}
+
+sub await_event
+{
+   my $self = shift;
+
+   $self->{await_event}->( @_ );
 }
 
 1;

--- a/lib/SyTest/ApplicationService.pm
+++ b/lib/SyTest/ApplicationService.pm
@@ -1,0 +1,25 @@
+package SyTest::ApplicationService;
+
+use strict;
+use warnings;
+
+sub new
+{
+   my $class = shift;
+   my ( $info, $await_http ) = @_;
+
+   return bless {
+      info       => $info,
+      await_http => $await_http,
+   }, $class;
+}
+
+sub await_http_request
+{
+   my $self = shift;
+   my ( $path, @args ) = @_;
+
+   $self->{await_http}->( $self->{info}->path . $path, @args );
+}
+
+1;

--- a/lib/SyTest/ApplicationService.pm
+++ b/lib/SyTest/ApplicationService.pm
@@ -5,6 +5,32 @@ use warnings;
 
 use Future::Utils qw( repeat );
 
+=head1 NAME
+
+C<SyTest::ApplicationService> - abstraction of a single application service
+
+=head1 DESCRIPTION
+
+An instance of this class represents an abstracted application service for the
+homeserver to talk to. It provides the test scripts a way to receive inbound
+HTTP requests and respond to them, and allows access to the user information
+allowing a test script to send API requests.
+
+=cut
+
+=head1 CONSTRUCTOR
+
+=cut
+
+=head2 new
+
+   $appserv = SyTest::ApplicationService->new( $info, $await_http )
+
+Returns a newly constructed instance that uses the given C<ASInfo> structure
+and the C<await_http> function.
+
+=cut
+
 sub new
 {
    my $class = shift;
@@ -55,11 +81,33 @@ sub new
    }, $class;
 }
 
+=head1 METHODS
+
+=cut
+
+=head2 info
+
+   $info = $appserv->info
+
+Returns the C<ASInfo> structure instance this object was constructed with.
+
+=cut
+
 sub info
 {
    my $self = shift;
    return $self->{info};
 }
+
+=head2 await_http_request
+
+   $f = $appserv->await_http_request( $path, @args )
+
+A wrapper around the C<await_http_request> function the instance was
+constructed with, that prepends this server's path prefix onto the C<$path>
+argument for convenience.
+
+=cut
 
 sub await_http_request
 {
@@ -68,6 +116,15 @@ sub await_http_request
 
    $self->{await_http}->( $self->info->path . $path, @args );
 }
+
+=head2 await_event
+
+   $f = $appserv->await_event( $type )
+
+Returns a L<Future> that will succeed with the next event of the given
+C<$type> that the homeserver pushes to the application service.
+
+=cut
 
 sub await_event
 {

--- a/lib/SyTest/ApplicationService.pm
+++ b/lib/SyTest/ApplicationService.pm
@@ -3,15 +3,55 @@ package SyTest::ApplicationService;
 use strict;
 use warnings;
 
+use Future::Utils qw( repeat );
+
 sub new
 {
    my $class = shift;
-   my ( $info, $await_http, $await_event ) = @_;
+   my ( $info, $await_http ) = @_;
+
+   my $path = $info->path;
+
+   # Map event types to ARRAYs of Futures
+   my %futures_by_type;
+
+   my $f = repeat {
+      $await_http->( qr{^\Q$path\E/transactions/\d+$}, sub { 1 },
+         timeout => 0,
+      )->then( sub {
+         my ( $request ) = @_;
+
+         # Respond immediately to AS
+         $request->respond_json( {} );
+
+         foreach my $event ( @{ $request->body_from_json->{events} } ) {
+            my $type = $event->{type};
+
+            my $queue = $futures_by_type{$type};
+
+            # Ignore any cancelled ones
+            shift @$queue while $queue and @$queue and $queue->[0]->is_cancelled;
+
+            if( $queue and my $f = shift @$queue ) {
+               $f->done( $event, $request );
+            }
+            else {
+               warn "Ignoring incoming AS event of type $type\n";
+            }
+         }
+
+         Future->done;
+      })
+   } while => sub { not $_[0]->failure };
+
+   $f->on_fail( sub { die $_[0] } );
 
    return bless {
       info       => $info,
       await_http => $await_http,
-      await_event => $await_event,
+
+      futures_by_type => \%futures_by_type,
+      await_loop_f    => $f,
    }, $class;
 }
 
@@ -26,8 +66,20 @@ sub await_http_request
 sub await_event
 {
    my $self = shift;
+   my ( $type ) = @_;
 
-   $self->{await_event}->( @_ );
+   my $failmsg = SyTest::CarpByFile::shortmess(
+      "Timed out waiting for an AS event of type $type"
+   );
+
+   push @{ $self->{futures_by_type}{$type} }, my $f = Future->new;
+
+   return Future->wait_any(
+      $f,
+
+      main::delay( 10 )
+         ->then_fail( $failmsg ),
+   );
 }
 
 1;

--- a/lib/SyTest/ApplicationService.pm
+++ b/lib/SyTest/ApplicationService.pm
@@ -58,8 +58,8 @@ sub new
             # Ignore any cancelled ones
             shift @$queue while $queue and @$queue and $queue->[0]->is_cancelled;
 
-            if( $queue and my $f = shift @$queue ) {
-               $f->done( $event, $request );
+            if( $queue and my $next_f = shift @$queue ) {
+               $next_f->done( $event, $request );
             }
             else {
                warn "Ignoring incoming AS event of type $type\n";

--- a/lib/SyTest/ApplicationService.pm
+++ b/lib/SyTest/ApplicationService.pm
@@ -43,7 +43,10 @@ sub new
 
    my $f = repeat {
       $await_http->( qr{^\Q$path\E/transactions/\d+$}, sub { 1 },
-         timeout => 0,
+         # Disable the timeout logic so this doesn't fail after 10 seconds;
+         #   we're just waiting indefinitely for the next transaction to
+         #   arrive.
+         timeout => undef,
       )->then( sub {
          my ( $request ) = @_;
 

--- a/lib/SyTest/ApplicationService.pm
+++ b/lib/SyTest/ApplicationService.pm
@@ -55,12 +55,18 @@ sub new
    }, $class;
 }
 
+sub info
+{
+   my $self = shift;
+   return $self->{info};
+}
+
 sub await_http_request
 {
    my $self = shift;
    my ( $path, @args ) = @_;
 
-   $self->{await_http}->( $self->{info}->path . $path, @args );
+   $self->{await_http}->( $self->info->path . $path, @args );
 }
 
 sub await_event

--- a/lib/SyTest/ApplicationService.pm
+++ b/lib/SyTest/ApplicationService.pm
@@ -56,12 +56,14 @@ sub new
          foreach my $event ( @{ $request->body_from_json->{events} } ) {
             my $type = $event->{type};
 
-            my $queue = $futures_by_type{$type};
+            my $futures = $futures_by_type{$type};
 
             # Ignore any cancelled ones
-            shift @$queue while $queue and @$queue and $queue->[0]->is_cancelled;
+            while( $futures and @$futures and $futures->[0]->is_cancelled ) {
+               shift @$futures;
+            }
 
-            if( $queue and my $next_f = shift @$queue ) {
+            if( $futures and my $next_f = shift @$futures ) {
                $next_f->done( $event, $request );
             }
             else {

--- a/tests/02as-info.pl
+++ b/tests/02as-info.pl
@@ -6,7 +6,7 @@ sub gen_token
    return join "", map { chr 64 + rand 63 } 1 .. $length;
 }
 
-struct ASInfo => [qw( localpart user_id as2hs_token hs2as_token path )];
+struct ASInfo => [qw( localpart user_id as2hs_token hs2as_token path id )];
 
 our $AS_INFO = fixture(
    setup => sub {
@@ -20,6 +20,7 @@ our $AS_INFO = fixture(
          gen_token( 32 ),
          gen_token( 32 ),
          "/appserv",
+         undef,
       ));
    },
 );

--- a/tests/02as-info.pl
+++ b/tests/02as-info.pl
@@ -1,0 +1,25 @@
+push our @EXPORT, qw( AS_INFO );
+
+sub gen_token
+{
+   my ( $length ) = @_;
+   return join "", map { chr 64 + rand 63 } 1 .. $length;
+}
+
+struct ASInfo => [qw( localpart user_id as2hs_token hs2as_token path )];
+
+our $AS_INFO = fixture(
+   setup => sub {
+      my $port = $HOMESERVER_PORTS[0];
+
+      my $localpart = "as-user";
+
+      Future->done( ASInfo(
+         $localpart,
+         "\@${localpart}:localhost:${port}",
+         gen_token( 32 ),
+         gen_token( 32 ),
+         "/appserv",
+      ));
+   },
+);

--- a/tests/02as-info.pl
+++ b/tests/02as-info.pl
@@ -20,7 +20,7 @@ our $AS_INFO = fixture(
          gen_token( 32 ),
          gen_token( 32 ),
          "/appserv",
-         undef,
+         "0",
       ));
    },
 );

--- a/tests/05synapse.pl
+++ b/tests/05synapse.pl
@@ -26,37 +26,13 @@ END {
    }
 }
 
-sub gen_token
-{
-   my ( $length ) = @_;
-   return join "", map { chr 64 + rand 63 } 1 .. $length;
-}
-
-push our @EXPORT, qw( AS_INFO HOMESERVER_INFO );
-
-struct ASInfo => [qw( localpart user_id as2hs_token hs2as_token path )];
-
-our $AS_INFO = fixture(
-   setup => sub {
-      my $port = $HOMESERVER_PORTS[0];
-
-      my $localpart = "as-user";
-
-      Future->done( ASInfo(
-         $localpart,
-         "\@${localpart}:localhost:${port}",
-         gen_token( 32 ),
-         gen_token( 32 ),
-         "/appserv",
-      ));
-   },
-);
+push our @EXPORT, qw( HOMESERVER_INFO );
 
 our @HOMESERVER_INFO = map {
    my $idx = $_;
 
    fixture(
-      requires => [ $main::TEST_SERVER_INFO, $AS_INFO ],
+      requires => [ $main::TEST_SERVER_INFO, $main::AS_INFO ],
 
       setup => sub {
          my ( $test_server_info, $as_user_info ) = @_;

--- a/tests/05synapse.pl
+++ b/tests/05synapse.pl
@@ -34,7 +34,7 @@ sub gen_token
 
 push our @EXPORT, qw( AS_INFO HOMESERVER_INFO );
 
-struct ASInfo => [qw( localpart user_id as2hs_token hs2as_token )];
+struct ASInfo => [qw( localpart user_id as2hs_token hs2as_token path )];
 
 our $AS_INFO = fixture(
    setup => sub {
@@ -47,6 +47,7 @@ our $AS_INFO = fixture(
          "\@${localpart}:localhost:${port}",
          gen_token( 32 ),
          gen_token( 32 ),
+         "/appserv",
       ));
    },
 );
@@ -102,7 +103,7 @@ our @HOMESERVER_INFO = map {
          if( $idx == 0 ) {
             # Configure application services on first instance only
             my $appserv_conf = $synapse->write_yaml_file( "appserv.yaml", {
-               url      => $test_server_info->client_location . "/appserv",
+               url      => $test_server_info->client_location . $as_user_info->path,
                as_token => $as_user_info->as2hs_token,
                hs_token => $as_user_info->hs2as_token,
                sender_localpart => $as_user_info->localpart,

--- a/tests/05synapse.pl
+++ b/tests/05synapse.pl
@@ -32,17 +32,17 @@ sub gen_token
    return join "", map { chr 64 + rand 63 } 1 .. $length;
 }
 
-push our @EXPORT, qw( AS_USER_INFO HOMESERVER_INFO );
+push our @EXPORT, qw( AS_INFO HOMESERVER_INFO );
 
-struct ASUserInfo => [qw( localpart user_id as2hs_token hs2as_token )];
+struct ASInfo => [qw( localpart user_id as2hs_token hs2as_token )];
 
-our $AS_USER_INFO = fixture(
+our $AS_INFO = fixture(
    setup => sub {
       my $port = $HOMESERVER_PORTS[0];
 
       my $localpart = "as-user";
 
-      Future->done( ASUserInfo(
+      Future->done( ASInfo(
          $localpart,
          "\@${localpart}:localhost:${port}",
          gen_token( 32 ),
@@ -55,7 +55,7 @@ our @HOMESERVER_INFO = map {
    my $idx = $_;
 
    fixture(
-      requires => [ $main::TEST_SERVER_INFO, $AS_USER_INFO ],
+      requires => [ $main::TEST_SERVER_INFO, $AS_INFO ],
 
       setup => sub {
          my ( $test_server_info, $as_user_info ) = @_;

--- a/tests/60app-services/00prepare.pl
+++ b/tests/60app-services/00prepare.pl
@@ -1,5 +1,3 @@
-use Future::Utils qw( repeat );
-
 use SyTest::ApplicationService;
 
 push our @EXPORT, qw( AS_USER APPSERV );
@@ -15,60 +13,6 @@ our $AS_USER = fixture(
    },
 );
 
-# Map event types to ARRAYs of Futures
-my %futures_by_type;
-
-sub await_as_event
-{
-   my ( $type ) = @_;
-   my $failmsg = SyTest::CarpByFile::shortmess(
-      "Timed out waiting for an AS event of type $type"
-   );
-
-   push @{ $futures_by_type{$type} }, my $f = $loop->new_future;
-
-   return Future->wait_any(
-      $f,
-
-      delay( 10 )
-         ->then_fail( $failmsg ),
-   );
-}
-
-my $f = repeat {
-   await_http_request( qr{^/appserv/transactions/\d+$}, sub { 1 },
-      timeout => 0,
-   )->then( sub {
-      my ( $request ) = @_;
-
-      # Respond immediately to AS
-      $request->respond_json( {} );
-
-      foreach my $event ( @{ $request->body_from_json->{events} } ) {
-         my $type = $event->{type};
-
-         my $queue = $futures_by_type{$type};
-
-         # Ignore any cancelled ones
-         shift @$queue while $queue and @$queue and $queue->[0]->is_cancelled;
-
-         if( $queue and my $f = shift @$queue ) {
-            $f->done( $event, $request );
-         }
-         else {
-            warn "Ignoring incoming AS event of type $type\n";
-         }
-      }
-
-      Future->done;
-   })
-} while => sub { not $_[0]->failure };
-
-$f->on_fail( sub { die $_[0] } );
-
-# lifecycle it
-$f->on_cancel( sub { undef $f } );
-
 our $APPSERV = fixture(
    requires => [ $main::AS_INFO ],
 
@@ -76,7 +20,7 @@ our $APPSERV = fixture(
       my ( $info ) = @_;
 
       Future->done( SyTest::ApplicationService->new(
-         $info, \&main::await_http_request, \&await_as_event,
+         $info, \&main::await_http_request
       ) );
    }
 );

--- a/tests/60app-services/00prepare.pl
+++ b/tests/60app-services/00prepare.pl
@@ -1,6 +1,8 @@
 use Future::Utils qw( repeat );
 
-push our @EXPORT, qw( AS_USER await_as_event );
+use SyTest::ApplicationService;
+
+push our @EXPORT, qw( AS_USER APPSERV await_as_event );
 
 our $AS_USER = fixture(
    requires => [ $main::API_CLIENTS[0], $main::AS_INFO ],
@@ -11,6 +13,18 @@ our $AS_USER = fixture(
       Future->done( User( $http, $as_user_info->user_id, $as_user_info->as2hs_token,
             undef, undef, undef, [], undef ) );
    },
+);
+
+our $APPSERV = fixture(
+   requires => [ $main::AS_INFO ],
+
+   setup => sub {
+      my ( $info ) = @_;
+
+      Future->done( SyTest::ApplicationService->new(
+         $info, \&main::await_http_request,
+      ) );
+   }
 );
 
 # Map event types to ARRAYs of Futures

--- a/tests/60app-services/00prepare.pl
+++ b/tests/60app-services/00prepare.pl
@@ -3,7 +3,7 @@ use Future::Utils qw( repeat );
 push our @EXPORT, qw( AS_USER await_as_event );
 
 our $AS_USER = fixture(
-   requires => [ $main::API_CLIENTS[0], $main::AS_USER_INFO ],
+   requires => [ $main::API_CLIENTS[0], $main::AS_INFO ],
 
    setup => sub {
       my ( $http, $as_user_info ) = @_;

--- a/tests/60app-services/00prepare.pl
+++ b/tests/60app-services/00prepare.pl
@@ -2,7 +2,7 @@ use Future::Utils qw( repeat );
 
 use SyTest::ApplicationService;
 
-push our @EXPORT, qw( AS_USER APPSERV await_as_event );
+push our @EXPORT, qw( AS_USER APPSERV );
 
 our $AS_USER = fixture(
    requires => [ $main::API_CLIENTS[0], $main::AS_INFO ],
@@ -13,18 +13,6 @@ our $AS_USER = fixture(
       Future->done( User( $http, $as_user_info->user_id, $as_user_info->as2hs_token,
             undef, undef, undef, [], undef ) );
    },
-);
-
-our $APPSERV = fixture(
-   requires => [ $main::AS_INFO ],
-
-   setup => sub {
-      my ( $info ) = @_;
-
-      Future->done( SyTest::ApplicationService->new(
-         $info, \&main::await_http_request,
-      ) );
-   }
 );
 
 # Map event types to ARRAYs of Futures
@@ -80,3 +68,15 @@ $f->on_fail( sub { die $_[0] } );
 
 # lifecycle it
 $f->on_cancel( sub { undef $f } );
+
+our $APPSERV = fixture(
+   requires => [ $main::AS_INFO ],
+
+   setup => sub {
+      my ( $info ) = @_;
+
+      Future->done( SyTest::ApplicationService->new(
+         $info, \&main::await_http_request, \&await_as_event,
+      ) );
+   }
+);

--- a/tests/60app-services/01as-create.pl
+++ b/tests/60app-services/01as-create.pl
@@ -58,7 +58,7 @@ test "Regular users cannot register within the AS namespace",
 
 test "AS can make room aliases",
    requires => [
-      $main::AS_USER, $main::AS_USER_INFO, $room_fixture,
+      $main::AS_USER, $main::AS_INFO, $room_fixture,
       room_alias_fixture( prefix => "astest-" ),
       qw( can_create_room_alias ),
    ],

--- a/tests/60app-services/01as-create.pl
+++ b/tests/60app-services/01as-create.pl
@@ -58,16 +58,16 @@ test "Regular users cannot register within the AS namespace",
 
 test "AS can make room aliases",
    requires => [
-      $main::AS_USER, $main::AS_INFO, $room_fixture,
+      $main::AS_USER, $main::AS_INFO, $main::APPSERV, $room_fixture,
       room_alias_fixture( prefix => "astest-" ),
       qw( can_create_room_alias ),
    ],
 
    do => sub {
-      my ( $as_user, $as_user_info, $room_id, $room_alias ) = @_;
+      my ( $as_user, $as_user_info, $appserv, $room_id, $room_alias ) = @_;
 
       Future->needs_all(
-         await_as_event( "m.room.aliases" )->then( sub {
+         $appserv->await_event( "m.room.aliases" )->then( sub {
             my ( $event, $request ) = @_;
 
             # As this is the first AS event we've received, lets check that the

--- a/tests/60app-services/01as-create.pl
+++ b/tests/60app-services/01as-create.pl
@@ -58,13 +58,13 @@ test "Regular users cannot register within the AS namespace",
 
 test "AS can make room aliases",
    requires => [
-      $main::AS_USER, $main::AS_INFO, $main::APPSERV, $room_fixture,
+      $main::AS_USER, $main::APPSERV, $room_fixture,
       room_alias_fixture( prefix => "astest-" ),
       qw( can_create_room_alias ),
    ],
 
    do => sub {
-      my ( $as_user, $as_user_info, $appserv, $room_id, $room_alias ) = @_;
+      my ( $as_user, $appserv, $room_id, $room_alias ) = @_;
 
       Future->needs_all(
          $appserv->await_event( "m.room.aliases" )->then( sub {
@@ -77,7 +77,7 @@ test "AS can make room aliases",
 
             assert_ok( defined $access_token,
                "HS provides an access_token" );
-            assert_eq( $access_token, $as_user_info->hs2as_token,
+            assert_eq( $access_token, $appserv->info->hs2as_token,
                "HS provides the correct token" );
 
             log_if_fail "Event", $event;

--- a/tests/60app-services/02ghost.pl
+++ b/tests/60app-services/02ghost.pl
@@ -1,15 +1,15 @@
 my $user_fixture = local_user_fixture();
 
 multi_test "AS-ghosted users can use rooms via AS",
-   requires => [ as_ghost_fixture(), $main::AS_USER, $user_fixture,
+   requires => [ as_ghost_fixture(), $main::AS_USER, $user_fixture, $main::APPSERV,
                      room_fixture( requires_users => [ $user_fixture ] ),
                 qw( can_receive_room_message_locally )],
 
    do => sub {
-      my ( $ghost, $as_user, $creator, $room_id ) = @_;
+      my ( $ghost, $as_user, $creator, $appserv, $room_id ) = @_;
 
       Future->needs_all(
-         await_as_event( "m.room.member" )->then( sub {
+         $appserv->await_event( "m.room.member" )->then( sub {
             my ( $event ) = @_;
 
             log_if_fail "AS event", $event;
@@ -41,7 +41,7 @@ multi_test "AS-ghosted users can use rooms via AS",
       )->SyTest::pass_on_done( "User joined room via AS" )
       ->then( sub {
          Future->needs_all(
-            await_as_event( "m.room.message" )->then( sub {
+            $appserv->await_event( "m.room.message" )->then( sub {
                my ( $event ) = @_;
 
                log_if_fail "AS event", $event;
@@ -88,15 +88,15 @@ multi_test "AS-ghosted users can use rooms via AS",
    };
 
 multi_test "AS-ghosted users can use rooms themselves",
-   requires => [ as_ghost_fixture(), $user_fixture,
+   requires => [ as_ghost_fixture(), $user_fixture, $main::APPSERV,
                      room_fixture( requires_users => [ $user_fixture ] ),
                 qw( can_receive_room_message_locally can_send_message )],
 
    do => sub {
-      my ( $ghost, $creator, $room_id ) = @_;
+      my ( $ghost, $creator, $appserv, $room_id ) = @_;
 
       Future->needs_all(
-         await_as_event( "m.room.member" )->then( sub {
+         $appserv->await_event( "m.room.member" )->then( sub {
             my ( $event ) = @_;
 
             log_if_fail "AS event", $event;
@@ -118,7 +118,7 @@ multi_test "AS-ghosted users can use rooms themselves",
       )->SyTest::pass_on_done( "Ghost joined room themselves" )
       ->then( sub {
          Future->needs_all(
-            await_as_event( "m.room.message" )->then( sub {
+            $appserv->await_event( "m.room.message" )->then( sub {
                my ( $event ) = @_;
 
                log_if_fail "AS event", $event;

--- a/tests/60app-services/03passive.pl
+++ b/tests/60app-services/03passive.pl
@@ -5,17 +5,17 @@ my $room_fixture = room_fixture(
 );
 
 multi_test "Inviting an AS-hosted user asks the AS server",
-   requires => [ $main::AS_USER, $user_fixture, $room_fixture,
+   requires => [ $main::AS_USER, $main::AS_INFO, $user_fixture, $room_fixture,
                  qw( can_invite_room )],
 
    do => sub {
-      my ( $as_user, $creator, $room_id ) = @_;
+      my ( $as_user, $as_info, $creator, $room_id ) = @_;
       my $server_name = $as_user->http->server_name;
 
       my $localpart = "astest-03passive-1";
       my $user_id = "\@$localpart:$server_name";
 
-      require_stub await_http_request( "/appserv/users/$user_id", sub { 1 } )
+      require_stub await_http_request( $as_info->path . "/users/$user_id", sub { 1 } )
          ->then( sub {
             my ( $request ) = @_;
 
@@ -45,15 +45,15 @@ multi_test "Inviting an AS-hosted user asks the AS server",
    };
 
 multi_test "Accesing an AS-hosted room alias asks the AS server",
-   requires => [ $main::AS_USER, local_user_fixture(), $room_fixture,
+   requires => [ $main::AS_USER, $main::AS_INFO, local_user_fixture(), $room_fixture,
                  room_alias_fixture( prefix => "astest-" ),
 
                 qw( can_join_room_by_alias )],
 
    do => sub {
-      my ( $as_user, $local_user, $room_id, $room_alias ) = @_;
+      my ( $as_user, $as_info, $local_user, $room_id, $room_alias ) = @_;
 
-      require_stub await_http_request( "/appserv/rooms/$room_alias", sub { 1 } )
+      require_stub await_http_request( $as_info->path . "/rooms/$room_alias", sub { 1 } )
          ->then( sub {
             my ( $request ) = @_;
 

--- a/tests/60app-services/03passive.pl
+++ b/tests/60app-services/03passive.pl
@@ -27,7 +27,7 @@ multi_test "Inviting an AS-hosted user asks the AS server",
       matrix_invite_user_to_room( $creator, $user_id, $room_id )
          ->SyTest::pass_on_done( "Sent invite" )
       ->then( sub {
-         await_as_event( "m.room.member" )
+         $appserv->await_event( "m.room.member" )
       })->then( sub {
          my ( $event ) = @_;
 
@@ -73,7 +73,7 @@ multi_test "Accesing an AS-hosted room alias asks the AS server",
          });
 
       Future->needs_all(
-         await_as_event( "m.room.member" )->then( sub {
+         $appserv->await_event( "m.room.member" )->then( sub {
             my ( $event ) = @_;
 
             log_if_fail "Event", $event;
@@ -92,7 +92,7 @@ multi_test "Accesing an AS-hosted room alias asks the AS server",
             Future->done;
          }),
 
-         await_as_event( "m.room.aliases" )->then( sub {
+         $appserv->await_event( "m.room.aliases" )->then( sub {
             my ( $event ) = @_;
 
             log_if_fail "Event", $event;
@@ -123,14 +123,14 @@ multi_test "Accesing an AS-hosted room alias asks the AS server",
    };
 
 test "Events in rooms with AS-hosted room aliases are sent to AS server",
-   requires => [ $user_fixture, $room_fixture,
+   requires => [ $user_fixture, $room_fixture, $main::APPSERV,
                  qw( can_join_room_by_alias can_send_message )],
 
    do => sub {
-      my ( $creator, $room_id ) = @_;
+      my ( $creator, $room_id, $appserv ) = @_;
 
       Future->needs_all(
-         await_as_event( "m.room.message" )->then( sub {
+         $appserv->await_event( "m.room.message" )->then( sub {
             my ( $event ) = @_;
 
             log_if_fail "Event", $event;

--- a/tests/60app-services/03passive.pl
+++ b/tests/60app-services/03passive.pl
@@ -5,17 +5,17 @@ my $room_fixture = room_fixture(
 );
 
 multi_test "Inviting an AS-hosted user asks the AS server",
-   requires => [ $main::AS_USER, $main::AS_INFO, $user_fixture, $room_fixture,
+   requires => [ $main::AS_USER, $main::APPSERV, $user_fixture, $room_fixture,
                  qw( can_invite_room )],
 
    do => sub {
-      my ( $as_user, $as_info, $creator, $room_id ) = @_;
+      my ( $as_user, $appserv, $creator, $room_id ) = @_;
       my $server_name = $as_user->http->server_name;
 
       my $localpart = "astest-03passive-1";
       my $user_id = "\@$localpart:$server_name";
 
-      require_stub await_http_request( $as_info->path . "/users/$user_id", sub { 1 } )
+      require_stub $appserv->await_http_request( "/users/$user_id", sub { 1 } )
          ->then( sub {
             my ( $request ) = @_;
 
@@ -45,15 +45,15 @@ multi_test "Inviting an AS-hosted user asks the AS server",
    };
 
 multi_test "Accesing an AS-hosted room alias asks the AS server",
-   requires => [ $main::AS_USER, $main::AS_INFO, local_user_fixture(), $room_fixture,
+   requires => [ $main::AS_USER, $main::APPSERV, local_user_fixture(), $room_fixture,
                  room_alias_fixture( prefix => "astest-" ),
 
                 qw( can_join_room_by_alias )],
 
    do => sub {
-      my ( $as_user, $as_info, $local_user, $room_id, $room_alias ) = @_;
+      my ( $as_user, $appserv, $local_user, $room_id, $room_alias ) = @_;
 
-      require_stub await_http_request( $as_info->path . "/rooms/$room_alias", sub { 1 } )
+      require_stub $appserv->await_http_request( "/rooms/$room_alias", sub { 1 } )
          ->then( sub {
             my ( $request ) = @_;
 


### PR DESCRIPTION
Various code adjustments to get to the point where all AS-related behaviour comes via fixtures.

This doesn't yet give us multiple-AS ability, but that should be straightforward after this by just turning the `$AS_*` scalar variables into `@AS_` arrays.