### PR TITLE
Update sytests to match e2e key upload changes

### DIFF
--- a/tests/10apidoc/00prepare.pl
+++ b/tests/10apidoc/00prepare.pl
@@ -2,7 +2,7 @@ our @EXPORT = qw( User is_User do_request_json_for );
 
 # A handy little structure for other scripts to find in 'user' and 'more_users'
 struct User =>
-   [qw( http user_id password access_token refresh_token eventstream_token
+   [qw( http user_id device_id password access_token refresh_token eventstream_token
         sync_next_batch saved_events pending_get_events )],
    predicate => 'is_User';
 

--- a/tests/10apidoc/01register.pl
+++ b/tests/10apidoc/01register.pl
@@ -103,7 +103,8 @@ sub matrix_register_user
       my ( $body ) = @_;
       my $access_token = $body->{access_token};
 
-      my $user = User( $http, $body->{user_id}, $password, $access_token, undef, undef, undef, [], undef );
+      my $user = User( $http, $body->{user_id}, $body->{device_id},
+                       $password, $access_token, undef, undef, undef, [], undef );
 
       my $f = Future->done;
 
@@ -163,7 +164,8 @@ sub matrix_register_user_via_secret
 
       my $access_token = $body->{access_token};
 
-      my $user = User( $http, $body->{user_id}, $password, $access_token, undef, undef, undef, [], undef );
+      my $user = User( $http, $body->{user_id}, $body->{device_id},
+                       $password, $access_token, undef, undef, undef, [], undef );
 
       return Future->done( $user )
         ->on_done( sub {

--- a/tests/10apidoc/02login.pl
+++ b/tests/10apidoc/02login.pl
@@ -249,7 +249,8 @@ sub matrix_login_again_with_user
 
       assert_json_keys( $body, qw( access_token home_server refresh_token ));
 
-      my $new_user = User( $user->http, $user->user_id, $user->password, $body->{access_token}, $body->{refresh_token}, undef, undef, [], undef );
+      my $new_user = User( $user->http, $user->user_id, $body->{device_id},
+                           $user->password, $body->{access_token}, $body->{refresh_token}, undef, undef, [], undef );
 
       Future->done( $new_user );
    });

--- a/tests/11register.pl
+++ b/tests/11register.pl
@@ -267,7 +267,9 @@ test "registration remembers parameters",
          assert_eq( $actual_user_id, "\@$localpart:$home_server",
             "registered user ID" );
 
-         my $user = User( $http, $actual_user_id, undef,
+         my $user = User( $http, $actual_user_id,
+                          $body->{device_id},
+                          undef,
                           $body->{access_token},
                           $body->{refresh_token},
                           undef, undef, [], undef );

--- a/tests/30rooms/13guestaccess.pl
+++ b/tests/30rooms/13guestaccess.pl
@@ -503,7 +503,9 @@ sub guest_user_fixture
             my ( $body ) = @_;
             my $access_token = $body->{access_token};
 
-            Future->done( User( $http, $body->{user_id}, undef, $access_token, undef, undef, undef, [], undef ) );
+            Future->done( User( $http, $body->{user_id},
+                                $body->{device_id},
+                                undef, $access_token, undef, undef, undef, [], undef ) );
          });
    })
 }

