### PR TITLE
Optionally run tests against a dendron with a split out synchrotron

### DIFF
--- a/lib/SyTest/Synapse.pm
+++ b/lib/SyTest/Synapse.pm
@@ -305,14 +305,13 @@ sub start
       );
 
       if ( $self->{pusher} ) {
-         @command = ( @command, "--pusher-config" => $pusher_config_path );
+         push @command, "--pusher-config" => $pusher_config_path;
       }
 
       if ( $self->{synchrotron} ) {
-         @command = ( @command,
+         push @command,
             "--synchrotron-config" => $synchrotron_config_path,
-            "--synchrotron-url" => "http://127.0.0.1:$synchrotron_port",
-         );
+            "--synchrotron-url" => "http://127.0.0.1:$synchrotron_port";
       }
    }
    else {

--- a/lib/SyTest/Synapse.pm
+++ b/lib/SyTest/Synapse.pm
@@ -232,6 +232,7 @@ sub start
       "replication_url"          => "http://127.0.0.1:$self->{unsecure_port}/_synapse/replication",
       "macaroon_secret_key"      => $macaroon_secret_key,
       "full_twisted_stacktraces" => "true",
+      "use_insecure_ssl_client_just_for_testing_do_not_use" => "true",
       "listeners" => [
          {
             type      => "http",

--- a/lib/SyTest/Synapse.pm
+++ b/lib/SyTest/Synapse.pm
@@ -25,7 +25,7 @@ sub _init
 
    $self->{$_} = delete $args->{$_} for qw(
       port unsecure_port output synapse_dir extra_args python config coverage
-      dendron pusher
+      dendron pusher synchrotron
    );
 
    $self->{hs_dir} = abs_path( "localhost-$self->{port}" );
@@ -223,6 +223,34 @@ sub start
       ],
    } );
 
+   my $synchrotron_port = $port - 8000 + 11000;
+   my $synchrotron_config_path = $self->write_yaml_file( synchrotron => {
+      "server_name"              => "localhost:$port",
+      "log_file"                 => "$log.synchrotron",
+      "database"                 => $db_config,
+      "database_config"          => $db_config_path,
+      "replication_url"          => "http://127.0.0.1:$self->{unsecure_port}/_synapse/replication",
+      "macaroon_secret_key"      => $macaroon_secret_key,
+      "full_twisted_stacktraces" => "true",
+      "listeners" => [
+         {
+            type      => "http",
+            resources => [{ names => ["client"] }],
+            port      => $synchrotron_port,
+         },
+         {
+            type => "manhole",
+            port => ( $port - 8000 + 11080 ),
+         },
+         {
+            type      => "http",
+            resources => [{ names => ["metrics"] }],
+            port      => ( $port - 8000 + 11090 ),
+         },
+      ],
+   } );
+
+
    $self->{logpath} = $log;
 
    {
@@ -277,6 +305,13 @@ sub start
 
       if ( $self->{pusher} ) {
          @command = ( @command, "--pusher-config" => $pusher_config_path );
+      }
+
+      if ( $self->{synchrotron} ) {
+         @command = ( @command,
+            "--synchrotron-config" => $synchrotron_config_path,
+            "--synchrotron-url" => "http://127.0.0.1:$synchrotron_port",
+         );
       }
    }
    else {

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -49,7 +49,8 @@ our %SYNAPSE_ARGS = (
    log_filter => [],
    coverage   => 0,
    dendron    => "",
-   pusher     => 0
+   pusher     => 0,
+   synchrotron => 0,
 );
 
 our $WANT_TLS = 1;  # This is shared with the test scripts
@@ -82,6 +83,8 @@ GetOptions(
    'dendron=s' => \$SYNAPSE_ARGS{dendron},
 
    'pusher+' => \$SYNAPSE_ARGS{pusher},
+
+   'synchrotron+' => \$SYNAPSE_ARGS{synchrotron},
 
    'p|port-base=i' => \(my $PORT_BASE = 8000),
 

--- a/tests/05synapse.pl
+++ b/tests/05synapse.pl
@@ -59,6 +59,7 @@ our @HOMESERVER_INFO = map {
             coverage      => $SYNAPSE_ARGS{coverage},
             dendron       => $SYNAPSE_ARGS{dendron},
             pusher        => $SYNAPSE_ARGS{pusher},
+            synchrotron   => $SYNAPSE_ARGS{synchrotron},
             ( scalar @{ $SYNAPSE_ARGS{log_filter} } ?
                ( filter_output => $SYNAPSE_ARGS{log_filter} ) :
                () ),


### PR DESCRIPTION
Checks that splitting out the /sync to a separate process works.