### PR TITLE
Add test for createUser endpoint

### DIFF
--- a/tests/60app-services/01as-create.pl
+++ b/tests/60app-services/01as-create.pl
@@ -27,6 +27,41 @@ test "AS can create a user",
       });
    };
 
+test "AS can get or create user and return an access_token",
+   requires => [ $main::AS_USER[0], $main::API_CLIENTS[0] ],
+
+   do => sub {
+      my ( $as_user, $http ) = @_;
+
+      do_request_json_for( $as_user,
+         method => "POST",
+         uri    => "/unstable/createUser",
+
+         content => {
+            localpart        => "user_localpart",
+            displayname      => "user_displayname",
+            duration_seconds => 200,
+         }
+      )->then( sub {
+         my ( $body ) = @_;
+
+         assert_json_keys( $body, qw( access_token user_id  home_server ));
+
+         my $user =User( $http , $body->{user_id}, "", $body->{access_token}, undef, undef, undef, [], undef );
+
+         do_request_json_for( $user,
+            method => "GET",
+            uri    => "/r0/profile/:user_id/displayname",
+         )}
+      )->then( sub {
+         my ( $body ) = @_;
+
+         assert_eq( $body->{displayname}, qw( user_displayname ));
+
+         Future->done(1);
+      });
+   };
+
 test "AS cannot create users outside its own namespace",
    requires => [ $main::AS_USER[0] ],
 


### PR DESCRIPTION
The createUser is working like:
```
Here is an example of how to send a post request to create user feature.

curl -i -H "Accept: application/json" -H "Content-Type:application/json" -X POST --data '{"localpart": "user_local_part", "displayname": "user spla\
yname", "duration_seconds": 200 }' "http://192.168.99.101:8008/_matrix/client/api/v1/createUser?access_token=this_is_the_app_service_token"
basically the payload is :
 '{"localpart": "user_local_part", "displayname": "user displayname", "duration_seconds": 200 }'
and as you can see in the url I need to add ?access_token=this_is_the_app_service_token"
parameter.
And this is an example of what I get back.

{
    "access_token": "MDAxN2xvY2F0aW9uIGxv",
    "home_server": "localhost",
    "user_id": "@user_local_part:localhost"
}
```