### PR TITLE
Allocate TCP ports from a predictable pool

### DIFF
--- a/jenkins/prep_sytest_for_postgres.sh
+++ b/jenkins/prep_sytest_for_postgres.sh
@@ -18,19 +18,14 @@ if [ -z "$POSTGRES_DB_2" ]; then
     exit 1
 fi
 
-if [ -z "$PORT_BASE" ]; then
-    echo >&2 "Variable PORT_BASE not set"
-    exit 1
-fi
-
-mkdir -p "localhost-$(($PORT_BASE + 1))"
-mkdir -p "localhost-$(($PORT_BASE + 2))"
+mkdir -p "localhost-0"
+mkdir -p "localhost-1"
 
 : PGUSER=${PGUSER:=$USER}
 
 # We leave user, password, host blank to use the defaults (unix socket and
 # local auth)
-cat > localhost-$(($PORT_BASE + 1))/database.yaml << EOF
+cat > "localhost-0/database.yaml" << EOF
 name: psycopg2
 args:
     database: $POSTGRES_DB_1
@@ -40,7 +35,7 @@ args:
     sslmode: disable
 EOF
 
-cat > localhost-$(($PORT_BASE + 2))/database.yaml << EOF
+cat > "localhost-1/database.yaml" << EOF
 name: psycopg2
 args:
     database: $POSTGRES_DB_2

--- a/jenkins/sytest-postgres.sh
+++ b/jenkins/sytest-postgres.sh
@@ -5,6 +5,7 @@
 set -ex
 
 : ${PORT_BASE=8000}
+: ${PORT_COUNT=20}
 
 cd "`dirname $0`/.."
 
@@ -13,4 +14,4 @@ cd "`dirname $0`/.."
 
 TOX_BIN="`pwd`/synapse/.tox/py27/bin"
 $TOX_BIN/pip install psycopg2
-./jenkins/install_and_run.sh --python="$TOX_BIN/python" --port-base ${PORT_BASE}
+./jenkins/install_and_run.sh --python="$TOX_BIN/python" --port-range ${PORT_BASE}:$((PORT_BASE+PORT_COUNT-1))

--- a/jenkins/sytest-sqlite.sh
+++ b/jenkins/sytest-sqlite.sh
@@ -5,10 +5,11 @@
 set -ex
 
 : ${PORT_BASE=8000}
+: ${PORT_COUNT=20}
 
 cd "`dirname $0`/.."
 
 ./jenkins/prep_synapse.sh
 
 TOX_BIN="`pwd`/synapse/.tox/py27/bin"
-./jenkins/install_and_run.sh --python="$TOX_BIN/python" --port-base ${PORT_BASE}
+./jenkins/install_and_run.sh --python="$TOX_BIN/python" --port-range ${PORT_BASE}:$((PORT_BASE+PORT_COUNT-1))

--- a/lib/SyTest/Synapse.pm
+++ b/lib/SyTest/Synapse.pm
@@ -133,7 +133,7 @@ sub start
    if( $self->{dendron} ) {
       # If we are running synapse behind dendron then only bind the unsecure
       # port for synapse.
-      $self->{unsecure_port} = $port + 9000 - 8000;
+      $self->{unsecure_port} = main::alloc_port();
    }
    else {
       push @$listeners, {
@@ -183,7 +183,7 @@ sub start
 
         # Metrics are always useful
         "enable_metrics" => 1,
-        "metrics_port" => ( $port - 8000 + 9090 ),
+        "metrics_port" => main::alloc_port(),
 
         "perspectives" => { servers => {} },
 
@@ -214,16 +214,16 @@ sub start
          {
             type      => "http",
             resources => [{ names => ["metrics"] }],
-            port      => ( $port - 8000 + 10090 ),
+            port      => main::alloc_port(),
          },
          {
             type => "manhole",
-            port => ( $port - 8000 + 10080 ),
+            port => main::alloc_port(),
          },
       ],
    } );
 
