### PR TITLE
Test unread counts in pushes

### DIFF
--- a/tests/61push/01message-pushed.pl
+++ b/tests/61push/01message-pushed.pl
@@ -47,6 +47,8 @@ multi_test "Test that a message is pushed",
          matrix_join_room( $bob, $room_id )
       })->then( sub {
          await_event_for( $alice, filter => sub {
+            my ( $event ) = @_;
+            return unless $event->{type} eq "m.room.member";
             return 1;
          })->then( sub {
             my ( $event ) = @_;

--- a/tests/61push/01message-pushed.pl
+++ b/tests/61push/01message-pushed.pl
@@ -93,7 +93,7 @@ multi_test "Test that a message is pushed",
             })->then( sub {
                my ( $request ) = @_;
 
-               $request->respond( HTTP::Response->new( 200, "OK", [], "" ) );
+               $request->respond_json( {} );
                Future->done( $request );
             }),
 
@@ -136,7 +136,7 @@ multi_test "Test that a message is pushed",
             })->then( sub {
                my ( $request ) = @_;
 
-               $request->respond( HTTP::Response->new( 200, "OK", [], "" ) );
+               $request->respond_json( {} );
                Future->done( $request );
             }),
 

--- a/tests/61push/01message-pushed.pl
+++ b/tests/61push/01message-pushed.pl
@@ -48,7 +48,6 @@ multi_test "Test that a message is pushed",
       })->then( sub {
          await_event_for( $alice, filter => sub {
             my ( $event ) = @_;
-            pass "got event";
             matrix_advance_room_receipt( $alice, $room_id,
                "m.read" => $event->{event_id}
             );

--- a/tests/61push/01message-pushed.pl
+++ b/tests/61push/01message-pushed.pl
@@ -47,11 +47,12 @@ multi_test "Test that a message is pushed",
          matrix_join_room( $bob, $room_id )
       })->then( sub {
          await_event_for( $alice, filter => sub {
+            return 1;
+         })->then( sub {
             my ( $event ) = @_;
             matrix_advance_room_receipt( $alice, $room_id,
                "m.read" => $event->{event_id}
             );
-            return 1;
          });
       })->then( sub {
          # Now that Bob has joined the room, we will create a pusher for
@@ -102,7 +103,7 @@ multi_test "Test that a message is pushed",
          my ( $request ) = @_;
          my $body = $request->body_from_json;
 
-         log_if_fail "Request body", $body;
+         log_if_fail "Message push request body", $body;
 
          assert_json_keys( my $notification = $body->{notification}, qw(
             id room_id type sender content devices counts
@@ -147,10 +148,12 @@ multi_test "Test that a message is pushed",
          my $body = $request->body_from_json;
          my $notification = $body->{notification};
 
+         log_if_fail "Zero badge push request body", $body;
+
          assert_json_keys( $notification->{counts}, qw(
             unread
          ));
-         assert_eq( $notification->{counts}->{unread}, 1, "unread count");
+         assert_eq( $notification->{counts}{unread}, 0, "unread count");
 
          pass "Zero badge push received";
 


### PR DESCRIPTION
Tests that unread counts increase and decrease correctly once messages and read receipts are sent respectively. Tests existing behaviour but uses event_id field added in https://github.com/matrix-org/synapse/pull/705/files