### PR TITLE
Extract a base `SyTest::Homeserver` class

### DIFF
--- a/lib/SyTest/Homeserver.pm
+++ b/lib/SyTest/Homeserver.pm
@@ -1,0 +1,68 @@
+package SyTest::Homeserver;
+
+use strict;
+use warnings;
+use 5.010;
+use base qw( IO::Async::Notifier );
+
+use YAML ();
+
+sub _init
+{
+   my $self = shift;
+   my ( $args ) = @_;
+
+   $self->{$_} = delete $args->{$_} for qw(
+      output hs_dir
+   );
+
+   $self->SUPER::_init( $args );
+}
+
+sub write_yaml_file
+{
+   my $self = shift;
+   my ( $relpath, $content ) = @_;
+
+   my $hs_dir = $self->{hs_dir};
+
+   YAML::DumpFile( my $abspath = "$hs_dir/$relpath", $content );
+
+   return $abspath;
+}
+
+sub clear_db_sqlite
+{
+   my $self = shift;
+   my %args = @_;
+
+   my $db = $args{path};
+
+   $self->{output}->diag( "Clearing SQLite database at $db" );
+
+   unlink $db if -f $db;
+}
+
+sub clear_db_pg
+{
+   my $self = shift;
+   my %args = @_;
+
+   my $host = $args{host} // '';
+   $self->{output}->diag( "Clearing Pg database $args{database} on '$host'" );
+
+   require DBI;
+   require DBD::Pg;
+
+   my $dbh = DBI->connect( "dbi:Pg:dbname=$args{database};host=$host", $args{user}, $args{password} )
+      or die DBI->errstr;
+
+   foreach my $row ( @{ $dbh->selectall_arrayref( "SELECT tablename FROM pg_tables WHERE schemaname = 'public'" ) } ) {
+      my ( $tablename ) = @$row;
+
+      $dbh->do( "DROP TABLE $tablename CASCADE" ) or
+         die $dbh->errstr;
+   }
+}
+
+1;

--- a/lib/SyTest/Homeserver.pm
+++ b/lib/SyTest/Homeserver.pm
@@ -89,6 +89,7 @@ sub await_connectable
    my $loop = $self->loop;
 
    my $attempts = 20;
+   my $delay    = 0.1;
 
    repeat {
       $loop->connect(
@@ -105,8 +106,9 @@ sub await_connectable
          }
 
          $attempts--;
+         $delay *= 1.5;
 
-         $loop->delay_future( after => 0.1 )
+         $loop->delay_future( after => $delay )
               ->then_done(0);
       })
    } while => sub { !$_[0]->failure and !$_[0]->get }

--- a/lib/SyTest/Homeserver.pm
+++ b/lib/SyTest/Homeserver.pm
@@ -8,6 +8,8 @@ use base qw( IO::Async::Notifier );
 use Future::Utils qw( repeat );
 
 use YAML ();
+use JSON ();
+use File::Slurper qw( write_binary );
 
 sub _init
 {
@@ -29,6 +31,18 @@ sub write_yaml_file
    my $hs_dir = $self->{hs_dir};
 
    YAML::DumpFile( my $abspath = "$hs_dir/$relpath", $content );
+
+   return $abspath;
+}
+
+sub write_json_file
+{
+   my $self = shift;
+   my ( $relpath, $content ) = @_;
+
+   my $hs_dir = $self->{hs_dir};
+
+   write_binary( my $abspath = "$hs_dir/$relpath", JSON::encode_json( $content ) );
 
    return $abspath;
 }

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -334,31 +334,15 @@ sub start
             )
          );
 
-         my $polling_period = 0.1;
+         $output->diag( "Connecting to server $port" );
 
-         my $poll;
-         $poll = sub {
-            $loop->connect(
-               addr => {
-                  family   => "inet",
-                  socktype => "stream",
-                  port     => $port,
-                  ip       => "127.0.0.1",
-               }
-            )->then( sub {
+         $self->adopt_future(
+            $self->await_connectable( $port )->then( sub {
                $output->diag( "Connected to server $port" );
-               my ( $connection ) = @_;
-
-               $connection->close;
 
                $self->started_future->done;
-            }, sub {
-               $loop->delay_future( after => $polling_period )->then( $poll );
-            });
-         };
-
-         $output->diag( "Connecting to server $port" );
-         $self->adopt_future( $poll->() );
+            })
+         );
 
          $self->open_logfile;
       }

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -1,4 +1,4 @@
-package SyTest::Synapse;
+package SyTest::Homeserver::Synapse;
 
 use strict;
 use warnings;

--- a/tests/05synapse.pl
+++ b/tests/05synapse.pl
@@ -1,4 +1,4 @@
-use SyTest::Synapse;
+use SyTest::Homeserver::Synapse;
 
 use Cwd qw( abs_path );
 
@@ -52,7 +52,7 @@ our @HOMESERVER_INFO = map {
 
          my $info = ServerInfo( "localhost:$secure_port", $location );
 
-         my $synapse = SyTest::Synapse->new(
+         my $synapse = SyTest::Homeserver::Synapse->new(
             synapse_dir   => $SYNAPSE_ARGS{directory},
             hs_dir        => abs_path( "localhost-$idx" ),
             ports         => {


### PR DESCRIPTION
In case of creating other kinds of homeserver wrapping in the future (e.g. dendron, ruma, ...)