-   my $synchrotron_port = $port - 8000 + 11000;
+   my $synchrotron_port = main::alloc_port();
    my $synchrotron_config_path = $self->write_yaml_file( synchrotron => {
       "server_name"              => "localhost:$port",
       "log_file"                 => "$log.synchrotron",
@@ -241,12 +241,12 @@ sub start
          },
          {
             type => "manhole",
-            port => ( $port - 8000 + 11080 ),
+            port => main::alloc_port(),
          },
          {
             type      => "http",
             resources => [{ names => ["metrics"] }],
-            port      => ( $port - 8000 + 11090 ),
+            port      => main::alloc_port(),
          },
       ],
    } );

--- a/lib/SyTest/Synapse.pm
+++ b/lib/SyTest/Synapse.pm
@@ -12,7 +12,7 @@ use Future::Utils qw( try_repeat );
 use IO::Async::Process;
 use IO::Async::FileStream;
 
-use Cwd qw( getcwd abs_path );
+use Cwd qw( getcwd );
 use File::Basename qw( dirname );
 use File::Path qw( make_path remove_tree );
 use List::Util qw( any pairmap );
@@ -26,15 +26,12 @@ sub _init
    my ( $args ) = @_;
 
    $self->{$_} = delete $args->{$_} for qw(
-      ports output synapse_dir extra_args python config coverage
+      ports output hs_dir synapse_dir extra_args python config coverage
       dendron pusher synchrotron
    );
 
    defined $self->{ports}{$_} or croak "Need a '$_' port\n"
       for qw( client client_unsecure metrics );
