### PR TITLE
Allow for multiple ASes

### DIFF
--- a/tests/02as-info.pl
+++ b/tests/02as-info.pl
@@ -8,19 +8,25 @@ sub gen_token
 
 struct ASInfo => [qw( localpart user_id as2hs_token hs2as_token path id )];
 
-our $AS_INFO = fixture(
-   setup => sub {
-      my $port = $HOMESERVER_PORTS[0];
+my $n_appservers = 1;
 
-      my $localpart = "as-user";
+our @AS_INFO = map {
+   my $idx = $_;
 
-      Future->done( ASInfo(
-         $localpart,
-         "\@${localpart}:localhost:${port}",
-         gen_token( 32 ),
-         gen_token( 32 ),
-         "/appserv",
-         "0",
-      ));
-   },
-);
+   fixture(
+      setup => sub {
+         my $port = $HOMESERVER_PORTS[0];
+
+         my $localpart = "as-user-$idx";
+
+         Future->done( ASInfo(
+            $localpart,
+            "\@${localpart}:localhost:${port}",
+            gen_token( 32 ),
+            gen_token( 32 ),
+            "/appservs/$idx",
+            $idx,
+         ));
+      },
+   );
+} 1 .. $n_appservers;

--- a/tests/02as-info.pl
+++ b/tests/02as-info.pl
@@ -25,7 +25,7 @@ our @AS_INFO = map {
             gen_token( 32 ),
             gen_token( 32 ),
             "/appservs/$idx",
-            $idx,
+            "AS-$idx",
          ));
       },
    );

