### PR TITLE
Increase the timeouts on a couple of problem tests

### DIFF
--- a/tests/30rooms/20typing.pl
+++ b/tests/30rooms/20typing.pl
@@ -139,6 +139,8 @@ multi_test "Typing notifications timeout and can be resent",
    requires => [ $typing_user_fixture, $room_fixture,
                 qw( can_set_room_typing )],
 
+   timeout => 100,
+
    do => sub {
       my ( $user, $room_id ) = @_;
 

--- a/tests/90jira/SYN-627.pl
+++ b/tests/90jira/SYN-627.pl
@@ -2,7 +2,7 @@ test "Events come down the correct room",
    requires => [ local_user_fixture( with_events => 0 ), "can_sync" ],
 
    # creating all those rooms is quite slow.
-   timeout => 20,
+   timeout => 100,
 
    check => sub {
       my ( $user ) = @_;


### PR DESCRIPTION
These tests keep randomly failing due to timeouts on jenkins. It might be an idea to bump the timeouts for now so that we get more reliable test output.