### PR TITLE
Wait for /sync to be ready in the tests.

### DIFF
--- a/tests/10apidoc/03events-initial.pl
+++ b/tests/10apidoc/03events-initial.pl
@@ -100,7 +100,8 @@ sub GET_new_events_for
 # Some Matrix protocol helper functions
 
 push our @EXPORT, qw(
-   matrix_initialsync matrix_get_events matrix_sync matrix_sync_again
+   matrix_initialsync matrix_get_events
+   matrix_sync matrix_sync_again
    flush_events_for await_event_for
 );
 
@@ -190,6 +191,8 @@ sub matrix_sync
 {
    my ( $user, %params ) = @_;
 
+   my $update_next_batch = delete $params{update_next_batch} // 1;
+
    do_request_json_for( $user,
       method  => "GET",
       uri     => "/r0/sync",
@@ -201,7 +204,9 @@ sub matrix_sync
       assert_json_keys( $body->{presence}, qw( events ));
       assert_json_keys( $body->{rooms}, qw( join invite leave ) );
 
-      $user->sync_next_batch = $body->{next_batch};
+      if ( $update_next_batch ) {
+         $user->sync_next_batch = $body->{next_batch};
+      }
    });
 }
 

--- a/tests/31sync/02sync.pl
+++ b/tests/31sync/02sync.pl
@@ -2,14 +2,14 @@ use Future::Utils qw( repeat );
 
 push our @EXPORT, qw(
    matrix_do_and_wait_for_sync
-   matrix_send_room_text_message_and_wait_for_sync
-   matrix_send_room_message_and_wait_for_sync
-   matrix_create_room_and_wait_for_sync
-   matrix_join_room_and_wait_for_sync
-   matrix_leave_room_and_wait_for_sync
-   matrix_invite_user_to_room_and_wait_for_sync
-   matrix_put_room_state_and_wait_for_sync
-   matrix_advance_room_receipt_and_wait_for_sync
+   matrix_send_room_text_message_synced
+   matrix_send_room_message_synced
+   matrix_create_room_synced
+   matrix_join_room_synced
+   matrix_leave_room_synced
+   matrix_invite_user_to_room_synced
+   matrix_put_room_state_synced
+   matrix_advance_room_receipt_synced
    sync_timeline_contains
 );
 
@@ -104,7 +104,7 @@ sub sync_timeline_contains
    sync_room_contains( $sync_body, $room_id, "timeline", $check );
 }
 
-sub matrix_send_room_text_message_and_wait_for_sync
+sub matrix_send_room_text_message_synced
 {
    my ( $user, $room_id, %params ) = @_;
 
@@ -122,7 +122,7 @@ sub matrix_send_room_text_message_and_wait_for_sync
    );
 }
 
-sub matrix_send_room_message_and_wait_for_sync
+sub matrix_send_room_message_synced
 {
    my ( $user, $room_id, %params ) = @_;
 
@@ -140,7 +140,7 @@ sub matrix_send_room_message_and_wait_for_sync
    );
 }
 
-sub matrix_create_room_and_wait_for_sync
+sub matrix_create_room_synced
 {
    my ( $user, %params ) = @_;
 
@@ -152,7 +152,7 @@ sub matrix_create_room_and_wait_for_sync
    );
 }
 
-sub matrix_join_room_and_wait_for_sync
+sub matrix_join_room_synced
 {
    my ( $user, $room_id, %params ) = @_;
 
@@ -164,7 +164,7 @@ sub matrix_join_room_and_wait_for_sync
    );
 }
 
-sub matrix_leave_room_and_wait_for_sync
+sub matrix_leave_room_synced
 {
    my ( $user, $room_id, %params ) = @_;
 
@@ -176,7 +176,7 @@ sub matrix_leave_room_and_wait_for_sync
    );
 }
 
-sub matrix_put_room_state_and_wait_for_sync
+sub matrix_put_room_state_synced
 {
    my ( $user, $room_id, %params ) = @_;
 
@@ -195,7 +195,7 @@ sub matrix_put_room_state_and_wait_for_sync
    );
 }
 
-sub matrix_invite_user_to_room_and_wait_for_sync
+sub matrix_invite_user_to_room_synced
 {
    my ( $inviter, $invitee, $room_id, %params ) = @_;
 
@@ -220,7 +220,7 @@ sub matrix_invite_user_to_room_and_wait_for_sync
    );
 }
 