-
-   my $port = $self->{ports}{client};
-   $self->{hs_dir} = abs_path( "localhost-$port" );
 
    $self->SUPER::_init( $args );
 }

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -86,7 +86,7 @@ GetOptions(
 
    'synchrotron+' => \$SYNAPSE_ARGS{synchrotron},
 
-   'p|port-range=s' => \(my $PORT_RANGE = "8000:8009"),
+   'p|port-range=s' => \(my $PORT_RANGE = "8000:8019"),
 
    'F|fixed=s' => sub { $FIXED_BUGS{$_}++ for split m/,/, $_[1] },
 

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -86,7 +86,7 @@ GetOptions(
 
    'synchrotron+' => \$SYNAPSE_ARGS{synchrotron},
 
-   'p|port-base=i' => \(my $PORT_BASE = 8000),
+   'p|port-range=s' => \(my $PORT_RANGE = "8000:8009"),
 
    'F|fixed=s' => sub { $FIXED_BUGS{$_}++ for split m/,/, $_[1] },
 
@@ -274,9 +274,18 @@ my $loop = IO::Async::Loop->new;
 my $old_SIGINT = $SIG{INT};
 $SIG{INT} = sub { $old_SIGINT->( "INT" ) if ref $old_SIGINT; exit 1 };
 
+( my ( $port_next, $port_max ) = split m/:/, $PORT_RANGE ) == 2 or
+   die "Expected a --port-range expressed as START:MAX\n";
+
+## TODO: better name here
+sub alloc_port
+{
+   die "No more free ports\n" if $port_next >= $port_max;
+   return $port_next++;
+}
 
 # We need two servers; a "local" and a "remote" one for federation-based tests
-our @HOMESERVER_PORTS = ( $PORT_BASE + 1, $PORT_BASE + 2 );
+our @HOMESERVER_PORTS = ( alloc_port(), alloc_port() );
 
 # Util. function for tests
 sub delay

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -86,7 +86,7 @@ GetOptions(
 
    'synchrotron+' => \$SYNAPSE_ARGS{synchrotron},
 
-   'p|port-range=s' => \(my $PORT_RANGE = "8000:8019"),
+   'p|port-range=s' => \(my $PORT_RANGE = "8800:8819"),
 
    'F|fixed=s' => sub { $FIXED_BUGS{$_}++ for split m/,/, $_[1] },
 

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -284,9 +284,6 @@ sub alloc_port
    return $port_next++;
 }
 
-# We need two servers; a "local" and a "remote" one for federation-based tests
-our @HOMESERVER_PORTS = ( alloc_port(), alloc_port() );
-
 # Util. function for tests
 sub delay
 {

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -151,7 +151,7 @@ Options:
 
        --coverage               - generate code coverage stats for synapse
 
-   -p, --port-base NUMBER       - initial port number to run server under test
+   -p, --port-range START:MAX   - pool of TCP ports to allocate from
 
    -F, --fixed BUGS             - bug names that are expected to be fixed
                                   (ignores 'bug' declarations with these names)

--- a/tests/02as-info.pl
+++ b/tests/02as-info.pl
@@ -15,13 +15,12 @@ our @AS_INFO = map {
 
    fixture(
       setup => sub {
-         my $port = $HOMESERVER_PORTS[0];
-
          my $localpart = "as-user-$idx";
 
          Future->done( ASInfo(
             $localpart,
-            "\@${localpart}:localhost:${port}",
+            undef,  # user_id field will be filled in later when we know what
+                    # the homeserver location actually is
             gen_token( 32 ),
             gen_token( 32 ),
             "/appservs/$idx",

--- a/tests/05synapse.pl
+++ b/tests/05synapse.pl
@@ -1,5 +1,7 @@
 use SyTest::Synapse;
 
+my $N_HOMESERVERS = 2;
+
 sub extract_extra_args
 {
    my ( $idx, $args ) = @_;
@@ -37,7 +39,7 @@ our @HOMESERVER_INFO = map {
       setup => sub {
          my ( $test_server_info, @as_infos ) = @_;
 
-         my $secure_port = $HOMESERVER_PORTS[$idx];
+         my $secure_port = main::alloc_port();
          my $unsecure_port = $WANT_TLS ? 0 : main::alloc_port();
 
          my @extra_args = extract_extra_args( $idx, $SYNAPSE_ARGS{extra_args} );
@@ -127,4 +129,4 @@ our @HOMESERVER_INFO = map {
          )->then_done( $info );
       },
    );
-} 0 .. $#HOMESERVER_PORTS;
+} 0 .. $N_HOMESERVERS-1;

--- a/tests/05synapse.pl
+++ b/tests/05synapse.pl
@@ -38,7 +38,7 @@ our @HOMESERVER_INFO = map {
          my ( $test_server_info, @as_infos ) = @_;
 
          my $secure_port = $HOMESERVER_PORTS[$idx];
-         my $unsecure_port = $WANT_TLS ? 0 : $secure_port + 1000;
+         my $unsecure_port = $WANT_TLS ? 0 : main::alloc_port();
 
          my @extra_args = extract_extra_args( $idx, $SYNAPSE_ARGS{extra_args} );
 

--- a/tests/05synapse.pl
+++ b/tests/05synapse.pl
@@ -55,6 +55,14 @@ our @HOMESERVER_INFO = map {
             ports         => {
                client          => $secure_port,
                client_unsecure => $unsecure_port,
+               metrics         => main::alloc_port(),
+
+               pusher_metrics => main::alloc_port(),
+               pusher_manhole => main::alloc_port(),
+
+               synchrotron         => main::alloc_port(),
+               synchrotron_metrics => main::alloc_port(),
+               synchrotron_manhole => main::alloc_port(),
             },
             output        => $OUTPUT,
             print_output  => $SYNAPSE_ARGS{log},

--- a/tests/05synapse.pl
+++ b/tests/05synapse.pl
@@ -104,6 +104,10 @@ our @HOMESERVER_INFO = map {
                } );
 
                push @confs, $appserv_conf;
+
+               # Now we can fill in the AS info's user_id
+               $as_info->user_id = sprintf "@%s:localhost:%d",
+                  $as_info->localpart, $secure_port;
             }
 
             $synapse->append_config(

--- a/tests/05synapse.pl
+++ b/tests/05synapse.pl
@@ -39,8 +39,8 @@ our @HOMESERVER_INFO = map {
       setup => sub {
          my ( $test_server_info, @as_infos ) = @_;
 
-         my $secure_port = main::alloc_port();
-         my $unsecure_port = $WANT_TLS ? 0 : main::alloc_port();
+         my $secure_port = main::alloc_port( "synapse[$idx]" );
+         my $unsecure_port = $WANT_TLS ? 0 : main::alloc_port( "synapse[$idx].unsecure" );
 
          my @extra_args = extract_extra_args( $idx, $SYNAPSE_ARGS{extra_args} );
 
@@ -55,14 +55,14 @@ our @HOMESERVER_INFO = map {
             ports         => {
                client          => $secure_port,
                client_unsecure => $unsecure_port,
-               metrics         => main::alloc_port(),
+               metrics         => main::alloc_port( "synapse[$idx].metrics" ),
 
-               pusher_metrics => main::alloc_port(),
-               pusher_manhole => main::alloc_port(),
+               pusher_metrics => main::alloc_port( "pusher[$idx].metrics" ),
+               pusher_manhole => main::alloc_port( "pusher[$idx].manhole" ),
 
-               synchrotron         => main::alloc_port(),
-               synchrotron_metrics => main::alloc_port(),
-               synchrotron_manhole => main::alloc_port(),
+               synchrotron         => main::alloc_port( "synchrotron[$idx]" ),
+               synchrotron_metrics => main::alloc_port( "synchrotron[$idx].metrics" ),
+               synchrotron_manhole => main::alloc_port( "synchrotron[$idx].manhole" ),
             },
             output        => $OUTPUT,
             print_output  => $SYNAPSE_ARGS{log},

--- a/tests/05synapse.pl
+++ b/tests/05synapse.pl
@@ -52,8 +52,10 @@ our @HOMESERVER_INFO = map {
 
          my $synapse = SyTest::Synapse->new(
             synapse_dir   => $SYNAPSE_ARGS{directory},
-            port          => $secure_port,
-            unsecure_port => $unsecure_port,
+            ports         => {
+               client          => $secure_port,
+               client_unsecure => $unsecure_port,
+            },
             output        => $OUTPUT,
             print_output  => $SYNAPSE_ARGS{log},
             extra_args    => \@extra_args,

--- a/tests/05synapse.pl
+++ b/tests/05synapse.pl
@@ -41,8 +41,8 @@ our @HOMESERVER_INFO = map {
       setup => sub {
          my ( $test_server_info, @as_infos ) = @_;
 
-         my $secure_port = main::alloc_port( "synapse[$idx]" );
-         my $unsecure_port = $WANT_TLS ? 0 : main::alloc_port( "synapse[$idx].unsecure" );
+         my $secure_port   = main::alloc_port( "synapse[$idx]" );
+         my $unsecure_port = main::alloc_port( "synapse[$idx].unsecure" );
 
          my @extra_args = extract_extra_args( $idx, $SYNAPSE_ARGS{extra_args} );
 

--- a/tests/05synapse.pl
+++ b/tests/05synapse.pl
@@ -54,7 +54,7 @@ our @HOMESERVER_INFO = map {
 
          my $synapse = SyTest::Synapse->new(
             synapse_dir   => $SYNAPSE_ARGS{directory},
-            hs_dir        => abs_path( "localhost-$secure_port" ),
+            hs_dir        => abs_path( "localhost-$idx" ),
             ports         => {
                client          => $secure_port,
                client_unsecure => $unsecure_port,

--- a/tests/05synapse.pl
+++ b/tests/05synapse.pl
@@ -1,5 +1,7 @@
 use SyTest::Synapse;
 
+use Cwd qw( abs_path );
+
 my $N_HOMESERVERS = 2;
 
 sub extract_extra_args
@@ -52,6 +54,7 @@ our @HOMESERVER_INFO = map {
 
          my $synapse = SyTest::Synapse->new(
             synapse_dir   => $SYNAPSE_ARGS{directory},
+            hs_dir        => abs_path( "localhost-$secure_port" ),
             ports         => {
                client          => $secure_port,
                client_unsecure => $unsecure_port,


### PR DESCRIPTION
Allocate TCP ports from a pool given as a commandline argument, instead of inventing arbitrary offsets from the main server ports. This allows multiple instances run concurrently on one machine with much more predictability between them, so they won't clash in allocated port numbers.