### PR TITLE
Test guests can/can't join over federation

### DIFF
--- a/tests/30rooms/13guestaccess.pl
+++ b/tests/30rooms/13guestaccess.pl
@@ -488,6 +488,8 @@ test "GET /publicRooms includes avatar URLs",
 test "Guest users can accept invites to private rooms over federation",
    requires => [ remote_user_fixture(), guest_user_fixture() ],
 
+   bug => "synapse#2065",
+
    do => sub {
       my ( $remote_user, $local_guest ) = @_;
 

--- a/tests/30rooms/13guestaccess.pl
+++ b/tests/30rooms/13guestaccess.pl
@@ -539,7 +539,8 @@ test "Guest users denied access over federation if guest access prohibited",
       })->then( sub {
          matrix_invite_user_to_room( $remote_user, $local_guest, $room_id )
       })->then( sub {
-         matrix_join_room( $local_guest, $room_id )->main::expect_http_403
+         matrix_join_room( $local_guest, $room_id )
+         ->main::expect_http_403
       })->then( sub {
          Future->done( 1 );
       });


### PR DESCRIPTION
Test that they can join if guest access is allowed (expected fail) and cannot join when guest access is prohibited.