### PR TITLE
Make expected failures clearer

### DIFF
--- a/lib/SyTest/Output/TAP.pm
+++ b/lib/SyTest/Output/TAP.pm
@@ -128,7 +128,7 @@ package SyTest::Output::TAP::Test {
       }
       else {
          # for expected fails, theoretically all we need to do is write the
-         # TODO, but Jenkins' 'TAP Test results page is arse and doesn't distinguish
+         # TODO, but Jenkins' 'TAP Test results' page is arse and doesn't distinguish
          # between expected and unexpected fails, so stick it in the name too.
          print "not ok ${\$self->num} " .
             ( $self->expect_fail ? "(expected fail) " : "" ) .

--- a/lib/SyTest/Output/TAP.pm
+++ b/lib/SyTest/Output/TAP.pm
@@ -127,7 +127,13 @@ package SyTest::Output::TAP::Test {
          print "ok ${\$self->num} $name\n";
       }
       else {
-         print "not ok ${\$self->num} ${\$self->name}" . ( $self->expect_fail ? " # TODO expected fail" : "" ) . "\n";
+         # for expected fails, theoretically all we need to do is write the
+         # TODO, but Jenkins' 'TAP Test results page is arse and doesn't distinguish
+         # between expected and unexpected fails, so stick it in the name too.
+         print "not ok ${\$self->num} " .
+            ( $self->expect_fail ? "(expected fail) " : "" ) .
+            $self->name .
+            ( $self->expect_fail ? " # TODO expected fail" : "" ) . "\n";
 
          print "# $_\n" for split m/\n/, $self->failure;
       }


### PR DESCRIPTION
I can never tell which tests are expected to fail, so put some text in the
test name.