### PR TITLE
Tiny whitespace change to keep my editor happy

### DIFF
--- a/tests/30rooms/06invite.pl
+++ b/tests/30rooms/06invite.pl
@@ -181,7 +181,8 @@ test "Invited user can reject local invite after originator leaves",
       do {
          my $creator = local_user_fixture();
          $creator, inviteonly_room_fixture( creator => $creator );
-   } ],
+      }
+   ],
    do => sub {
       my ( $invitee, $creator, $room_id ) = @_;
 

--- a/tests/30rooms/06invite.pl
+++ b/tests/30rooms/06invite.pl
@@ -109,7 +109,8 @@ test "Invited user can reject invite",
       do {
          my $creator = local_user_fixture();
          $creator, inviteonly_room_fixture( creator => $creator );
-   } ],
+      }
+   ],
    do => \&invited_user_can_reject_invite;
 
 test "Invited user can reject invite over federation",
@@ -117,7 +118,8 @@ test "Invited user can reject invite over federation",
       do {
          my $creator = local_user_fixture();
          $creator, inviteonly_room_fixture( creator => $creator );
-   } ],
+      }
+   ],
    do => \&invited_user_can_reject_invite;
 
 sub invited_user_can_reject_invite
@@ -148,7 +150,8 @@ test "Invited user can reject invite for empty room",
       do {
          my $creator = local_user_fixture();
          $creator, inviteonly_room_fixture( creator => $creator );
-   } ],
+      }
+   ],
    do => \&invited_user_can_reject_invite_for_empty_room;
 
 test "Invited user can reject invite over federation for empty room",
@@ -156,7 +159,8 @@ test "Invited user can reject invite over federation for empty room",
       do {
          my $creator = local_user_fixture();
          $creator, inviteonly_room_fixture( creator => $creator );
-   } ],
+      }
+   ],
    do => \&invited_user_can_reject_invite_for_empty_room;
 
 sub invited_user_can_reject_invite_for_empty_room


### PR DESCRIPTION
vim's code folding was upset about misaligned `{` and `}` braces.