### PR TITLE
Test ability for room members to override displayname on a per-room basis

### DIFF
--- a/tests/30rooms/14override-per-room.pl
+++ b/tests/30rooms/14override-per-room.pl
@@ -1,0 +1,31 @@
+test "Room members can override their displayname on a room-specific basis",
+   bug => "#1382",
+
+   requires => [ local_user_and_room_fixtures() ],
+
+   do => sub {
+      my ( $user, $room_id ) = @_;
+
+      matrix_put_room_state( $user, $room_id,
+         type      => "m.room.member",
+         state_key => $user->user_id,
+         content   => {
+            membership => "join",
+            displayname => "Overridden",
+         },
+      )->then( sub {
+         matrix_get_room_state( $user, $room_id,
+            type      => "m.room.member",
+            state_key => $user->user_id,
+         );
+      })->then( sub {
+         my ( $state ) = @_;
+
+         log_if_fail "State", $state;
+
+         assert_eq( $state->{displayname}, "Overridden",
+            'displayname in my m.room.member event' );
+
+         Future->done(1);
+      });
+   };

--- a/tests/30rooms/14override-per-room.pl
+++ b/tests/30rooms/14override-per-room.pl
@@ -1,6 +1,4 @@
 test "Room members can override their displayname on a room-specific basis",
-   bug => "#1382",
-
    requires => [ local_user_and_room_fixtures() ],
 
    do => sub {
@@ -31,8 +29,6 @@ test "Room members can override their displayname on a room-specific basis",
    };
 
 test "Room members can join a room with an overridden displayname",
-   bug => "#1382",
-
    requires => [ local_user_and_room_fixtures(), local_user_fixture() ],
 
    do => sub {

--- a/tests/30rooms/14override-per-room.pl
+++ b/tests/30rooms/14override-per-room.pl
@@ -29,3 +29,36 @@ test "Room members can override their displayname on a room-specific basis",
          Future->done(1);
       });
    };
+
+test "Room members can join a room with an overridden displayname",
+   bug => "#1382",
+
+   requires => [ local_user_and_room_fixtures(), local_user_fixture() ],
+
+   do => sub {
+      my ( $creator, $room_id, $joiner ) = @_;
+
+      # PUT'ing my membership state should join me
+      matrix_put_room_state( $joiner, $room_id,
+         type      => "m.room.member",
+         state_key => $joiner->user_id,
+         content   => {
+            membership => "join",
+            displayname => "Overridden",
+         },
+      )->then( sub {
+         matrix_get_room_state( $creator, $room_id,
+            type      => "m.room.member",
+            state_key => $joiner->user_id,
+         );
+      })->then( sub {
+         my ( $state ) = @_;
+
+         log_if_fail "State", $state;
+
+         assert_eq( $state->{displayname}, "Overridden",
+            'displayname in my m.room.member event at join time' );
+
+         Future->done(1);
+      });
+   };

--- a/tests/31sync/06state.pl
+++ b/tests/31sync/06state.pl
@@ -567,8 +567,6 @@ test "A change to displayname should appear in incremental /sync",
    requires => [ local_user_fixture( with_events => 0 ),
                  qw( can_sync ) ],
 
-   bug => "SYN-707",
-
    check => sub {
       my ( $user ) = @_;
 

--- a/tests/31sync/06state.pl
+++ b/tests/31sync/06state.pl
@@ -591,7 +591,8 @@ test "A change to displayname should appear in incremental /sync",
             state_key => $user->user_id,
          );
       })->then( sub {
-         ( $event_id_1 ) = @_;
+         my ( $result ) = @_;
+         $event_id_1 = $result->{event_id};
 
          matrix_send_room_text_message_synced( $user, $room_id,
             body => "A message to wait on because the m.room.member might not come down /sync"
@@ -609,8 +610,8 @@ test "A change to displayname should appear in incremental /sync",
          log_if_fail "Room", $room;
 
          assert_eq( scalar @{ $timeline }, 2, "Expected 2 events");
-         assert_eq( $timeline->[0]{event_id}, $event_id_1 );
-         assert_eq( $timeline->[1]{event_id}, $event_id_2 );
+         assert_eq( $timeline->[0]{event_id}, $event_id_1, "First event ID" );
+         assert_eq( $timeline->[1]{event_id}, $event_id_2, "Second event ID" );
 
          Future->done(1);
       });


### PR DESCRIPTION
This tests the synapse code added by https://github.com/matrix-org/synapse/pull/1852