### PR TITLE
Test that ASes may begin user IDs with '_'; normal users cannot

### DIFF
--- a/tests/05synapse.pl
+++ b/tests/05synapse.pl
@@ -124,6 +124,7 @@ our @HOMESERVER_INFO = map {
                   namespaces => {
                      users => [
                         { regex => '@astest-.*', exclusive => "true" },
+                        { regex => '@_.*:' . $info->server_name, exclusive => "false" },
                      ],
                      aliases => [
                         { regex => '#astest-.*', exclusive => "true" },

--- a/tests/10apidoc/01register.pl
+++ b/tests/10apidoc/01register.pl
@@ -71,7 +71,7 @@ sub localpart_fixture
 {
    fixture(
       setup => sub {
-         Future->done( sprintf "_ANON_-%d", $next_anon_uid++ );
+         Future->done( sprintf "ANON-%d", $next_anon_uid++ );
       },
    );
 }

--- a/tests/90jira/SYN-738.pl
+++ b/tests/90jira/SYN-738.pl
@@ -1,0 +1,28 @@
+test "User signups are forbidden from starting with '_'",
+   requires => [ $main::API_CLIENTS[0] ],
+
+   bug => "SYN-738",
+
+   do => sub {
+      my ( $http ) = @_;
+
+      matrix_register_user( $http, "_badname_here" )
+         ->main::expect_http_4xx;
+   };
+
+test "AS can create users starting with '_'",
+   requires => [ $main::AS_USER[0] ],
+
+   do => sub {
+      my ( $as_user ) = @_;
+
+      do_request_json_for( $as_user,
+         method => "POST",
+         uri    => "/api/v1/register",
+
+         content => {
+            type => "m.login.application_service",
+            user => "_astest-goes-here",
+         },
+      );
+   };

--- a/tests/90jira/SYN-738.pl
+++ b/tests/90jira/SYN-738.pl
@@ -1,8 +1,6 @@
 test "User signups are forbidden from starting with '_'",
    requires => [ $main::API_CLIENTS[0] ],
 
-   bug => "SYN-738",
-
    do => sub {
       my ( $http ) = @_;
 


### PR DESCRIPTION
Tests the code submitted in https://github.com/matrix-org/synapse/pull/958