### PR TITLE
Don't prematurely start fixtures just because they happen not to have…

### DIFF
--- a/run-tests.pl
+++ b/run-tests.pl
@@ -331,6 +331,10 @@ sub fixture
       }
    }
 
+   # If there's no requirements, we still want to wait for $f_start before we
+   # actually invoke $setup
+   @req_futures or push @req_futures, $f_start;
+
    return Fixture(
       \@requires,
 


### PR DESCRIPTION
… any dependencies.

Without this, if `@requires` is empty, then the `needs_all()` is immediately ready, so its `then` chain executes within the `fixture` function itself, and the setup process begins far too soon, before anyone called the start function.

This fix totally cleans up all those warnings about "Future(0x...) lost a sequence Future at ...", and if I'm testing correctly, also solves @NegativeMjark's unit test timeout issue.

E.g. I now get

    $ ./run-tests-in-tox -O tap tests/61push/06_push_rules_in_sync.pl 
    # Clearing SQLite database at :memory:
    # Generating config for port 8001
    # Starting server for port 8001
    # Connecting to server 8001
    # Connected to server 8001
    ok 1 Push rules come down in an initial /sync
    ok 2 Adding a push rule wakes up an incremental /sync
    ok 3 Disabling a push rule wakes up an incremental /sync
    ok 4 Enabling a push rule wakes up an incremental /sync
    ok 5 Setting actions for a push rule wakes up an incremental /sync
    1..5
    # Killing synapse servers 
