### PR TITLE
Unconditionalise synapse components under dendron

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -204,10 +204,10 @@ sub start
 
         # If we're using dendron-style split workers, we need to disable these
         # things in the main process
-        "start_pushers" => (not $self->{dendron}),
-        "notify_appservices" => (not $self->{dendron}),
-        "send_federation" => (not $self->{dendron}),
-        "notify_appservices" => (not $self->{dendron}),
+        "start_pushers"      => ( not $self->{dendron} ),
+        "notify_appservices" => ( not $self->{dendron} ),
+        "send_federation"    => ( not $self->{dendron} ),
+        "notify_appservices" => ( not $self->{dendron} ),
 
         "url_preview_enabled" => "true",
         "url_preview_ip_range_blacklist" => [],

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -207,7 +207,6 @@ sub start
         "start_pushers"      => ( not $self->{dendron} ),
         "notify_appservices" => ( not $self->{dendron} ),
         "send_federation"    => ( not $self->{dendron} ),
-        "notify_appservices" => ( not $self->{dendron} ),
 
         "url_preview_enabled" => "true",
         "url_preview_ip_range_blacklist" => [],

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -27,8 +27,7 @@ sub _init
 
    $self->{$_} = delete $args->{$_} for qw(
       ports synapse_dir extra_args python config coverage
-      dendron pusher synchrotron federation_reader bind_host
-      media_repository appservice client_reader federation_sender
+      dendron bind_host
    );
 
    defined $self->{ports}{$_} or croak "Need a '$_' port\n"
@@ -202,11 +201,13 @@ sub start
         "listeners" => $listeners,
 
         "bcrypt_rounds" => 0,
-        "start_pushers" => (not $self->{pusher}),
 
-        "notify_appservices" => (not $self->{appservice}),
-
-        "send_federation" => (not $self->{federation_sender}),
+        # If we're using dendron-style split workers, we need to disable these
+        # things in the main process
+        "start_pushers" => (not $self->{dendron}),
+        "notify_appservices" => (not $self->{dendron}),
+        "send_federation" => (not $self->{dendron}),
+        "notify_appservices" => (not $self->{dendron}),
 
         "url_preview_enabled" => "true",
         "url_preview_ip_range_blacklist" => [],
@@ -427,43 +428,19 @@ sub start
          "--cert-file" => $cert_file,
          "--key-file" => $key_file,
          "--addr" => "$bind_host:$port",
+
+         "--pusher-config" => $pusher_config_path,
+         "--appservice-config" => $appservice_config_path,
+         "--federation-sender-config" => $federation_sender_config_path,
+         "--synchrotron-config" => $synchrotron_config_path,
+         "--synchrotron-url" => "http://$bind_host:$self->{ports}{synchrotron}",
+         "--federation-reader-config" => $federation_reader_config_path,
+         "--federation-reader-url" => "http://$bind_host:$self->{ports}{federation_reader}",
+         "--media-repository-config" => $media_repository_config_path,
+         "--media-repository-url" => "http://$bind_host:$self->{ports}{media_repository}",
+         "--client-reader-config" => $client_reader_config_path,
+         "--client-reader-url" => "http://$bind_host:$self->{ports}{client_reader}",
       );
-
-      if ( $self->{pusher} ) {
-         push @command, "--pusher-config" => $pusher_config_path;
-      }
-
-      if ( $self->{appservice} ) {
-         push @command, "--appservice-config" => $appservice_config_path;
-      }
-
-      if ( $self->{federation_sender} ) {
-         push @command, "--federation-sender-config" => $federation_sender_config_path;
-      }
-
-      if ( $self->{synchrotron} ) {
-         push @command,
-            "--synchrotron-config" => $synchrotron_config_path,
-            "--synchrotron-url" => "http://$bind_host:$self->{ports}{synchrotron}";
-      }
-
-      if ( $self->{federation_reader} ) {
-         push @command,
-            "--federation-reader-config" => $federation_reader_config_path,
-            "--federation-reader-url" => "http://$bind_host:$self->{ports}{federation_reader}";
-      }
-
-      if ( $self->{media_repository} ) {
-         push @command,
-            "--media-repository-config" => $media_repository_config_path,
-            "--media-repository-url" => "http://$bind_host:$self->{ports}{media_repository}";
-      }
-
-      if ( $self->{client_reader} ) {
-         push @command,
-            "--client-reader-config" => $client_reader_config_path,
-            "--client-reader-url" => "http://$bind_host:$self->{ports}{client_reader}";
-      }
    }
    else {
       @command = @synapse_command

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -89,17 +89,13 @@ GetOptions(
 
    'pusher+' => \$SYNAPSE_ARGS{pusher},
 
-   'synchrotron+' => \$SYNAPSE_ARGS{synchrotron},
-
-   'federation-reader+' => \$SYNAPSE_ARGS{federation_reader},
-
-   'media-repository+' => \$SYNAPSE_ARGS{media_repository},
-
-   'appservice+' => \$SYNAPSE_ARGS{appservice},
-
-   'federation-sender+' => \$SYNAPSE_ARGS{federation_sender},
-
-   'client-reader+' => \$SYNAPSE_ARGS{client_reader},
+   # These are now unused, but retaining arguments for commandline parsing support
+   'synchrotron+'       => sub {},
+   'federation-reader+' => sub {},
+   'media-repository+'  => sub {},
+   'appservice+'        => sub {},
+   'federation-sender+' => sub {},
+   'client-reader+'     => sub {},
 
    'bind-host=s' => \$BIND_HOST,
 

--- a/tests/05synapse.pl
+++ b/tests/05synapse.pl
@@ -109,13 +109,6 @@ our @HOMESERVER_INFO = map {
             python              => $SYNAPSE_ARGS{python},
             coverage            => $SYNAPSE_ARGS{coverage},
             dendron             => $SYNAPSE_ARGS{dendron},
-            pusher              => $SYNAPSE_ARGS{pusher},
-            synchrotron         => $SYNAPSE_ARGS{synchrotron},
-            federation_reader   => $SYNAPSE_ARGS{federation_reader},
-            media_repository    => $SYNAPSE_ARGS{media_repository},
-            appservice          => $SYNAPSE_ARGS{appservice},
-            federation_sender   => $SYNAPSE_ARGS{federation_sender},
-            client_reader       => $SYNAPSE_ARGS{client_reader},
             ( scalar @{ $SYNAPSE_ARGS{log_filter} } ?
                ( filter_output => $SYNAPSE_ARGS{log_filter} ) :
                () ),


### PR DESCRIPTION
Having each component be optional will make the `haproxy` config much harder to generate. Turns out we don't really make use of this conditional feature much, so make the code simpler by just starting all the components.

Also fixes the bug that the main synapse wasn't passed the `notify_appservices` argument before, so the appservice worker wasn't happy to start up.