### PR TITLE
Invite rejections: test that invitee no longer gets the invite down /sync

### DIFF
--- a/tests/30rooms/06invite.pl
+++ b/tests/30rooms/06invite.pl
@@ -142,6 +142,14 @@ sub invited_user_can_reject_invite
          die "Expected membership to be 'leave'";
 
       Future->done(1);
+   })->then( sub {
+      matrix_sync( $invitee )
+   })->then( sub {
+      my ( $body ) = @_;
+
+      assert_json_object( $body->{rooms}{invite} );
+      keys %{ $body->{rooms}{invite} } and die "Expected empty dictionary";
+      Future->done(1);
    });
 }
 
@@ -173,6 +181,14 @@ sub invited_user_can_reject_invite_for_empty_room
    })
    ->then( sub {
       matrix_leave_room( $invitee, $room_id )
+   })->then( sub {
+      matrix_sync( $invitee )
+   })->then( sub {
+      my ( $body ) = @_;
+
+      assert_json_object( $body->{rooms}{invite} );
+      keys %{ $body->{rooms}{invite} } and die "Expected empty dictionary";
+      Future->done(1);
    });
 }
 

--- a/tests/30rooms/06invite.pl
+++ b/tests/30rooms/06invite.pl
@@ -147,6 +147,8 @@ sub invited_user_can_reject_invite
    })->then( sub {
       my ( $body ) = @_;
 
+      # Check that invitee no longer sees the invite
+
       assert_json_object( $body->{rooms}{invite} );
       keys %{ $body->{rooms}{invite} } and die "Expected empty dictionary";
       Future->done(1);
@@ -185,6 +187,8 @@ sub invited_user_can_reject_invite_for_empty_room
       matrix_sync( $invitee )
    })->then( sub {
       my ( $body ) = @_;
+
+      # Check that invitee no longer sees the invite
 
       assert_json_object( $body->{rooms}{invite} );
       keys %{ $body->{rooms}{invite} } and die "Expected empty dictionary";


### PR DESCRIPTION
Tests: https://github.com/matrix-org/synapse/pull/646