-sub matrix_advance_room_receipt_and_wait_for_sync
+sub matrix_advance_room_receipt_synced
 {
    my ( $user, $room_id, $type, $event_id ) = @_;
 

--- a/tests/31sync/02sync.pl
+++ b/tests/31sync/02sync.pl
@@ -1,3 +1,210 @@
+use Future::Utils qw( repeat );
+
+push our @EXPORT, qw(
+   matrix_do_and_wait_for_sync
+   matrix_send_room_text_message_and_wait_for_sync
+   matrix_send_room_message_and_wait_for_sync
+   matrix_create_room_and_wait_for_sync
+   matrix_join_room_and_wait_for_sync
+   matrix_leave_room_and_wait_for_sync
+   matrix_invite_user_to_room_and_wait_for_sync
+   matrix_put_room_state_and_wait_for_sync
+   sync_timeline_contains
+);
+
+=head2 matrix_sync_until
+
+   my ( $sync_body ) = matrix_sync_until( $user, %query_params, until => sub {
+      my ( $sync_body ) = @_;
+
+      if acceptable( $sync_body ) {
+         return 1;
+      } else {
+         return 0;
+      }
+   )->get;
+
+A convenient wrapper around L</matrix_again> which repeatedly calls /sync
+until the contents of the response are acceptable.
+
+=cut
+
+
+sub matrix_do_and_wait_for_sync
+{
+   my ( $user, %params ) = @_;
+
+   my $check = delete $params{check} or die "Must supply a 'check' param";
+   my $do = delete $params{do} or die "Must supply a 'do' param";
+   $params{timeout} = $params{timeout} // 1000;
+
+   my $next_batch;
+
+   matrix_sync( $user,
+      filter => '{"room":{"rooms":[]},"account_data":{"types":[]},"presence":{"types":[]}}',
+      update_next_batch => 0,
+   )->then( sub {
+      my ( $body ) = @_;
+
+      $next_batch = $body->{next_batch};
+
+      $do->();
+   })->then( sub {
+      my ( $action_result ) = @_;
+
+      my $finished = repeat {
+            matrix_sync( $user,
+               %params,
+               since             => $next_batch,
+               update_next_batch => 0,
+            )->then( sub {
+               my ( $body ) = @_;
+
+               $next_batch = $body->{next_batch};
+
+               Future->done( $check->( $body, $action_result ) );
+            });
+         }
+         until => sub {
+            $_[0]->failure or $_[0]->get
+         };
+
+      $finished->then( sub { Future->done( $action_result ); } );
+   });
+}
+
+sub sync_timeline_contains
+{
+   my ( $sync_body, $room_id, $check ) = @_;
+
+   my $room =  $sync_body->{rooms}{join}{$room_id};
+
+   foreach my $event ( @{ $room->{timeline}{events} } ) {
+      if ( $check->( $event ) ) {
+         return 1;
+      }
+   }
+
+   return 0;
+}
+
+sub matrix_send_room_text_message_and_wait_for_sync
+{
+   my ( $user, $room_id, %params ) = @_;
+
+   matrix_do_and_wait_for_sync( $user,
+      do => sub {
+         matrix_send_room_text_message( $user, $room_id, %params );
+      },
+      check => sub {
+         my ( $sync_body, $event_id ) = @_;
+
+         sync_timeline_contains( $sync_body, $room_id, sub {
+            $_[0]->{event_id} eq $event_id
+         });
+      },
+   );
+}
+
+sub matrix_send_room_message_and_wait_for_sync
+{
+   my ( $user, $room_id, %params ) = @_;
+
+   matrix_do_and_wait_for_sync( $user,
+      do => sub {
+         matrix_send_room_message( $user, $room_id, %params );
+      },
+      check => sub {
+         my ( $sync_body, $event_id ) = @_;
+
+         sync_timeline_contains( $sync_body, $room_id, sub {
+            $_[0]->{event_id} eq $event_id
+         });
+      },
+   );
+}
+
+sub matrix_create_room_and_wait_for_sync
+{
+   my ( $user, %params ) = @_;
+
+   matrix_do_and_wait_for_sync( $user,
+      do => sub {
+         matrix_create_room( $user, %params );
+      },
+      check => sub { exists $_[0]->{rooms}{join}{$_[1]} },
+   );
+}
+
+sub matrix_join_room_and_wait_for_sync
+{
+   my ( $user, $room_id, %params ) = @_;
+
+   matrix_do_and_wait_for_sync( $user,
+      do => sub {
+         matrix_join_room( $user, $room_id, %params );
+      },
+      check => sub { exists $_[0]->{rooms}{join}{$room_id} },
+   );
+}
+
+sub matrix_leave_room_and_wait_for_sync
+{
+   my ( $user, $room_id, %params ) = @_;
+
+   matrix_do_and_wait_for_sync( $user,
+      do => sub {
+         matrix_leave_room( $user, $room_id, %params );
+      },
+      check => sub { exists $_[0]->{rooms}{leave}{$room_id} },
+   );
+}
+
+sub matrix_put_room_state_and_wait_for_sync
+{
+   my ( $user, $room_id, %params ) = @_;
+
+   matrix_do_and_wait_for_sync( $user,
+      do => sub {
+         matrix_put_room_state( $user, $room_id, %params );
+      },
+      check => sub {
+         my ( $sync_body, $put_result ) = @_;
+         my $event_id = $put_result->{event_id};
+
+         sync_timeline_contains( $sync_body, $room_id, sub {
+            $_[0]->{event_id} eq $event_id;
+         });
+      },
+   );
+}
+
+sub matrix_invite_user_to_room_and_wait_for_sync
+{
+   my ( $inviter, $invitee, $room_id, %params ) = @_;
+
+   matrix_do_and_wait_for_sync( $inviter,
+      do => sub {
+         matrix_do_and_wait_for_sync( $invitee,
+            do => sub {
+               matrix_invite_user_to_room(
+                  $inviter, $invitee, $room_id, %params
+               );
+            },
+            check => sub { exists $_[0]->{rooms}{invite}{$room_id} },
+         );
+      },
+      check => sub {
+         sync_timeline_contains( $_[0], $room_id, sub {
+            $_[0]->{type} eq "m.room.member"
+               and $_[0]->{state_key} eq $invitee->user_id
+               and $_[0]->{content}{membership} eq "invite"
+         });
+      },
+   );
+}
+
+
 test "Can sync",
     requires => [ local_user_fixture( with_events => 0 ),
                   qw( can_create_filter )],

--- a/tests/31sync/02sync.pl
+++ b/tests/31sync/02sync.pl
@@ -34,9 +34,9 @@ push our @EXPORT, qw(
 Does something and waits for the result to appear in an incremental sync.
 Doesn't affect the next_batch token used by matrix_sync_again.
 
-The do parameter is a subroutine with the action to perform that returns
+The C<do> parameter is a subroutine with the action to perform that returns
 a future.
-The check parameter is a subroutine that receives the body of an incremental
+The C<check> parameter is a subroutine that receives the body of an incremental
 sync and the result of performing the action. The check subroutine returns
 a true value if the incremental sync contains the result of the action, or a
 false value if the incremental sync does not.

--- a/tests/31sync/02sync.pl
+++ b/tests/31sync/02sync.pl
@@ -34,7 +34,7 @@ push our @EXPORT, qw(
 Does something and waits for the result to appear in an incremental sync.
 Doesn't affect the next_batch token used by matrix_sync_again.
 
-The do parameter is the a subroutine with the action to perform that returns
+The do parameter is a subroutine with the action to perform that returns
 a future.
 The check parameter is a subroutine that receives the body of an incremental
 sync and the result of performing the action. The check subroutine returns

--- a/tests/31sync/02sync.pl
+++ b/tests/31sync/02sync.pl
@@ -24,8 +24,9 @@ sub matrix_do_and_wait_for_sync
    my $next_batch;
 
    matrix_sync( $user,
-      filter => '{"room":{"rooms":[]},"account_data":{"types":[]},"presence":{"types":[]}}',
+      filter            => '{"room":{"rooms":[]},"account_data":{"types":[]},"presence":{"types":[]}}',
       update_next_batch => 0,
+      set_presence      => "offline",
    )->then( sub {
       my ( $body ) = @_;
 
@@ -40,6 +41,7 @@ sub matrix_do_and_wait_for_sync
                %params,
                since             => $next_batch,
                update_next_batch => 0,
+               set_presence      => "offline",
             )->then( sub {
                my ( $body ) = @_;
 

--- a/tests/31sync/03joined.pl
+++ b/tests/31sync/03joined.pl
@@ -1,3 +1,5 @@
+use Future::Utils qw( repeat );
+
 test "Can sync a joined room",
    requires => [ local_user_fixture( with_events => 0 ),
                  qw( can_sync ) ],
@@ -12,7 +14,7 @@ test "Can sync a joined room",
       matrix_create_filter( $user, $filter )->then( sub {
          ( $filter_id ) = @_;
 
-         matrix_create_room( $user )
+         matrix_create_room_and_wait_for_sync( $user )
       })->then( sub {
          ( $room_id ) = @_;
 
@@ -52,7 +54,7 @@ test "Full state sync includes joined rooms",
       matrix_create_filter( $user, $filter )->then( sub {
          ( $filter_id ) = @_;
 
-         matrix_create_room( $user )
+         matrix_create_room_and_wait_for_sync( $user )
       })->then( sub {
          ( $room_id ) = @_;
 
@@ -92,11 +94,11 @@ test "Newly joined room is included in an incremental sync",
 
          matrix_sync( $user, filter => $filter_id );
       })->then( sub {
-         matrix_create_room( $user );
+         matrix_create_room_and_wait_for_sync( $user );
       })->then( sub {
          ( $room_id ) = @_;
 
-         matrix_sync_again( $user, filter => $filter_id );
+         matrix_sync_again( $user, filter => $filter_id);
       })->then( sub {
          my ( $body ) = @_;
 

--- a/tests/31sync/03joined.pl
+++ b/tests/31sync/03joined.pl
@@ -154,7 +154,7 @@ test "Newly joined room has correct timeline in incremental sync",
             matrix_send_room_text_message( $user_a, $room_id, body => "test" );
          } 0 .. 3 );
       })->then( sub {
-         matrix_join_room( $user_b, $room_id );
+         matrix_join_room_and_wait_for_sync( $user_b, $room_id );
       })->then( sub {
          matrix_sync_again( $user_b, filter => $filter_id_b );
       })->then( sub {
@@ -201,7 +201,7 @@ test "Newly joined room includes presence in incremental sync",
 
          matrix_sync( $user_b );
       })->then( sub {
-         matrix_join_room( $user_b, $room_id );
+         matrix_join_room_and_wait_for_sync( $user_b, $room_id );
       })->then( sub {
          matrix_sync_again( $user_b );
       })->then( sub {
@@ -254,7 +254,13 @@ test "Get presence for newly joined members in incremental sync",
 
          matrix_sync( $user_a );
       })->then( sub {
-         matrix_join_room( $user_b, $room_id );
+         matrix_send_room_text_message_and_wait_for_sync( $user_a, $room_id,
+            body => "Wait for presence changes cause by the first sync to trickle through",
+         );
+      })->then( sub {
+         matrix_sync_again( $user_a );
+      })->then( sub {
+         matrix_join_room_and_wait_for_sync( $user_b, $room_id );
       })->then( sub {
          matrix_sync_again( $user_a );
       })->then( sub {
@@ -265,6 +271,7 @@ test "Get presence for newly joined members in incremental sync",
          assert_json_list( $body->{presence}{events} );
 
          my $presence = $body->{presence}{events};
+         log_if_fail "Presence", $presence;
 
          assert_eq( scalar @$presence, 1, "number of presence events" );
 

--- a/tests/31sync/03joined.pl
+++ b/tests/31sync/03joined.pl
@@ -255,7 +255,7 @@ test "Get presence for newly joined members in incremental sync",
          matrix_sync( $user_a );
       })->then( sub {
          matrix_send_room_text_message_and_wait_for_sync( $user_a, $room_id,
-            body => "Wait for presence changes cause by the first sync to trickle through",
+            body => "Wait for presence changes caused by the first sync to trickle through",
          );
       })->then( sub {
          matrix_sync_again( $user_a );

--- a/tests/31sync/03joined.pl
+++ b/tests/31sync/03joined.pl
@@ -14,7 +14,7 @@ test "Can sync a joined room",
       matrix_create_filter( $user, $filter )->then( sub {
          ( $filter_id ) = @_;
 
-         matrix_create_room_and_wait_for_sync( $user )
+         matrix_create_room_synced( $user )
       })->then( sub {
          ( $room_id ) = @_;
 
@@ -54,7 +54,7 @@ test "Full state sync includes joined rooms",
       matrix_create_filter( $user, $filter )->then( sub {
          ( $filter_id ) = @_;
 
-         matrix_create_room_and_wait_for_sync( $user )
+         matrix_create_room_synced( $user )
       })->then( sub {
          ( $room_id ) = @_;
 
@@ -94,7 +94,7 @@ test "Newly joined room is included in an incremental sync",
 
          matrix_sync( $user, filter => $filter_id );
       })->then( sub {
-         matrix_create_room_and_wait_for_sync( $user );
+         matrix_create_room_synced( $user );
       })->then( sub {
          ( $room_id ) = @_;
 
@@ -154,7 +154,7 @@ test "Newly joined room has correct timeline in incremental sync",
             matrix_send_room_text_message( $user_a, $room_id, body => "test" );
          } 0 .. 3 );
       })->then( sub {
-         matrix_join_room_and_wait_for_sync( $user_b, $room_id );
+         matrix_join_room_synced( $user_b, $room_id );
       })->then( sub {
          matrix_sync_again( $user_b, filter => $filter_id_b );
       })->then( sub {
@@ -201,7 +201,7 @@ test "Newly joined room includes presence in incremental sync",
 
          matrix_sync( $user_b );
       })->then( sub {
-         matrix_join_room_and_wait_for_sync( $user_b, $room_id );
+         matrix_join_room_synced( $user_b, $room_id );
       })->then( sub {
          matrix_sync_again( $user_b );
       })->then( sub {
@@ -254,13 +254,13 @@ test "Get presence for newly joined members in incremental sync",
 
          matrix_sync( $user_a );
       })->then( sub {
-         matrix_send_room_text_message_and_wait_for_sync( $user_a, $room_id,
+         matrix_send_room_text_message_synced( $user_a, $room_id,
             body => "Wait for presence changes caused by the first sync to trickle through",
          );
       })->then( sub {
          matrix_sync_again( $user_a );
       })->then( sub {
-         matrix_join_room_and_wait_for_sync( $user_b, $room_id );
+         matrix_join_room_synced( $user_b, $room_id );
       })->then( sub {
          matrix_sync_again( $user_a );
       })->then( sub {

--- a/tests/31sync/04timeline.pl
+++ b/tests/31sync/04timeline.pl
@@ -21,7 +21,7 @@ test "Can sync a room with a single message",
          );
       })->then( sub {
          ( $event_id_1 ) = @_;
-         matrix_send_room_text_message_and_wait_for_sync( $user, $room_id,
+         matrix_send_room_text_message_synced( $user, $room_id,
             body => "Test message 2",
          );
       })->then( sub {
@@ -76,7 +76,7 @@ test "Can sync a room with a message with a transaction id",
       })->then( sub {
          ( $room_id ) = @_;
 
-         matrix_send_room_text_message_and_wait_for_sync( $user, $room_id,
+         matrix_send_room_text_message_synced( $user, $room_id,
             body => "A test message", txn_id => "my_transaction_id"
          );
       })->then( sub {
@@ -125,7 +125,7 @@ test "A message sent after an initial sync appears in the timeline of an increme
       matrix_create_filter( $user, $filter )->then( sub {
          ( $filter_id ) = @_;
 
-         matrix_create_room_and_wait_for_sync( $user );
+         matrix_create_room_synced( $user );
       })->then( sub {
          ( $room_id ) = @_;
 
@@ -133,7 +133,7 @@ test "A message sent after an initial sync appears in the timeline of an increme
       })->then( sub {
          my ( $body ) = @_;
 
-         matrix_send_room_text_message_and_wait_for_sync( $user, $room_id,
+         matrix_send_room_text_message_synced( $user, $room_id,
             body => "A test message", txn_id => "my_transaction_id"
          );
       })->then( sub {
@@ -195,7 +195,7 @@ test "A filtered timeline reaches its limit",
          ( $event_id ) = @_;
 
          Future->needs_all( map {
-            matrix_send_room_message_and_wait_for_sync( $user, $room_id,
+            matrix_send_room_message_synced( $user, $room_id,
                content => { "filler" => $_ },
                type    => "a.made.up.filler.type",
             )
@@ -238,7 +238,7 @@ test "Syncing a new room with a large timeline limit isn't limited",
       matrix_create_filter( $user, $filter )->then( sub {
          ( $filter_id ) = @_;
 
-         matrix_create_room_and_wait_for_sync( $user );
+         matrix_create_room_synced( $user );
       })->then( sub {
          ( $room_id ) = @_;
 
@@ -272,7 +272,7 @@ test "A full_state incremental update returns only recent timeline",
       matrix_create_filter( $user, $filter )->then( sub {
          ( $filter_id ) = @_;
 
-         matrix_create_room_and_wait_for_sync( $user );
+         matrix_create_room_synced( $user );
       })->then( sub {
          ( $room_id ) = @_;
 
@@ -287,7 +287,7 @@ test "A full_state incremental update returns only recent timeline",
             )
          } 0 .. 10 );
       })->then( sub {
-         matrix_send_room_message_and_wait_for_sync( $user, $room_id,
+         matrix_send_room_message_synced( $user, $room_id,
             content => { "filler" => 11 },
             type    => "another.filler.type",
          );
@@ -332,7 +332,7 @@ test "A prev_batch token can be used in the v1 messages API",
       })->then( sub {
          ( $event_id_1 ) = @_;
 
-         matrix_send_room_text_message_and_wait_for_sync( $user, $room_id,
+         matrix_send_room_text_message_synced( $user, $room_id,
             body => "2"
          );
       })->then( sub {
@@ -395,7 +395,7 @@ test "A next_batch token can be used in the v1 messages API",
       })->then( sub {
          ( $room_id ) = @_;
 
-         matrix_send_room_text_message_and_wait_for_sync( $user, $room_id,
+         matrix_send_room_text_message_synced( $user, $room_id,
             body => "1"
          );
       })->then( sub {

--- a/tests/31sync/04timeline.pl
+++ b/tests/31sync/04timeline.pl
@@ -21,8 +21,7 @@ test "Can sync a room with a single message",
          );
       })->then( sub {
          ( $event_id_1 ) = @_;
-
-         matrix_send_room_text_message( $user, $room_id,
+         matrix_send_room_text_message_and_wait_for_sync( $user, $room_id,
             body => "Test message 2",
          );
       })->then( sub {
@@ -77,7 +76,7 @@ test "Can sync a room with a message with a transaction id",
       })->then( sub {
          ( $room_id ) = @_;
 
-         matrix_send_room_text_message( $user, $room_id,
+         matrix_send_room_text_message_and_wait_for_sync( $user, $room_id,
             body => "A test message", txn_id => "my_transaction_id"
          );
       })->then( sub {
@@ -126,7 +125,7 @@ test "A message sent after an initial sync appears in the timeline of an increme
       matrix_create_filter( $user, $filter )->then( sub {
          ( $filter_id ) = @_;
 
-         matrix_create_room( $user );
+         matrix_create_room_and_wait_for_sync( $user );
       })->then( sub {
          ( $room_id ) = @_;
 
@@ -134,7 +133,7 @@ test "A message sent after an initial sync appears in the timeline of an increme
       })->then( sub {
          my ( $body ) = @_;
 
-         matrix_send_room_text_message( $user, $room_id,
+         matrix_send_room_text_message_and_wait_for_sync( $user, $room_id,
             body => "A test message", txn_id => "my_transaction_id"
          );
       })->then( sub {
@@ -196,7 +195,7 @@ test "A filtered timeline reaches its limit",
          ( $event_id ) = @_;
 
          Future->needs_all( map {
-            matrix_send_room_message( $user, $room_id,
+            matrix_send_room_message_and_wait_for_sync( $user, $room_id,
                content => { "filler" => $_ },
                type    => "a.made.up.filler.type",
             )
@@ -239,7 +238,7 @@ test "Syncing a new room with a large timeline limit isn't limited",
       matrix_create_filter( $user, $filter )->then( sub {
          ( $filter_id ) = @_;
 
-         matrix_create_room( $user );
+         matrix_create_room_and_wait_for_sync( $user );
       })->then( sub {
          ( $room_id ) = @_;
 
@@ -273,7 +272,7 @@ test "A full_state incremental update returns only recent timeline",
       matrix_create_filter( $user, $filter )->then( sub {
          ( $filter_id ) = @_;
 
-         matrix_create_room( $user );
+         matrix_create_room_and_wait_for_sync( $user );
       })->then( sub {
          ( $room_id ) = @_;
 
@@ -288,10 +287,10 @@ test "A full_state incremental update returns only recent timeline",
             )
          } 0 .. 10 );
       })->then( sub {
-         matrix_send_room_message( $user, $room_id,
-               content => { "filler" => $_ },
-               type    => "another.filler.type",
-             );
+         matrix_send_room_message_and_wait_for_sync( $user, $room_id,
+            content => { "filler" => 11 },
+            type    => "another.filler.type",
+         );
       })->then( sub {
          matrix_sync_again( $user, filter => $filter_id, full_state => 'true' );
       })->then( sub {
@@ -333,7 +332,9 @@ test "A prev_batch token can be used in the v1 messages API",
       })->then( sub {
          ( $event_id_1 ) = @_;
 
-         matrix_send_room_text_message( $user, $room_id, body => "2" );
+         matrix_send_room_text_message_and_wait_for_sync( $user, $room_id,
+            body => "2"
+         );
       })->then( sub {
          ( $event_id_2 ) = @_;
 
@@ -394,7 +395,9 @@ test "A next_batch token can be used in the v1 messages API",
       })->then( sub {
          ( $room_id ) = @_;
 
-         matrix_send_room_text_message( $user, $room_id, body => "1" );
+         matrix_send_room_text_message_and_wait_for_sync( $user, $room_id,
+            body => "1"
+         );
       })->then( sub {
          ( $event_id_1 ) = @_;
 

--- a/tests/31sync/06state.pl
+++ b/tests/31sync/06state.pl
@@ -582,7 +582,7 @@ test "A change to displayname should appear in incremental /sync",
    requires => [ local_user_fixture( with_events => 0 ),
                  qw( can_sync ) ],
 
-   bug => "SYN-?",
+   bug => "SYN-707",
 
    check => sub {
       my ( $user ) = @_;

--- a/tests/31sync/06state.pl
+++ b/tests/31sync/06state.pl
@@ -50,7 +50,7 @@ test "State is included in the timeline in the initial sync",
       })->then( sub {
          ( $room_id ) = @_;
 
-         matrix_put_room_state_and_wait_for_sync( $user, $room_id,
+         matrix_put_room_state_synced( $user, $room_id,
             type    => "a.madeup.test.state",
             content => { "my_key" => 1 },
          );
@@ -109,11 +109,11 @@ test "State from remote users is included in the state in the initial sync",
                                    type    => "a.madeup.test.state",
                                    content => { "my_key" => 1 });
         })->then( sub {
-            matrix_invite_user_to_room_and_wait_for_sync(
+            matrix_invite_user_to_room_synced(
                $remote_user, $user, $room_id
             );
         })->then( sub {
-            matrix_join_room_and_wait_for_sync( $user, $room_id );
+            matrix_join_room_synced( $user, $room_id );
         })->then( sub {
             matrix_sync( $user, filter => $filter_id );
         })->then( sub {
@@ -169,7 +169,7 @@ test "Changes to state are included in an incremental sync",
             state_key => "this_state_changes"
          );
       })->then( sub {
-         matrix_put_room_state_and_wait_for_sync( $user, $room_id,
+         matrix_put_room_state_synced( $user, $room_id,
             type      => "a.madeup.test.state",
             content   => { "my_key" => 1 },
             state_key => "this_state_does_not_change"
@@ -177,7 +177,7 @@ test "Changes to state are included in an incremental sync",
       })->then( sub {
          matrix_sync( $user, filter => $filter_id );
       })->then( sub {
-         matrix_put_room_state_and_wait_for_sync( $user, $room_id,
+         matrix_put_room_state_synced( $user, $room_id,
             type      => "a.madeup.test.state",
             content   => { "my_key" => 2 },
             state_key => "this_state_changes",
@@ -236,7 +236,7 @@ test "Changes to state are included in an gapped incremental sync",
             state_key => "this_state_changes"
          )
       })->then( sub {
-         matrix_put_room_state_and_wait_for_sync( $user, $room_id,
+         matrix_put_room_state_synced( $user, $room_id,
             type      => "a.madeup.test.state",
             content   => { "my_key" => 1 },
             state_key => "this_state_does_not_change"
@@ -262,7 +262,7 @@ test "Changes to state are included in an gapped incremental sync",
             )
          } 0 .. 19 );
       })->then( sub {
-         matrix_send_room_message_and_wait_for_sync( $user, $room_id,
+         matrix_send_room_message_synced( $user, $room_id,
             content => { "filler" => 20 },
             type    => "a.made.up.filler.type",
          );
@@ -311,11 +311,11 @@ test "State from remote users is included in the timeline in an incremental sync
             matrix_create_room( $remote_user );
         })->then( sub {
             ( $room_id ) = @_;
-            matrix_invite_user_to_room_and_wait_for_sync(
+            matrix_invite_user_to_room_synced(
                $remote_user, $user, $room_id
             );
         })->then( sub {
-            matrix_join_room_and_wait_for_sync( $user, $room_id );
+            matrix_join_room_synced( $user, $room_id );
         })->then( sub {
             matrix_sync( $user, filter => $filter_id );
         })->then( sub {
@@ -383,7 +383,7 @@ test "A full_state incremental update returns all state",
             state_key => "this_state_changes"
          );
       })->then( sub {
-         matrix_put_room_state_and_wait_for_sync( $user, $room_id,
+         matrix_put_room_state_synced( $user, $room_id,
             type      => "a.madeup.test.state",
             content   => { "my_key" => 1 },
             state_key => "this_state_does_not_change"
@@ -405,7 +405,7 @@ test "A full_state incremental update returns all state",
          );
       })->then( sub {
          Future->needs_all( map {
-            matrix_send_room_message_and_wait_for_sync( $user, $room_id,
+            matrix_send_room_message_synced( $user, $room_id,
                content => { "filler" => $_ },
                type    => "a.made.up.filler.type",
             )
@@ -488,13 +488,13 @@ test "When user joins a room the state is included in the next sync",
             state_key => "",
          );
       })->then( sub {
-         matrix_invite_user_to_room_and_wait_for_sync(
+         matrix_invite_user_to_room_synced(
             $user_a, $user_b, $room_id
          );
       })->then( sub {
          matrix_sync( $user_b, filter => $filter_id_b );
       })->then( sub {
-         matrix_join_room_and_wait_for_sync( $user_b, $room_id );
+         matrix_join_room_synced( $user_b, $room_id );
       })->then( sub {
          matrix_sync_again( $user_b, filter => $filter_id_b );
       })->then( sub {
@@ -540,7 +540,7 @@ test "A change to displayname should not result in a full state sync",
       })->then( sub {
          ( $room_id ) = @_;
 
-         matrix_put_room_state_and_wait_for_sync( $user, $room_id,
+         matrix_put_room_state_synced( $user, $room_id,
             type      => "a.madeup.test.state",
             content   => { "my_key" => 1 },
             state_key => ""
@@ -560,7 +560,7 @@ test "A change to displayname should not result in a full state sync",
             state_key => $user->user_id,
          );
       })->then( sub {
-         matrix_send_room_text_message_and_wait_for_sync( $user, $room_id,
+         matrix_send_room_text_message_synced( $user, $room_id,
             body => "A message to wait on because the m.room.member doesn't come down /sync"
          );
       })->then( sub {
@@ -592,7 +592,7 @@ test "A change to displayname should appear in incremental /sync",
       matrix_create_filter( $user, {} )->then( sub {
          ( $filter_id ) = @_;
 
-         matrix_create_room_and_wait_for_sync( $user );
+         matrix_create_room_synced( $user );
       })->then( sub {
          ( $room_id ) = @_;
 
@@ -608,7 +608,7 @@ test "A change to displayname should appear in incremental /sync",
       })->then( sub {
          ( $event_id_1 ) = @_;
 
-         matrix_send_room_text_message_and_wait_for_sync( $user, $room_id,
+         matrix_send_room_text_message_synced( $user, $room_id,
             body => "A message to wait on because the m.room.member might not come down /sync"
           );
       })->then( sub {
@@ -665,7 +665,7 @@ test "When user joins a room the state is included in a gapped sync",
             state_key => ""
          )
       })->then( sub {
-         matrix_invite_user_to_room_and_wait_for_sync(
+         matrix_invite_user_to_room_synced(
             $user_a, $user_b, $room_id
          );
       })->then( sub {
@@ -680,7 +680,7 @@ test "When user joins a room the state is included in a gapped sync",
             )
          } 0 .. 19 );
       })->then( sub {
-         matrix_send_room_message_and_wait_for_sync( $user_a, $room_id,
+         matrix_send_room_message_synced( $user_a, $room_id,
             content => { "filler" => 20 },
             type    => "a.made.up.filler.type",
          );
@@ -742,7 +742,7 @@ test "When user joins and leaves a room in the same batch, the full state is sti
             state_key => "",
          );
       })->then( sub {
-         matrix_invite_user_to_room_and_wait_for_sync(
+         matrix_invite_user_to_room_synced(
             $user_a, $user_b, $room_id
          );
       })->then( sub {
@@ -750,7 +750,7 @@ test "When user joins and leaves a room in the same batch, the full state is sti
       })->then( sub {
          matrix_join_room( $user_b, $room_id );
       })->then( sub {
-         matrix_leave_room_and_wait_for_sync( $user_b, $room_id );
+         matrix_leave_room_synced( $user_b, $room_id );
       })->then( sub {
          matrix_sync_again( $user_b, filter => $filter_id_b );
       })->then( sub {

--- a/tests/31sync/07invited.pl
+++ b/tests/31sync/07invited.pl
@@ -19,7 +19,9 @@ test "Rooms a user is invited to appear in an initial sync",
       })->then( sub {
          ( $room_id ) = @_;
 
-         matrix_invite_user_to_room( $user_a, $user_b, $room_id );
+         matrix_invite_user_to_room_and_wait_for_sync(
+            $user_a, $user_b, $room_id
+         );
       })->then( sub {
          matrix_sync( $user_b, filter => $filter_id_b );
       })->then( sub {
@@ -66,7 +68,9 @@ test "Rooms a user is invited to appear in an incremental sync",
       })->then( sub {
          ( $room_id ) = @_;
 
-         matrix_invite_user_to_room( $user_a, $user_b, $room_id );
+         matrix_invite_user_to_room_and_wait_for_sync(
+            $user_a, $user_b, $room_id
+         );
       })->then( sub {
          matrix_sync_again( $user_b, filter => $filter_id_b );
       })->then( sub {

--- a/tests/31sync/07invited.pl
+++ b/tests/31sync/07invited.pl
@@ -19,7 +19,7 @@ test "Rooms a user is invited to appear in an initial sync",
       })->then( sub {
          ( $room_id ) = @_;
 
-         matrix_invite_user_to_room_and_wait_for_sync(
+         matrix_invite_user_to_room_synced(
             $user_a, $user_b, $room_id
          );
       })->then( sub {
@@ -68,7 +68,7 @@ test "Rooms a user is invited to appear in an incremental sync",
       })->then( sub {
          ( $room_id ) = @_;
 
-         matrix_invite_user_to_room_and_wait_for_sync(
+         matrix_invite_user_to_room_synced(
             $user_a, $user_b, $room_id
          );
       })->then( sub {

--- a/tests/31sync/08polling.pl
+++ b/tests/31sync/08polling.pl
@@ -10,7 +10,7 @@ test "Sync can be polled for updates",
       matrix_create_filter( $user, {} )->then( sub {
          ( $filter_id ) = @_;
 
-         matrix_create_room_and_wait_for_sync( $user );
+         matrix_create_room_synced( $user );
       })->then( sub {
          ( $room_id ) = @_;
 
@@ -56,7 +56,7 @@ test "Sync is woken up for leaves",
       matrix_create_filter( $user, {} )->then( sub {
          ( $filter_id ) = @_;
 
-         matrix_create_room_and_wait_for_sync( $user );
+         matrix_create_room_synced( $user );
       })->then( sub {
          ( $room_id ) = @_;
 

--- a/tests/31sync/08polling.pl
+++ b/tests/31sync/08polling.pl
@@ -10,7 +10,7 @@ test "Sync can be polled for updates",
       matrix_create_filter( $user, {} )->then( sub {
          ( $filter_id ) = @_;
 
-         matrix_create_room( $user );
+         matrix_create_room_and_wait_for_sync( $user );
       })->then( sub {
          ( $room_id ) = @_;
 
@@ -56,7 +56,7 @@ test "Sync is woken up for leaves",
       matrix_create_filter( $user, {} )->then( sub {
          ( $filter_id ) = @_;
 
-         matrix_create_room( $user );
+         matrix_create_room_and_wait_for_sync( $user );
       })->then( sub {
          ( $room_id ) = @_;
 

--- a/tests/31sync/09archived.pl
+++ b/tests/31sync/09archived.pl
@@ -16,7 +16,7 @@ test "Left rooms appear in the leave section of sync",
       })->then( sub {
          ( $room_id ) = @_;
 
-         matrix_leave_room_and_wait_for_sync( $user, $room_id );
+         matrix_leave_room_synced( $user, $room_id );
       })->then( sub {
          matrix_sync( $user, filter => $filter_id );
       })->then( sub {
@@ -44,13 +44,13 @@ test "Newly left rooms appear in the leave section of incremental sync",
      )->then( sub {
          ( $filter_id ) = @_;
 
-         matrix_create_room_and_wait_for_sync( $user );
+         matrix_create_room_synced( $user );
       })->then( sub {
          ( $room_id ) = @_;
 
          matrix_sync( $user, filter => $filter_id );
       })->then( sub {
-         matrix_leave_room_and_wait_for_sync( $user, $room_id );
+         matrix_leave_room_synced( $user, $room_id );
       })->then( sub {
          matrix_sync_again( $user, filter => $filter_id );
       })->then( sub {
@@ -85,14 +85,14 @@ test "We should see our own leave event, even if history_visibility is " .
       })->then( sub {
          ( $room_id ) = @_;
 
-         matrix_put_room_state_and_wait_for_sync( $user, $room_id,
+         matrix_put_room_state_synced( $user, $room_id,
             type    => "m.room.history_visibility",
             content => { history_visibility => "joined" },
          );
       })->then( sub {
          matrix_sync( $user, filter => $filter_id );
       })->then( sub {
-         matrix_leave_room_and_wait_for_sync( $user, $room_id );
+         matrix_leave_room_synced( $user, $room_id );
       })->then( sub {
          matrix_sync_again( $user, filter => $filter_id );
       })->then( sub {
@@ -133,8 +133,8 @@ test "Newly left rooms appear in the leave section of gapped sync",
       matrix_create_filter( $user, {} )->then( sub {
          ( $filter_id ) = @_;
          Future->needs_all(
-            matrix_create_room_and_wait_for_sync( $user )->on_done( sub { ( $room_id_1 ) = @_; } ),
-            matrix_create_room_and_wait_for_sync( $user )->on_done( sub { ( $room_id_2 ) = @_; } ),
+            matrix_create_room_synced( $user )->on_done( sub { ( $room_id_1 ) = @_; } ),
+            matrix_create_room_synced( $user )->on_done( sub { ( $room_id_2 ) = @_; } ),
          );
       })->then( sub {
          matrix_sync( $user, filter => $filter_id );
@@ -153,7 +153,7 @@ test "Newly left rooms appear in the leave section of gapped sync",
             )
          } 0 .. 19 );
       })->then( sub {
-         matrix_send_room_message_and_wait_for_sync( $user, $room_id_2,
+         matrix_send_room_message_synced( $user, $room_id_2,
             content => { "filler" => 20 },
             type    => "a.made.up.filler.type",
          );
@@ -193,11 +193,11 @@ test "Previously left rooms don't appear in the leave section of sync",
       })->then( sub {
          matrix_join_room( $user2, $room_id_1 );
       })->then( sub {
-         matrix_join_room_and_wait_for_sync( $user2, $room_id_2 );
+         matrix_join_room_synced( $user2, $room_id_2 );
       })->then( sub {
          matrix_sync( $user, filter => $filter_id );
       })->then( sub {
-         matrix_leave_room_and_wait_for_sync( $user, $room_id_1 );
+         matrix_leave_room_synced( $user, $room_id_1 );
       })->then( sub {
          matrix_sync_again( $user, filter => $filter_id );
       })->then( sub {
@@ -217,7 +217,7 @@ test "Previously left rooms don't appear in the leave section of sync",
          }  0 .. 4 );
 
       })->then( sub {
-         matrix_send_room_message_and_wait_for_sync( $user2, $room_id_2,
+         matrix_send_room_message_synced( $user2, $room_id_2,
             content => { "filler" => 5 },
             type    => "a.made.up.filler.type",
          );
@@ -251,13 +251,13 @@ test "Left rooms appear in the leave section of full state sync",
       )->then( sub {
          ( $filter_id ) = @_;
 
-         matrix_create_room_and_wait_for_sync( $user );
+         matrix_create_room_synced( $user );
       })->then( sub {
          ( $room_id ) = @_;
 
          matrix_sync( $user, filter => $filter_id );
       })->then( sub {
-         matrix_leave_room_and_wait_for_sync( $user, $room_id );
+         matrix_leave_room_synced( $user, $room_id );
       })->then( sub {
          matrix_sync_again( $user, filter => $filter_id, full_state => 'true' );
       })->then( sub {
@@ -298,7 +298,7 @@ test "Archived rooms only contain history from before the user left",
       })->then( sub {
          ( $room_id ) = @_;
 
-         matrix_join_room_and_wait_for_sync( $user_b, $room_id );
+         matrix_join_room_synced( $user_b, $room_id );
       })->then( sub {
          matrix_sync( $user_b, filter => $filter_id_b );
       })->then( sub {
@@ -318,7 +318,7 @@ test "Archived rooms only contain history from before the user left",
       })->then( sub {
          matrix_send_room_text_message( $user_a, $room_id, body => "after" );
       })->then( sub {
-         matrix_put_room_state_and_wait_for_sync( $user_a, $room_id,
+         matrix_put_room_state_synced( $user_a, $room_id,
             type      => "a.madeup.test.state",
             content   => { "my_key" => "after" },
             state_key => "",

--- a/tests/31sync/09archived.pl
+++ b/tests/31sync/09archived.pl
@@ -132,11 +132,9 @@ test "Newly left rooms appear in the leave section of gapped sync",
 
       matrix_create_filter( $user, {} )->then( sub {
          ( $filter_id ) = @_;
-
-         matrix_create_room( $user )->on_done( sub { ( $room_id_1 ) = @_; } );
-      })->then( sub {
-         matrix_create_room_and_wait_for_sync($user )->on_done( sub {
-            ( $room_id_2 ) = @_; }
+         Future->needs_all(
+            matrix_create_room_and_wait_for_sync( $user )->on_done( sub { ( $room_id_1 ) = @_; } ),
+            matrix_create_room_and_wait_for_sync( $user )->on_done( sub { ( $room_id_2 ) = @_; } ),
          );
       })->then( sub {
          matrix_sync( $user, filter => $filter_id );

--- a/tests/31sync/10archived-ban.pl
+++ b/tests/31sync/10archived-ban.pl
@@ -1,3 +1,25 @@
+sub ban_user_and_wait_for_sync
+{
+   my ( $banner, $bannee, $room_id ) = @_;
+
+   matrix_do_and_wait_for_sync( $banner,
+      do => sub {
+         do_request_json_for( $banner,
+            method => "POST",
+            uri    => "/r0/rooms/$room_id/ban",
+            content => { user_id => $bannee->user_id, reason => "testing" },
+         );
+      },
+      check => sub {
+         sync_timeline_contains( $_[0], $room_id, sub {
+            $_[0]->{type} eq "m.room.member"
+               and $_[0]->{state_key} eq $bannee->user_id
+               and $_[0]->{content}{membership} eq "ban"
+         });
+      }
+   );
+}
+
 test "Banned rooms appear in the leave section of sync",
    requires => [ local_user_fixtures( 2, with_events => 0 ),
                  qw( can_sync ) ],
@@ -19,14 +41,9 @@ test "Banned rooms appear in the leave section of sync",
       })->then( sub {
          ( $room_id ) = @_;
 
-         matrix_join_room( $user_b, $room_id);
+         matrix_join_room( $user_b, $room_id );
       })->then( sub {
-
-         do_request_json_for( $user_a,
-            method => "POST",
-            uri    => "/r0/rooms/$room_id/ban",
-            content => { user_id => $user_b->user_id, reason => "testing" },
-         );
+         ban_user_and_wait_for_sync( $user_a, $user_b, $room_id );
       })->then( sub {
          matrix_sync( $user_b, filter => $filter_id_b );
       })->then( sub {
@@ -65,11 +82,7 @@ test "Newly banned rooms appear in the leave section of incremental sync",
       })->then( sub {
          matrix_sync( $user_b, filter => $filter_id_b );
       })->then( sub {
-         do_request_json_for( $user_a,
-            method => "POST",
-            uri    => "/r0/rooms/$room_id/ban",
-            content => { user_id => $user_b->user_id, reason => "testing" },
-         );
+         ban_user_and_wait_for_sync( $user_a, $user_b, $room_id );
       })->then( sub {
          matrix_sync_again( $user_b, filter => $filter_id_b );
       })->then( sub {
@@ -119,7 +132,12 @@ test "Newly banned rooms appear in the leave section of incremental sync",
                content => { "filler" => $_ },
                type    => "a.made.up.filler.type",
             )
-         } 0 .. 20 );
+         } 0 .. 19 );
+      })->then( sub {
+         matrix_send_room_message_and_wait_for_sync( $user_a, $room_id,
+            content => { "filler" => 20 },
+            type    => "a.made.up.filler.type",
+         );
       })->then( sub {
          matrix_sync_again( $user_b, filter => $filter_id_b );
       })->then( sub {

--- a/tests/31sync/10archived-ban.pl
+++ b/tests/31sync/10archived-ban.pl
@@ -1,4 +1,4 @@
-sub ban_user_and_wait_for_sync
+sub ban_user_synced
 {
    my ( $banner, $bannee, $room_id ) = @_;
 
@@ -43,7 +43,7 @@ test "Banned rooms appear in the leave section of sync",
 
          matrix_join_room( $user_b, $room_id );
       })->then( sub {
-         ban_user_and_wait_for_sync( $user_a, $user_b, $room_id );
+         ban_user_synced( $user_a, $user_b, $room_id );
       })->then( sub {
          matrix_sync( $user_b, filter => $filter_id_b );
       })->then( sub {
@@ -82,7 +82,7 @@ test "Newly banned rooms appear in the leave section of incremental sync",
       })->then( sub {
          matrix_sync( $user_b, filter => $filter_id_b );
       })->then( sub {
-         ban_user_and_wait_for_sync( $user_a, $user_b, $room_id );
+         ban_user_synced( $user_a, $user_b, $room_id );
       })->then( sub {
          matrix_sync_again( $user_b, filter => $filter_id_b );
       })->then( sub {
@@ -134,7 +134,7 @@ test "Newly banned rooms appear in the leave section of incremental sync",
             )
          } 0 .. 19 );
       })->then( sub {
-         matrix_send_room_message_and_wait_for_sync( $user_a, $room_id,
+         matrix_send_room_message_synced( $user_a, $room_id,
             content => { "filler" => 20 },
             type    => "a.made.up.filler.type",
          );

--- a/tests/31sync/12receipts.pl
+++ b/tests/31sync/12receipts.pl
@@ -83,7 +83,9 @@ test "New read receipts appear in incremental v2 /sync",
 
          matrix_sync( $user, filter => $filter_id );
       })->then( sub {
-         matrix_advance_room_receipt( $user, $room_id, "m.read", $event_id );
+         matrix_advance_room_receipt_and_wait_for_sync(
+            $user, $room_id, "m.read", $event_id
+         );
       })->then( sub {
          matrix_sync_again( $user, filter => $filter_id );
       })->then( sub {

--- a/tests/31sync/12receipts.pl
+++ b/tests/31sync/12receipts.pl
@@ -83,7 +83,7 @@ test "New read receipts appear in incremental v2 /sync",
 
          matrix_sync( $user, filter => $filter_id );
       })->then( sub {
-         matrix_advance_room_receipt_and_wait_for_sync(
+         matrix_advance_room_receipt_synced(
             $user, $room_id, "m.read", $event_id
          );
       })->then( sub {

--- a/tests/31sync/13inline_filter.pl
+++ b/tests/31sync/13inline_filter.pl
@@ -1,17 +1,23 @@
 use JSON qw( encode_json );
 
 test "Can pass a JSON filter as a query parameter",
-   requires => [ local_user_and_room_fixtures() ],
+   requires => [ local_user_fixture() ],
 
    check => sub {
-      my ( $user, $room_id ) = @_;
+      my ( $user ) = @_;
 
-      matrix_sync( $user, filter => encode_json( {
-         room => {
-            state => { types => [ "m.room.member" ] },
-            timeline => { limit => 0 },
-         }
-      }))->then( sub {
+      my ( $room_id );
+
+      matrix_create_room_and_wait_for_sync( $user )->then( sub {
+         ( $room_id ) = @_;
+
+         matrix_sync( $user, filter => encode_json( {
+            room => {
+               state => { types => [ "m.room.member" ] },
+               timeline => { limit => 0 },
+            }
+         }));
+      })->then( sub {
          my ( $body ) = @_;
 
          my $room = $body->{rooms}{join}{$room_id};

--- a/tests/31sync/13inline_filter.pl
+++ b/tests/31sync/13inline_filter.pl
@@ -8,7 +8,7 @@ test "Can pass a JSON filter as a query parameter",
 
       my ( $room_id );
 
-      matrix_create_room_and_wait_for_sync( $user )->then( sub {
+      matrix_create_room_synced( $user )->then( sub {
          ( $room_id ) = @_;
 
          matrix_sync( $user, filter => encode_json( {


### PR DESCRIPTION
We want to do this because we want to test /sync requests that are handled by a separate process.
How it works:
  * Before performing an update sytest makes a /sync request to get a token from synapse. This /sync request doesn't affect the token stored on the user object.
  * Sytest then performs an action that updates.
  * Sytest then polls /sync until the change it was expecting is visible.
  * When the change is visible it returns result of the update.
  * Sytest then can call sync for real and check that the result matches it's expectations.

Alternatives:
  1) Have the tests call /sync repeatedly until they observe whatever the test is expecting. This doesn't work because some of the tests need to check that the timeline is limited appropriately between /sync invocations.
  2) Do the action, then repeatedly call /sync. This doesn't work because the action could be returned to the client before the first /sync that was checking for it.