### PR TITLE
Globally disable any and all HTTP/1.1 pipelining for all HTTP clients…

### DIFF
--- a/lib/SyTest/HTTPClient.pm
+++ b/lib/SyTest/HTTPClient.pm
@@ -23,6 +23,17 @@ use SyTest::JSONSensible;
 
 use constant MIME_TYPE_JSON => "application/json";
 
+sub _init
+{
+   my $self = shift;
+   my ( $params ) = @_;
+
+   # Turn off pipelining because it gets in the way of longpolls
+   $params->{pipeline} = 0;
+
+   $self->SUPER::_init( $params );
+}
+
 sub configure
 {
    my $self = shift;


### PR DESCRIPTION
…, because it's almost never what we want in the presence of longpolling