--- a/tests/05synapse.pl
+++ b/tests/05synapse.pl
@@ -32,10 +32,10 @@ our @HOMESERVER_INFO = map {
    my $idx = $_;
 
    fixture(
-      requires => [ $main::TEST_SERVER_INFO, $main::AS_INFO ],
+      requires => [ $main::TEST_SERVER_INFO, @main::AS_INFO ],
 
       setup => sub {
-         my ( $test_server_info, $as_user_info ) = @_;
+         my ( $test_server_info, @as_infos ) = @_;
 
          my $secure_port = $HOMESERVER_PORTS[$idx];
          my $unsecure_port = $WANT_TLS ? 0 : $secure_port + 1000;
@@ -79,24 +79,32 @@ our @HOMESERVER_INFO = map {
 
          if( $idx == 0 ) {
             # Configure application services on first instance only
-            my $appserv_conf = $synapse->write_yaml_file( "appserv.yaml", {
-               url      => $test_server_info->client_location . $as_user_info->path,
-               as_token => $as_user_info->as2hs_token,
-               hs_token => $as_user_info->hs2as_token,
-               sender_localpart => $as_user_info->localpart,
-               namespaces => {
-                  users => [
-                     { regex => '@astest-.*', exclusive => "true" },
-                  ],
-                  aliases => [
-                     { regex => '#astest-.*', exclusive => "true" },
-                  ],
-                  rooms => [],
-               }
-            } );
+            my @confs;
+
+            foreach my $idx ( 0 .. $#as_infos ) {
+               my $as_info = $as_infos[$idx];
+
+               my $appserv_conf = $synapse->write_yaml_file( "appserv-$idx.yaml", {
+                  url      => $test_server_info->client_location . $as_info->path,
+                  as_token => $as_info->as2hs_token,
+                  hs_token => $as_info->hs2as_token,
+                  sender_localpart => $as_info->localpart,
+                  namespaces => {
+                     users => [
+                        { regex => '@astest-.*', exclusive => "true" },
+                     ],
+                     aliases => [
+                        { regex => '#astest-.*', exclusive => "true" },
+                     ],
+                     rooms => [],
+                  }
+               } );
+
+               push @confs, $appserv_conf;
+            }
 
             $synapse->append_config(
-               app_service_config_files => [ $appserv_conf ],
+               app_service_config_files => \@confs,
             );
          }
 

--- a/tests/05synapse.pl
+++ b/tests/05synapse.pl
@@ -85,6 +85,7 @@ our @HOMESERVER_INFO = map {
                my $as_info = $as_infos[$idx];
 
                my $appserv_conf = $synapse->write_yaml_file( "appserv-$idx.yaml", {
+                  id       => $as_info->id,
                   url      => $test_server_info->client_location . $as_info->path,
                   as_token => $as_info->as2hs_token,
                   hs_token => $as_info->hs2as_token,

--- a/tests/60app-services/00prepare.pl
+++ b/tests/60app-services/00prepare.pl
@@ -2,25 +2,33 @@ use SyTest::ApplicationService;
 
 push our @EXPORT, qw( AS_USER APPSERV );
 
-our $AS_USER = fixture(
-   requires => [ $main::API_CLIENTS[0], $main::AS_INFO ],
+our @AS_USER = map {
+   my $AS_INFO = $_;
 
-   setup => sub {
-      my ( $http, $as_user_info ) = @_;
+   fixture(
+      requires => [ $main::API_CLIENTS[0], $AS_INFO ],
 
-      Future->done( User( $http, $as_user_info->user_id, $as_user_info->as2hs_token,
-            undef, undef, undef, [], undef ) );
-   },
-);
+      setup => sub {
+         my ( $http, $as_user_info ) = @_;
 
-our $APPSERV = fixture(
-   requires => [ $main::AS_INFO ],
+         Future->done( User( $http, $as_user_info->user_id, $as_user_info->as2hs_token,
+               undef, undef, undef, [], undef ) );
+      },
+   );
+} @main::AS_INFO;
 
-   setup => sub {
-      my ( $info ) = @_;
+our @APPSERV = map {
+   my $AS_INFO = $_;
 
-      Future->done( SyTest::ApplicationService->new(
-         $info, \&main::await_http_request
-      ) );
-   }
-);
+   fixture(
+      requires => [ $AS_INFO ],
+
+      setup => sub {
+         my ( $info ) = @_;
+
+         Future->done( SyTest::ApplicationService->new(
+            $info, \&main::await_http_request
+         ) );
+      }
+   );
+} @main::AS_INFO;

--- a/tests/60app-services/01as-create.pl
+++ b/tests/60app-services/01as-create.pl
@@ -5,7 +5,7 @@ my $room_fixture = room_fixture(
 );
 
 test "AS can create a user",
-   requires => [ $main::AS_USER, $room_fixture ],
+   requires => [ $main::AS_USER[0], $room_fixture ],
 
    do => sub {
       my ( $as_user, $room_id ) = @_;
@@ -30,7 +30,7 @@ test "AS can create a user",
    };
 
 test "AS cannot create users outside its own namespace",
-   requires => [ $main::AS_USER ],
+   requires => [ $main::AS_USER[0] ],
 
    do => sub {
       my ( $as_user ) = @_;
@@ -58,7 +58,7 @@ test "Regular users cannot register within the AS namespace",
 
 test "AS can make room aliases",
    requires => [
-      $main::AS_USER, $main::APPSERV, $room_fixture,
+      $main::AS_USER[0], $main::APPSERV[0], $room_fixture,
       room_alias_fixture( prefix => "astest-" ),
       qw( can_create_room_alias ),
    ],
@@ -174,8 +174,11 @@ sub matrix_register_as_ghost
 my $next_as_user_id = 0;
 sub as_ghost_fixture
 {
+   my ( $idx ) = @_;
+   $idx //= 0;
+
    fixture(
-      requires => [ $main::AS_USER ],
+      requires => [ $main::AS_USER[$idx] ],
 
       setup => sub {
          my ( $as_user ) = @_;

--- a/tests/60app-services/02ghost.pl
+++ b/tests/60app-services/02ghost.pl
@@ -1,7 +1,7 @@
 my $user_fixture = local_user_fixture();
 
 multi_test "AS-ghosted users can use rooms via AS",
-   requires => [ as_ghost_fixture(), $main::AS_USER, $user_fixture, $main::APPSERV,
+   requires => [ as_ghost_fixture(), $main::AS_USER[0], $user_fixture, $main::APPSERV[0],
                      room_fixture( requires_users => [ $user_fixture ] ),
                 qw( can_receive_room_message_locally )],
 
@@ -88,7 +88,7 @@ multi_test "AS-ghosted users can use rooms via AS",
    };
 
 multi_test "AS-ghosted users can use rooms themselves",
-   requires => [ as_ghost_fixture(), $user_fixture, $main::APPSERV,
+   requires => [ as_ghost_fixture(), $user_fixture, $main::APPSERV[0],
                      room_fixture( requires_users => [ $user_fixture ] ),
                 qw( can_receive_room_message_locally can_send_message )],
 
@@ -161,7 +161,7 @@ multi_test "AS-ghosted users can use rooms themselves",
 my $unregistered_as_user_localpart = "astest-02ghost-1";
 
 test "Ghost user must register before joining room",
-   requires => [ $main::AS_USER, local_user_and_room_fixtures(), $main::HOMESERVER_INFO[0] ],
+   requires => [ $main::AS_USER[0], local_user_and_room_fixtures(), $main::HOMESERVER_INFO[0] ],
 
    check => sub {
       my ( $as_user, undef, $room_id, $hs_info ) = @_;

--- a/tests/60app-services/03passive.pl
+++ b/tests/60app-services/03passive.pl
@@ -5,7 +5,7 @@ my $room_fixture = room_fixture(
 );
 
 multi_test "Inviting an AS-hosted user asks the AS server",
-   requires => [ $main::AS_USER, $main::APPSERV, $user_fixture, $room_fixture,
+   requires => [ $main::AS_USER[0], $main::APPSERV[0], $user_fixture, $room_fixture,
                  qw( can_invite_room )],
 
    do => sub {
@@ -45,7 +45,7 @@ multi_test "Inviting an AS-hosted user asks the AS server",
    };
 
 multi_test "Accesing an AS-hosted room alias asks the AS server",
-   requires => [ $main::AS_USER, $main::APPSERV, local_user_fixture(), $room_fixture,
+   requires => [ $main::AS_USER[0], $main::APPSERV[0], local_user_fixture(), $room_fixture,
                  room_alias_fixture( prefix => "astest-" ),
 
                 qw( can_join_room_by_alias )],
@@ -123,7 +123,7 @@ multi_test "Accesing an AS-hosted room alias asks the AS server",
    };
 
 test "Events in rooms with AS-hosted room aliases are sent to AS server",
-   requires => [ $user_fixture, $room_fixture, $main::APPSERV,
+   requires => [ $user_fixture, $room_fixture, $main::APPSERV[0],
                  qw( can_join_room_by_alias can_send_message )],
 
    do => sub {

--- a/tests/60app-services/04asuser.pl
+++ b/tests/60app-services/04asuser.pl
@@ -1,5 +1,5 @@
 test "AS user (not ghost) can join room without registering",
-   requires => [ $main::AS_USER, local_user_fixture(), $main::HOMESERVER_INFO[0] ],
+   requires => [ $main::AS_USER[0], local_user_fixture(), $main::HOMESERVER_INFO[0] ],
 
    do => sub {
       my ( $as_user, $user, $hs_info ) = @_;
@@ -18,7 +18,7 @@ test "AS user (not ghost) can join room without registering",
 # TODO: Remove this test when the in-use ASes stop passing the user_id param
 # (or if we end up killing non-ghost AS users)
 test "AS user (not ghost) can join room without registering, with user_id query param",
-   requires => [ $main::AS_USER, local_user_fixture(), $main::HOMESERVER_INFO[0] ],
+   requires => [ $main::AS_USER[0], local_user_fixture(), $main::HOMESERVER_INFO[0] ],
 
    do => sub {
       my ( $as_user, $user, $hs_info ) = @_;


### PR DESCRIPTION
Changes the storage of AS instance-related variables into arrays. Though currently these are 1-element arrays.