### PR TITLE
Make room_fixture less magical.

### DIFF
--- a/tests/30rooms/04messages.pl
+++ b/tests/30rooms/04messages.pl
@@ -6,7 +6,7 @@ my $local_user_fixture = local_user_fixture();
 
 my $remote_fixture = remote_user_fixture();
 
-my $room_fixture = room_fixture(
+my $room_fixture = magic_room_fixture(
    requires_users => [ $senduser_fixture, $local_user_fixture, $remote_fixture ],
 );
 
@@ -190,7 +190,7 @@ test "Remote room members can get room messages",
    };
 
 test "Message history can be paginated",
-   requires => [ local_user_and_room_fixtures() ],
+   requires => [ magic_local_user_and_room_fixtures() ],
 
    proves => [qw( can_paginate_room )],
 
@@ -241,7 +241,7 @@ test "Message history can be paginated over federation",
       my $local_user_fixture = local_user_fixture();
 
       [ $local_user_fixture,
-        room_fixture( requires_users => [ $local_user_fixture ], with_alias => 1 ),
+        magic_room_fixture( requires_users => [ $local_user_fixture ], with_alias => 1 ),
         remote_user_fixture(),
 
         qw( can_paginate_room ),

--- a/tests/30rooms/05aliases.pl
+++ b/tests/30rooms/05aliases.pl
@@ -8,9 +8,7 @@ my $room_alias;
 
 my $creator_fixture = local_user_fixture();
 
-my $room_fixture = room_fixture(
-   requires_users => [ $creator_fixture ],
-);
+my $room_fixture = room_fixture( $creator_fixture );
 
 test "Room aliases can contain Unicode",
    requires => [ $creator_fixture, $room_fixture,

--- a/tests/30rooms/06invite.pl
+++ b/tests/30rooms/06invite.pl
@@ -227,7 +227,7 @@ test "Invited user can reject local invite after originator leaves",
    };
 
 test "Invited user can see room metadata",
-   requires => [ local_user_and_room_fixtures(), local_user_fixture() ],
+   requires => [ magic_local_user_and_room_fixtures(), local_user_fixture() ],
 
    do => sub {
       my ( $creator, $room_id, $invitee ) = @_;

--- a/tests/30rooms/07ban.pl
+++ b/tests/30rooms/07ban.pl
@@ -4,7 +4,7 @@ my $banned_user_fixture = local_user_fixture();
 
 test "Banned user is kicked and may not rejoin until unbanned",
    requires => [ $creator_fixture, $banned_user_fixture,
-                     room_fixture( requires_users => [ $creator_fixture, $banned_user_fixture ] ),
+                     magic_room_fixture( requires_users => [ $creator_fixture, $banned_user_fixture ] ),
                 qw( can_ban_room )],
 
    do => sub {

--- a/tests/30rooms/20typing.pl
+++ b/tests/30rooms/20typing.pl
@@ -28,7 +28,7 @@ my $local_user_fixture = local_user_fixture();
 
 my $remote_user_fixture = remote_user_fixture();
 
-my $room_fixture = room_fixture(
+my $room_fixture = magic_room_fixture(
    requires_users => [
       $typing_user_fixture, $local_user_fixture, $remote_user_fixture
    ],

--- a/tests/40presence.pl
+++ b/tests/40presence.pl
@@ -6,7 +6,7 @@ my $remote_user_fixture = remote_user_fixture();
 
 # Ensure all the users are members of a shared room, so that we know presence
 # messages can be shared between them all
-my $room_fixture = room_fixture(
+my $room_fixture = magic_room_fixture(
    requires_users => [
       $senduser_fixture, $local_user_fixture, $remote_user_fixture
    ],

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -116,11 +116,11 @@ test "Outbound federation can send room-join requests",
 test "Inbound federation can receive room-join requests",
    requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
                  $main::HOMESERVER_INFO[0],
-                 room_fixture( requires_users => [ local_user_fixture() ] ),
+                 local_user_and_room_fixtures(),
                  federation_user_id_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $inbound_server, $info, $room_id, $user_id ) = @_;
+      my ( $outbound_client, $inbound_server, $info, undef, $room_id, $user_id ) = @_;
       my $first_home_server = $info->server_name;
 
       my $local_server_name = $outbound_client->server_name;

--- a/tests/50federation/32room-getevent.pl
+++ b/tests/50federation/32room-getevent.pl
@@ -1,10 +1,10 @@
 test "Inbound federation can return events",
    requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
-                 room_fixture( requires_users => [ local_user_fixture() ] ),
+                 local_user_and_room_fixtures(),
                  federation_user_id_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $info, $room_id, $user_id ) = @_;
+      my ( $outbound_client, $info, undef, $room_id, $user_id ) = @_;
       my $first_home_server = $info->server_name;
 
       my $local_server_name = $outbound_client->server_name;

--- a/tests/50federation/33room-get-missing-events.pl
+++ b/tests/50federation/33room-get-missing-events.pl
@@ -101,11 +101,11 @@ test "Outbound federation can request missing events",
 
 test "Inbound federation can return missing events",
    requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
-                 room_fixture( requires_users => [ local_user_fixture() ] ),
+                 local_user_and_room_fixtures(),
                  federation_user_id_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $info, $room_id, $user_id ) = @_;
+      my ( $outbound_client, $info, undef, $room_id, $user_id ) = @_;
       my $first_home_server = $info->server_name;
 
       $outbound_client->join_room(

--- a/tests/60app-services/01as-create.pl
+++ b/tests/60app-services/01as-create.pl
@@ -1,8 +1,6 @@
 my $user_fixture = local_user_fixture();
 
-my $room_fixture = room_fixture(
-   requires_users => [ $user_fixture ],
-);
+my $room_fixture = room_fixture( $user_fixture );
 
 test "AS can create a user",
    requires => [ $main::AS_USER[0], $room_fixture ],

--- a/tests/60app-services/02ghost.pl
+++ b/tests/60app-services/02ghost.pl
@@ -2,7 +2,7 @@ my $user_fixture = local_user_fixture();
 
 multi_test "AS-ghosted users can use rooms via AS",
    requires => [ as_ghost_fixture(), $main::AS_USER[0], $user_fixture, $main::APPSERV[0],
-                     room_fixture( requires_users => [ $user_fixture ] ),
+                     room_fixture( $user_fixture ),
                 qw( can_receive_room_message_locally )],
 
    do => sub {
@@ -89,7 +89,7 @@ multi_test "AS-ghosted users can use rooms via AS",
 
 multi_test "AS-ghosted users can use rooms themselves",
    requires => [ as_ghost_fixture(), $user_fixture, $main::APPSERV[0],
-                     room_fixture( requires_users => [ $user_fixture ] ),
+                     room_fixture( $user_fixture ),
                 qw( can_receive_room_message_locally can_send_message )],
 
    do => sub {

--- a/tests/60app-services/03passive.pl
+++ b/tests/60app-services/03passive.pl
@@ -1,8 +1,6 @@
 my $user_fixture = local_user_fixture();
 
-my $room_fixture = room_fixture(
-   requires_users => [ $user_fixture ],
-);
+my $room_fixture = room_fixture( $user_fixture );
 
 multi_test "Inviting an AS-hosted user asks the AS server",
    requires => [ $main::AS_USER[0], $main::APPSERV[0], $user_fixture, $room_fixture,


### PR DESCRIPTION
Rather than calling ``matrix_create_and_join_room`` which does extra stuff it
calls ``matrix_create_room``. There are a couple of tests that depend on
the extra stuff so I've added a ``magic_room_fixture`` which calls
``matrix_create_and_join_room`` preserving the old behaviour.