### PR TITLE
Add config for which host sytest should bind ports on.

### DIFF
--- a/jenkins/install_and_run.sh
+++ b/jenkins/install_and_run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Installs the dependencies, and then runs the tests. This is used by both
 # the sytest builds and the synapse ones.

--- a/jenkins/install_and_run.sh
+++ b/jenkins/install_and_run.sh
@@ -16,4 +16,4 @@ cd "`dirname $0`/.."
 
 ./jenkins/kill_old_listeners.sh
 
-./run-tests.pl --bind-host ${BIND_HOST:localhost} -O tap --all "$@" > results.tap
+./run-tests.pl --bind-host ${BIND_HOST:-localhost} -O tap --all "$@" > results.tap

--- a/jenkins/install_and_run.sh
+++ b/jenkins/install_and_run.sh
@@ -16,4 +16,4 @@ cd "`dirname $0`/.."
 
 ./jenkins/kill_old_listeners.sh
 
-./run-tests.pl -O tap --all "$@" > results.tap
+./run-tests.pl --bind-host ${BIND_HOST:localhost} -O tap --all "$@" > results.tap

--- a/jenkins/prep_sytest_for_postgres.sh
+++ b/jenkins/prep_sytest_for_postgres.sh
@@ -18,14 +18,14 @@ if [ -z "$POSTGRES_DB_2" ]; then
     exit 1
 fi
 
-mkdir -p "localhost-0"
-mkdir -p "localhost-1"
+mkdir -p "server-0"
+mkdir -p "server-1"
 
 : PGUSER=${PGUSER:=$USER}
 
 # We leave user, password, host blank to use the defaults (unix socket and
 # local auth)
-cat > "localhost-0/database.yaml" << EOF
+cat > "server-0/database.yaml" << EOF
 name: psycopg2
 args:
     database: $POSTGRES_DB_1
@@ -35,7 +35,7 @@ args:
     sslmode: disable
 EOF
 
-cat > "localhost-1/database.yaml" << EOF
+cat > "server-1/database.yaml" << EOF
 name: psycopg2
 args:
     database: $POSTGRES_DB_2