--- a/tests/41end-to-end-keys/01-upload-key.pl
+++ b/tests/41end-to-end-keys/01-upload-key.pl
@@ -10,11 +10,11 @@ test "Can upload device keys",
 
       do_request_json_for( $user,
          method  => "POST",
-         uri     => "/v2_alpha/keys/upload/alices_first_device",
+         uri     => "/unstable/keys/upload",
          content => {
             device_keys => {
                user_id => $user->user_id,
-               device_id => "alices_first_device",
+               device_id => $user->device_id,
             },
             one_time_keys => {
                "my_algorithm:my_id_1", "my+base64+key"
@@ -44,7 +44,7 @@ test "Can query device keys using POST",
 
       do_request_json_for( $user,
          method  => "POST",
-         uri     => "/v2_alpha/keys/query/",
+         uri     => "/unstable/keys/query/",
          content => {
             device_keys => {
                $user->user_id => {}
@@ -59,7 +59,7 @@ test "Can query device keys using POST",
          assert_json_keys( $device_keys, $user->user_id );
 
          my $alice_keys = $device_keys->{ $user->user_id };
-         assert_json_keys( $alice_keys, "alices_first_device" );
+         assert_json_keys( $alice_keys, $user->device_id );
          # TODO: Check that the content matches what we uploaded.
          Future->done(1)
       })
@@ -72,12 +72,14 @@ test "Can query specific device keys using POST",
    check => sub {
       my ( $user ) = @_;
 
+      my $device_id = $user->device_id;
+
       do_request_json_for( $user,
          method  => "POST",
-         uri     => "/v2_alpha/keys/query/",
+         uri     => "/unstable/keys/query/",
          content => {
             device_keys => {
-               $user->user_id => [ "alices_first_device" ]
+               $user->user_id => [ $device_id ]
             }
          }
       )->then( sub {
@@ -89,7 +91,7 @@ test "Can query specific device keys using POST",
          assert_json_keys( $device_keys, $user->user_id );
 
          my $alice_keys = $device_keys->{ $user->user_id };
-         assert_json_keys( $alice_keys, "alices_first_device" );
+         assert_json_keys( $alice_keys, $device_id );
          # TODO: Check that the content matches what we uploaded.
          Future->done(1)
       })
@@ -104,7 +106,7 @@ test "Can query device keys using GET",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/v2_alpha/keys/query/${\$user->user_id}"
+         uri    => "/unstable/keys/query/${\$user->user_id}"
       )->then( sub {
          my ( $content ) = @_;
 
@@ -114,7 +116,7 @@ test "Can query device keys using GET",
          assert_json_keys( $device_keys, $user->user_id );
 
          my $alice_keys = $device_keys->{ $user->user_id };
-         assert_json_keys( $alice_keys, "alices_first_device" );
+         assert_json_keys( $alice_keys, $user->device_id );
          # TODO: Check that the content matches what we uploaded.
          Future->done(1)
       })
@@ -125,16 +127,16 @@ push our @EXPORT, qw( matrix_put_e2e_keys );
 sub matrix_put_e2e_keys
 {
    # TODO(paul): I don't really know what's parametric about this
-   my ( $user, $device_id ) = @_;
+   my ( $user ) = @_;
 
    do_request_json_for( $user,
       method => "POST",
-      uri    => "/v2_alpha/keys/upload/$device_id",
+      uri    => "/unstable/keys/upload",
 
       content => {
          device_keys => {
             user_id => $user->user_id,
-            device_id => $device_id,
+            device_id => $user->device_id,
          },
          one_time_keys => {
             "my_algorithm:my_id_1" => "my+base64+key",

--- a/tests/41end-to-end-keys/03-one-time-keys.pl
+++ b/tests/41end-to-end-keys/03-one-time-keys.pl
@@ -5,9 +5,11 @@ multi_test "Can claim one time key using POST",
    check => sub {
       my ( $user ) = @_;
 
+      my $device_id = $user->device_id;
+
       do_request_json_for( $user,
          method  => "POST",
-         uri     => "/v2_alpha/keys/upload/alices_first_device",
+         uri     => "/unstable/keys/upload",
          content => {
             one_time_keys => {
                "test_algorithm:test_id", "test+base64+key"
@@ -16,28 +18,12 @@ multi_test "Can claim one time key using POST",
       )->SyTest::pass_on_done( "Uploaded one-time keys" )
       ->then( sub {
          do_request_json_for( $user,
-            method => "GET",
-            uri    => "/v2_alpha/keys/upload/alices_first_device",
-         )
-      })->then( sub {
-         my ( $content ) = @_;
-         log_if_fail "First device content", $content;
-
-         assert_json_keys( $content, "one_time_key_counts" );
-         assert_json_keys( $content->{one_time_key_counts}, "test_algorithm" );
-
-         $content->{one_time_key_counts}{test_algorithm} eq "1" or
-            die "Expected 1 one time key";
-
-         pass "Counted one time keys";
-
-         do_request_json_for( $user,
             method  => "POST",
-            uri     => "/v2_alpha/keys/claim",
+            uri     => "/unstable/keys/claim",
             content => {
                one_time_keys => {
                   $user->user_id => {
-                     alices_first_device => "test_algorithm"
+                     $device_id => "test_algorithm"
                   }
                }
             }
@@ -52,9 +38,9 @@ multi_test "Can claim one time key using POST",
          assert_json_keys( $one_time_keys, $user->user_id );
 
          my $alice_keys = $one_time_keys->{ $user->user_id };
-         assert_json_keys( $alice_keys, "alices_first_device" );
+         assert_json_keys( $alice_keys, $device_id );
 
-         my $alice_device_keys = $alice_keys->{alices_first_device};
+         my $alice_device_keys = $alice_keys->{$device_id};
          assert_json_keys( $alice_device_keys, "test_algorithm:test_id" );
 
          "test+base64+key" eq $alice_device_keys->{"test_algorithm:test_id"} or
@@ -62,18 +48,24 @@ multi_test "Can claim one time key using POST",
 
          pass "Took one time key";
 
+         # a second claim should give no keys
          do_request_json_for( $user,
-            method => "GET",
-            uri    => "/v2_alpha/keys/upload/alices_first_device",
+            method  => "POST",
+            uri     => "/unstable/keys/claim",
+            content => {
+               one_time_keys => {
+                  $user->user_id => {
+                     $device_id => "test_algorithm"
+                  }
+               }
+            }
          )
       })->then( sub {
          my ( $content ) = @_;
-         log_if_fail "First device content", $content;
+         log_if_fail "Second claim response", $content;
 
-         assert_json_keys( $content, "one_time_key_counts" );
-
-         exists $content->{one_time_key_counts}{test_algorithm} and
-            die "Expected that the key would be removed from the counts";
+         assert_json_keys( $content, "one_time_keys" );
+         assert_deeply_eq( $content->{one_time_keys}, {}, "Second claim result" );
 
          Future->done(1)
       });

--- a/tests/41end-to-end-keys/04-query-key-federation.pl
+++ b/tests/41end-to-end-keys/04-query-key-federation.pl
@@ -5,12 +5,12 @@ multi_test "Can query remote device keys using POST",
    check => sub {
       my ( $user, $remote_user ) = @_;
 
-      matrix_put_e2e_keys( $user, "alices_first_device" )
+      matrix_put_e2e_keys( $user )
          ->SyTest::pass_on_done( "Uploaded key" )
       ->then( sub {
          do_request_json_for( $remote_user,
             method  => "POST",
-            uri     => "/v2_alpha/keys/query/",
+            uri     => "/unstable/keys/query/",
             content => {
                device_keys => {
                   $user->user_id => {}
@@ -26,7 +26,7 @@ multi_test "Can query remote device keys using POST",
          assert_json_keys( $device_keys, $user->user_id );
 
          my $alice_keys = $device_keys->{ $user->user_id };
-         assert_json_keys( $alice_keys, "alices_first_device" );
+         assert_json_keys( $alice_keys, $user->device_id );
          # TODO: Check that the content matches what we uploaded.
          Future->done(1)
       });

--- a/tests/60app-services/00prepare.pl
+++ b/tests/60app-services/00prepare.pl
@@ -11,8 +11,10 @@ our @AS_USER = map {
       setup => sub {
          my ( $http, $as_user_info ) = @_;
 
-         Future->done( User( $http, $as_user_info->user_id, undef, $as_user_info->as2hs_token,
-               undef, undef, undef, [], undef ) );
+         Future->done( User( $http, $as_user_info->user_id,
+                             undef,
+                             undef, $as_user_info->as2hs_token,
+                             undef, undef, undef, [], undef ) );
       },
    );
 } @main::AS_INFO;

--- a/tests/60app-services/01as-create.pl
+++ b/tests/60app-services/01as-create.pl
@@ -47,7 +47,7 @@ test "AS can get or create user and return an access_token",
 
          assert_json_keys( $body, qw( access_token user_id  home_server ));
 
-         my $user =User( $http , $body->{user_id}, "", $body->{access_token}, undef, undef, undef, [], undef );
+         my $user =User( $http , $body->{user_id}, undef, "", $body->{access_token}, undef, undef, undef, [], undef );
 
          do_request_json_for( $user,
             method => "GET",
@@ -199,7 +199,7 @@ sub matrix_register_as_ghost
 
       # TODO: user has no event stream yet. Should they?
       Future->done(
-         User( $as_user->http, $body->{user_id}, undef, $body->{access_token}, undef, undef, undef, [], undef )
+         User( $as_user->http, $body->{user_id}, undef, undef, $body->{access_token}, undef, undef, undef, [], undef )
       );
    });
 }


### PR DESCRIPTION
The e2e endpoints have never been specced, so we should be accessing them on an
/unstable endpoint for now.

The 'deviceId' parameter on e2e key upload is now optional (and where it
exists, it must match that from the login) - so we can no longer just make it
up. Stash the device_id when we register or login, and use it in the e2e keys.

GET /keys/upload has never even been proposed as an API, and has now been
removed from synapse. Test that keys have been claimed using a second call to
/claim instead.