--- a/lib/SyTest/Homeserver.pm
+++ b/lib/SyTest/Homeserver.pm
@@ -88,7 +88,7 @@ sub clear_db_pg
 sub await_connectable
 {
    my $self = shift;
-   my ( $port ) = @_;
+   my ( $host, $port ) = @_;
 
    my $loop = $self->loop;
 
@@ -97,12 +97,9 @@ sub await_connectable
 
    repeat {
       $loop->connect(
-         addr => {
-            family   => "inet",
-            socktype => "stream",
-            port     => $port,
-            ip       => "127.0.0.1",
-         }
+         host => $host,
+         service => $port,
+         socktype => "stream",
       )->then_done(1)
        ->else( sub {
          if( !$attempts ) {

--- a/lib/SyTest/Homeserver.pm
+++ b/lib/SyTest/Homeserver.pm
@@ -97,8 +97,8 @@ sub await_connectable
 
    repeat {
       $loop->connect(
-         host => $host,
-         service => $port,
+         host     => $host,
+         service  => $port,
          socktype => "stream",
       )->then_done(1)
        ->else( sub {

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -27,7 +27,7 @@ sub _init
 
    $self->{$_} = delete $args->{$_} for qw(
       ports synapse_dir extra_args python config coverage
-      dendron pusher synchrotron
+      dendron pusher synchrotron bind_host
    );
 
    defined $self->{ports}{$_} or croak "Need a '$_' port\n"
@@ -121,6 +121,7 @@ sub start
    my $log = "$hs_dir/homeserver.log";
 
    my $listeners = [];
+   my $bind_host = $self->{bind_host};
 
    if( $self->{dendron} ) {
       # If we are running synapse behind dendron then only bind the unsecure
@@ -132,7 +133,7 @@ sub start
       push @$listeners, {
          type => "http",
          port => $port,
-         bind_address => "127.0.0.1",
+         bind_address => $bind_host,
          tls => 1,
          resources => [{
             names => [ "client", "federation", "replication" ], compress => 0
@@ -144,13 +145,20 @@ sub start
       push @$listeners, {
          type => "http",
          port => $unsecure_port,
-         bind_address => "127.0.0.1",
+         bind_address => $bind_host,
          tls => 0,
          resources => [{
             names => [ "client", "federation", "replication" ], compress => 0
          }]
       }
    }
+
+   push @$listeners, {
+      type => "metrics",
+      port => $self->{ports}{metrics},
+      bind_address => $bind_host,
+      tls => 0,
+   };
 
    my $cert_file = "$hs_dir/cert.pem";
    my $key_file = "$hs_dir/key.pem";
@@ -160,7 +168,7 @@ sub start
    my $registration_shared_secret = "reg_secret";
 
    my $config_path = $self->write_yaml_file( config => {
-        "server_name" => "localhost:$port",
+        "server_name" => "$bind_host:$port",
         "log_file" => "$log",
         (-f $log_config_file) ? ("log_config" => $log_config_file) : (),
         "tls_certificate_path" => $cert_file,
@@ -180,7 +188,6 @@ sub start
 
         # Metrics are always useful
         "enable_metrics" => 1,
-        "metrics_port" => $self->{ports}{metrics},
 
         "perspectives" => { servers => {} },
 
@@ -201,16 +208,18 @@ sub start
    my $pusher_config_path = $self->write_yaml_file( pusher => {
       "worker_app"             => "synapse.app.pusher",
       "worker_log_file"        => "$log.pusher",
-      "worker_replication_url" => "http://127.0.0.1:$self->{ports}{client_unsecure}/_synapse/replication",
+      "worker_replication_url" => "http://$bind_host:$self->{ports}{client_unsecure}/_synapse/replication",
       "worker_listeners"       => [
          {
             type      => "http",
             resources => [{ names => ["metrics"] }],
+            bind_address => $bind_host,
             port      => $self->{ports}{pusher_metrics},
          },
          {
             type => "manhole",
-            port => $self->{ports}{pusher_manhole},,
+            port => $self->{ports}{pusher_manhole},
+            bind_address => $bind_host,
          },
       ],
    } );
@@ -218,21 +227,24 @@ sub start
    my $synchrotron_config_path = $self->write_yaml_file( synchrotron => {
       "worker_app"             => "synapse.app.synchrotron",
       "worker_log_file"        => "$log.synchrotron",
-      "worker_replication_url" => "http://127.0.0.1:$self->{ports}{client_unsecure}/_synapse/replication",
+      "worker_replication_url" => "http://$bind_host:$self->{ports}{client_unsecure}/_synapse/replication",
       "worker_listeners"       => [
          {
             type      => "http",
             resources => [{ names => ["client"] }],
             port      => $self->{ports}{synchrotron},
+            bind_address => $bind_host,
          },
          {
             type => "manhole",
             port => $self->{ports}{synchrotron_manhole},
+            bind_address => $bind_host,
          },
          {
             type      => "http",
             resources => [{ names => ["metrics"] }],
             port      => $self->{ports}{synchrotron_metrics},
+            bind_address => $bind_host,
          },
       ],
    } );
@@ -262,7 +274,7 @@ sub start
    push @synapse_command,
       "-m", "synapse.app.homeserver",
       "--config-path" => $config_path,
-      "--server-name" => "localhost:$port";
+      "--server-name" => "$bind_host:$port";
 
    $output->diag( "Generating config for port $port" );
 
@@ -281,13 +293,13 @@ sub start
          $self->{dendron},
          "--synapse-python" => $self->{python},
          "--synapse-config" => $config_path,
-         "--synapse-url" => "http://127.0.0.1:$self->{ports}{client_unsecure}",
+         "--synapse-url" => "http://$bind_host:$self->{ports}{client_unsecure}",
          "--synapse-postgres" => join( " ", @db_arg_pairs ),
          "--macaroon-secret" => $macaroon_secret_key,
-         "--server-name" => "localhost:$port",
+         "--server-name" => "$bind_host:$port",
          "--cert-file" => $cert_file,
          "--key-file" => $key_file,
-         "--addr" => "127.0.0.1:$port",
+         "--addr" => "$bind_host:$port",
       );
 
       if ( $self->{pusher} ) {
@@ -297,7 +309,7 @@ sub start
       if ( $self->{synchrotron} ) {
          push @command,
             "--synchrotron-config" => $synchrotron_config_path,
-            "--synchrotron-url" => "http://127.0.0.1:$self->{ports}{synchrotron}";
+            "--synchrotron-url" => "http://$bind_host:$self->{ports}{synchrotron}";
       }
    }
    else {
@@ -338,7 +350,7 @@ sub start
          $output->diag( "Connecting to server $port" );
 
          $self->adopt_future(
-            $self->await_connectable( $port )->then( sub {
+            $self->await_connectable( $bind_host, $port )->then( sub {
                $output->diag( "Connected to server $port" );
 
                $self->started_future->done;

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -55,6 +55,8 @@ our %SYNAPSE_ARGS = (
 
 our $WANT_TLS = 1;  # This is shared with the test scripts
 
+our $BIND_HOST = "localhost";
+
 my %FIXED_BUGS;
 
 my $STOP_ON_FAIL;
@@ -85,6 +87,8 @@ GetOptions(
    'pusher+' => \$SYNAPSE_ARGS{pusher},
 
    'synchrotron+' => \$SYNAPSE_ARGS{synchrotron},
+
+   'bind-host=s' => \$BIND_HOST,
 
    'p|port-range=s' => \(my $PORT_RANGE = "8800:8819"),
 

--- a/tests/01http-server.pl
+++ b/tests/01http-server.pl
@@ -17,7 +17,7 @@ our $TEST_SERVER_INFO = fixture(
    requires => [],
 
    setup => sub {
-      my $listen_host = "localhost";
+      my $listen_host = $BIND_HOST;
 
       my $http_server = SyTest::HTTPServer->new;
       $loop->add( $http_server );
@@ -26,11 +26,8 @@ our $TEST_SERVER_INFO = fixture(
       my $server_info;
 
       $http_server->listen(
-         addr => {
-            family   => "inet",
-            socktype => "stream",
-            port     => 0,
-         },
+         host => $BIND_HOST,
+         service => 0,
          extensions => ["SSL"],
          SSL_cert_file => "$DIR/../keys/tls-selfsigned.crt",
          SSL_key_file => "$DIR/../keys/tls-selfsigned.key",

--- a/tests/05synapse.pl
+++ b/tests/05synapse.pl
@@ -61,14 +61,14 @@ our @HOMESERVER_INFO = map {
          my @extra_args = extract_extra_args( $idx, $SYNAPSE_ARGS{extra_args} );
 
          my $location = $WANT_TLS ?
-            "https://localhost:$secure_port" :
-            "http://localhost:$unsecure_port";
+            "https://$BIND_HOST:$secure_port" :
+            "http://$BIND_HOST:$unsecure_port";
 
-         my $info = ServerInfo( "localhost:$secure_port", $location );
+         my $info = ServerInfo( "$BIND_HOST:$secure_port", $location );
 
          my $synapse = SyTest::Homeserver::Synapse->new(
             synapse_dir   => $SYNAPSE_ARGS{directory},
-            hs_dir        => abs_path( "localhost-$idx" ),
+            hs_dir        => abs_path( "$BIND_HOST-$idx" ),
             ports         => {
                client          => $secure_port,
                client_unsecure => $unsecure_port,
@@ -81,6 +81,7 @@ our @HOMESERVER_INFO = map {
                synchrotron_metrics => main::alloc_port( "synchrotron[$idx].metrics" ),
                synchrotron_manhole => main::alloc_port( "synchrotron[$idx].manhole" ),
             },
+            bind_host     => $BIND_HOST,
             output        => $OUTPUT,
             print_output  => $SYNAPSE_ARGS{log},
             extra_args    => \@extra_args,
@@ -135,7 +136,7 @@ our @HOMESERVER_INFO = map {
                push @confs, $appserv_conf;
 
                # Now we can fill in the AS info's user_id
-               $as_info->user_id = sprintf "@%s:localhost:%d",
+               $as_info->user_id = sprintf "@%s:$BIND_HOST:%d",
                   $as_info->localpart, $secure_port;
             }
 

--- a/tests/05synapse.pl
+++ b/tests/05synapse.pl
@@ -68,7 +68,7 @@ our @HOMESERVER_INFO = map {
 
          my $synapse = SyTest::Homeserver::Synapse->new(
             synapse_dir   => $SYNAPSE_ARGS{directory},
-            hs_dir        => abs_path( "$BIND_HOST-$idx" ),
+            hs_dir        => abs_path( "server-$idx" ),
             ports         => {
                client          => $secure_port,
                client_unsecure => $unsecure_port,

--- a/tests/07id-server.pl
+++ b/tests/07id-server.pl
@@ -15,14 +15,14 @@ sub id_server_fixture
          $loop->add( $id_server );
 
          $id_server->listen(
-            host    => "$BIND_HOST",
-            service => "",
-            extensions => [qw( SSL )],
+            host          => $BIND_HOST,
+            service       => "",
+            extensions    => [qw( SSL )],
             # Synapse currently only talks IPv4
-            family => "inet",
+            family        => "inet",
 
             SSL_cert_file => "$DIR/../keys/tls-selfsigned.crt",
-            SSL_key_file => "$DIR/../keys/tls-selfsigned.key",
+            SSL_key_file  => "$DIR/../keys/tls-selfsigned.key",
          )->then_done( $id_server );
       },
 

--- a/tests/07id-server.pl
+++ b/tests/07id-server.pl
@@ -15,7 +15,7 @@ sub id_server_fixture
          $loop->add( $id_server );
 
          $id_server->listen(
-            host    => "localhost",
+            host    => "$BIND_HOST",
             service => "",
             extensions => [qw( SSL )],
             # Synapse currently only talks IPv4

--- a/tests/30rooms/08levels.pl
+++ b/tests/30rooms/08levels.pl
@@ -89,7 +89,7 @@ test_powerlevel "'ban' event respects room powerlevel",
 ##    try => sub {
 ##       my ( $test_user, $room_id ) = @_;
 ## 
-##       matrix_invite_user_to_room( $test_user, '@random-invitee:localhost:8001', $room_id );
+##       matrix_invite_user_to_room( $test_user, '@random-invitee:$BIND_HOST:8001', $room_id );
 ##    };
 
 test_powerlevel "setting 'm.room.name' respects room powerlevel",

--- a/tests/50federation/00prepare.pl
+++ b/tests/50federation/00prepare.pl
@@ -21,13 +21,13 @@ our $INBOUND_SERVER = fixture(
       require IO::Async::SSL;
 
       $inbound_server->listen(
-         host    => "$BIND_HOST",
-         service => "",
-         extensions => [qw( SSL )],
+         host          => $BIND_HOST,
+         service       => "",
+         extensions    => [qw( SSL )],
          # Synapse currently only talks IPv4
-         family => "inet",
+         family        => "inet",
 
-         SSL_key_file => "$DIR/server.key",
+         SSL_key_file  => "$DIR/server.key",
          SSL_cert_file => "$DIR/server.crt",
       )->on_done( sub {
          my ( $inbound_server ) = @_;

--- a/tests/50federation/00prepare.pl
+++ b/tests/50federation/00prepare.pl
@@ -21,7 +21,7 @@ our $INBOUND_SERVER = fixture(
       require IO::Async::SSL;
 
       $inbound_server->listen(
-         host    => "localhost",
+         host    => "$BIND_HOST",
          service => "",
          extensions => [qw( SSL )],
          # Synapse currently only talks IPv4

--- a/tests/90jira/SYN-202.pl
+++ b/tests/90jira/SYN-202.pl
@@ -24,7 +24,7 @@ multi_test "Left room members do not cause problems for presence",
          #   Impossible currently for this unit test to detect it, but the
          #   log should hopefully *not* contain a message like this:
          #
-         #      synapse.handlers.message - 395 - WARNING -  - Failed to get member presence of u'@SYN-202-user2:localhost:8001'
+         #      synapse.handlers.message - 395 - WARNING -  - Failed to get member presence of u'@SYN-202-user2:$BIND_HOST:8001'
 
          Future->done(1);
       });


### PR DESCRIPTION
This can be used to run multiple instances of sytest on the same machine
by supplying different 127.*.*.* addresses for each instance.