### PR TITLE
Neater repeat loops that fail faster

### DIFF
--- a/run-tests.pl
+++ b/run-tests.pl
@@ -337,12 +337,12 @@ sub retry_until_success(&)
    my $delay = 0.1;
 
    try_repeat {
-      $code->()
-      ->else_with_f( sub {
-         my ( $f ) = @_;
-         delay( $delay *= 1.5 )
-            ->then( sub { $f } );
-      });
+      my $prev_f = shift;
+
+      ( $prev_f ?
+            delay( $delay *= 1.5 ) :
+            Future->done )
+         ->then( $code );
    }  until => sub { !$_[0]->failure };
 }
 

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -14,7 +14,7 @@ use SyTest::Assertions qw( :all );
 use SyTest::JSONSensible;
 
 use Future;
-use Future::Utils qw( try_repeat_until_success );
+use Future::Utils qw( try_repeat );
 use IO::Async::Loop;
 
 use Data::Dump qw( pp );
@@ -336,14 +336,14 @@ sub retry_until_success(&)
 
    my $delay = 0.1;
 
-   try_repeat_until_success {
+   try_repeat {
       $code->()
       ->else_with_f( sub {
          my ( $f ) = @_;
          delay( $delay *= 1.5 )
             ->then( sub { $f } );
       });
-   };
+   }  until => sub { !$_[0]->failure };
 }
 
 my @log_if_fail_lines;

--- a/tests/00expect_http_fail.pl
+++ b/tests/00expect_http_fail.pl
@@ -1,5 +1,7 @@
 use Future 0.33; # ->then catch semantics
 
+use Carp;
+
 sub gen_expect_failure
 {
    my ( $name, $match ) = @_;
@@ -30,6 +32,8 @@ our @EXPORT = qw(
    expect_http_302
    expect_http_4xx expect_http_400 expect_http_401 expect_http_403 expect_http_404
    expect_http_413 expect_http_error
+
+   check_http_code
 );
 
 *expect_http_302 = gen_expect_failure( '302' => qr/^302/ );
@@ -47,3 +51,64 @@ our @EXPORT = qw(
 *expect_http_413 = gen_expect_failure( '413' => qr/^413/ );
 
 *expect_http_error = gen_expect_failure( '4xx or 5xx' => qr/^[45]/ );
+
+=head2 check_http_code
+
+   $f_out = check_http_code( $f_in, %resultmap )
+   $f_out = $f_in->main::check_http_code( %resultmap )
+
+A utility wrapper around a L<Future> that normally returns HTTP responses
+(such as those returned by C<do_json_for> and similar).
+
+With an empty C<%resultmap> the function is transparent; the result of its
+return future is whatever the input future's result was. However, keys in
+C<%resultmap> cause different results for different HTTP status codes.
+
+Each key in C<%resultmap> is either a numeric HTTP result code (e.g. C<200>),
+a result code category (e.g. C<4xx>) or the special string C<"fail">, which
+applies to failures that didn't even result in an HTTP response at all.
+
+The corresponding value decides what alternative result the output future
+should provide. C<"ok"> means it should return a single scalar true value,
+C<"redo"> means it should return a single scalar false value (the reason being
+this is likely to be used inside a C<repeat_until_true> block, thus causing
+the block to repeat).
+
+=cut
+
+sub check_http_code
+{
+   my $f = shift;
+   my %resultmap = @_;
+
+   my $interpret_code = sub {
+      my ( $f, $code ) = @_;
+
+      my $outcome = $resultmap{$code} //
+                    $resultmap{ substr( $code, 0, 1 ) . "xx" };
+
+      if( !defined $outcome ) {
+         return $f;
+      }
+      elsif( $outcome eq "ok" ) {
+         return Future->done(1);
+      }
+      elsif( $outcome eq "redo" ) {
+         return Future->done(0);
+      }
+      else {
+         croak "Outcome '$outcome' not recognised";
+      }
+   };
+
+   return $f->then_with_f(
+      sub {  # done
+         my ( $f, $body, $response ) = @_;
+         $interpret_code->( $f, $response ? $response->code : "200" );
+      },
+      http => sub {  # catch http
+         my ( $f, undef, $name, $response ) = @_;
+         $interpret_code->( $f, $response ? $response->code : "fail" );
+      },
+   );
+}

--- a/tests/10apidoc/12device_management.pl
+++ b/tests/10apidoc/12device_management.pl
@@ -253,12 +253,15 @@ test "DELETE /device/{deviceId}",
             ->main::expect_http_404;
       })->then( sub {
          # our access token should be invalidated
-         retry_until_success {
+         repeat_until_true {
             do_request_json_for(
                $other_login,
                method  => "GET",
                uri     => "/r0/sync",
-            )->main::expect_http_401
+            )->main::check_http_code(
+               401 => "ok",
+               200 => "redo",
+            );
          };
       });
    };

--- a/tests/10apidoc/12device_management.pl
+++ b/tests/10apidoc/12device_management.pl
@@ -1,5 +1,4 @@
 use JSON qw( decode_json );
-use Future::Utils qw( try_repeat_until_success );
 
 our @EXPORT = qw( matrix_get_device matrix_set_device_display_name matrix_delete_device );
 
@@ -253,17 +252,13 @@ test "DELETE /device/{deviceId}",
          matrix_get_device( $user, $DEVICE_ID )
             ->main::expect_http_404;
       })->then( sub {
-         my $delay = 0.1;
          # our access token should be invalidated
-         try_repeat_until_success {
+         retry_until_success {
             do_request_json_for(
                $other_login,
                method  => "GET",
                uri     => "/r0/sync",
             )->main::expect_http_401
-            ->else_with_f( sub {
-               my ( $f ) = @_; delay( $delay *= 1.5 )->then( sub { $f } );
-            })
          };
       });
    };

--- a/tests/10apidoc/31room-state.pl
+++ b/tests/10apidoc/31room-state.pl
@@ -250,7 +250,7 @@ test "POST /rooms/:room_id/state/m.room.name sets name",
 
          content => { name => $name },
       )->then( sub {
-         retry_until_success {
+         repeat_until_true {
             matrix_initialsync_room( $user, $room_id )->then( sub {
                my ( $body ) = @_;
 
@@ -259,10 +259,7 @@ test "POST /rooms/:room_id/state/m.room.name sets name",
 
                my %state_by_type = partition_by { $_->{type} } @$state;
 
-               $state_by_type{"m.room.name"} or
-                  die "Expected to find m.room.name state";
-
-               Future->done(1);
+               Future->done( defined $state_by_type{"m.room.name"} );
             })
          };
       })
@@ -309,7 +306,7 @@ test "POST /rooms/:room_id/state/m.room.topic sets topic",
 
          content => { topic => $topic },
       )->then( sub {
-         retry_until_success {
+         repeat_until_true {
             matrix_initialsync_room( $user, $room_id )->then( sub {
                my ( $body ) = @_;
 
@@ -318,10 +315,7 @@ test "POST /rooms/:room_id/state/m.room.topic sets topic",
 
                my %state_by_type = partition_by { $_->{type} } @$state;
 
-               $state_by_type{"m.room.topic"} or
-                  die "Expected to find m.room.topic state";
-
-               Future->done(1);
+               Future->done( defined $state_by_type{"m.room.topic"} );
             })
          };
       })

--- a/tests/10apidoc/31room-state.pl
+++ b/tests/10apidoc/31room-state.pl
@@ -1,6 +1,5 @@
 use List::Util qw( any );
 use List::UtilsBy qw( partition_by );
-use Future::Utils qw( try_repeat_until_success );
 
 my $name = "room name here";
 
@@ -245,15 +244,13 @@ test "POST /rooms/:room_id/state/m.room.name sets name",
    check => sub {
       my ( $user, $room_id, undef ) = @_;
 
-      my $delay = 0.1;
-
       do_request_json_for( $user,
          method => "PUT",
          uri    => "/r0/rooms/$room_id/state/m.room.name",
 
          content => { name => $name },
       )->then( sub {
-         try_repeat_until_success( sub {
+         retry_until_success( sub {
             matrix_initialsync_room( $user, $room_id )->then( sub {
                my ( $body ) = @_;
 
@@ -266,8 +263,6 @@ test "POST /rooms/:room_id/state/m.room.name sets name",
                   die "Expected to find m.room.name state";
 
                Future->done(1);
-            })->else_with_f( sub {
-               my ( $f ) = @_; delay( $delay *= 1.5 )->then( sub { $f } );
             })
          });
       })
@@ -308,15 +303,13 @@ test "POST /rooms/:room_id/state/m.room.topic sets topic",
    check => sub {
       my ( $user, $room_id, undef ) = @_;
 
-      my $delay = 0.1;
-
       do_request_json_for( $user,
          method => "PUT",
          uri    => "/r0/rooms/$room_id/state/m.room.topic",
 
          content => { topic => $topic },
       )->then( sub {
-         try_repeat_until_success( sub {
+         retry_until_success( sub {
             matrix_initialsync_room( $user, $room_id )->then( sub {
                my ( $body ) = @_;
 
@@ -329,8 +322,6 @@ test "POST /rooms/:room_id/state/m.room.topic sets topic",
                   die "Expected to find m.room.topic state";
 
                Future->done(1);
-            })->else_with_f( sub {
-               my ( $f ) = @_; delay( $delay *= 1.5 )->then( sub { $f } );
             })
          })
       })

--- a/tests/10apidoc/31room-state.pl
+++ b/tests/10apidoc/31room-state.pl
@@ -250,7 +250,7 @@ test "POST /rooms/:room_id/state/m.room.name sets name",
 
          content => { name => $name },
       )->then( sub {
-         retry_until_success( sub {
+         retry_until_success {
             matrix_initialsync_room( $user, $room_id )->then( sub {
                my ( $body ) = @_;
 
@@ -264,7 +264,7 @@ test "POST /rooms/:room_id/state/m.room.name sets name",
 
                Future->done(1);
             })
-         });
+         };
       })
    };
 
@@ -309,7 +309,7 @@ test "POST /rooms/:room_id/state/m.room.topic sets topic",
 
          content => { topic => $topic },
       )->then( sub {
-         retry_until_success( sub {
+         retry_until_success {
             matrix_initialsync_room( $user, $room_id )->then( sub {
                my ( $body ) = @_;
 
@@ -323,7 +323,7 @@ test "POST /rooms/:room_id/state/m.room.topic sets topic",
 
                Future->done(1);
             })
-         })
+         };
       })
    };
 

--- a/tests/13logout.pl
+++ b/tests/13logout.pl
@@ -17,8 +17,11 @@ test "Can logout current device",
          )
       })->then( sub {
          # our access token should be invalidated
-         retry_until_success {
-            matrix_sync( $user )->main::expect_http_401
+         repeat_until_true {
+            matrix_sync( $user )->main::check_http_code(
+               401 => "ok",
+               200 => "redo",
+            );
          };
       })->then( sub {
          matrix_sync( $other_login );
@@ -45,13 +48,19 @@ test "Can logout all devices",
          )
       })->then( sub {
          # our access token should be invalidated
-         retry_until_success {
-            matrix_sync( $user )->main::expect_http_401
+         repeat_until_true {
+            matrix_sync( $user )->main::check_http_code(
+               401 => "ok",
+               200 => "redo",
+            );
          };
       })->then( sub {
          # our access token should be invalidated
-         retry_until_success {
-            matrix_sync( $other_login )->main::expect_http_401
+         repeat_until_true {
+            matrix_sync( $other_login )->main::check_http_code(
+               401 => "ok",
+               200 => "redo",
+            );
          };
       });
    };

--- a/tests/13logout.pl
+++ b/tests/13logout.pl
@@ -1,5 +1,3 @@
-use Future::Utils qw( try_repeat_until_success );
-
 test "Can logout current device",
    requires => [ local_user_fixture( with_events => 0 ) ],
 
@@ -18,13 +16,9 @@ test "Can logout current device",
             content => {},
          )
       })->then( sub {
-         my $delay = 0.1;
          # our access token should be invalidated
-         try_repeat_until_success {
+         retry_until_success {
             matrix_sync( $user )->main::expect_http_401
-            ->else_with_f( sub {
-               my ( $f ) = @_; delay( $delay *= 1.5 )->then( sub { $f } );
-            })
          };
       })->then( sub {
          matrix_sync( $other_login );
@@ -50,22 +44,14 @@ test "Can logout all devices",
             content => {},
          )
       })->then( sub {
-         my $delay = 0.1;
          # our access token should be invalidated
-         try_repeat_until_success {
+         retry_until_success {
             matrix_sync( $user )->main::expect_http_401
-            ->else_with_f( sub {
-               my ( $f ) = @_; delay( $delay *= 1.5 )->then( sub { $f } );
-            })
          };
       })->then( sub {
-         my $delay = 0.1;
          # our access token should be invalidated
-         try_repeat_until_success {
+         retry_until_success {
             matrix_sync( $other_login )->main::expect_http_401
-            ->else_with_f( sub {
-               my ( $f ) = @_; delay( $delay *= 1.5 )->then( sub { $f } );
-            })
          };
       });
    };

--- a/tests/14account/01change-password.pl
+++ b/tests/14account/01change-password.pl
@@ -1,5 +1,3 @@
-use Future::Utils qw( try_repeat_until_success );
-
 my $password = "my secure password";
 
 =head2 matrix_set_password
@@ -99,13 +97,9 @@ test "After changing password, a different session no longer works",
       })->then( sub {
          matrix_set_password( $user, $password, "my new password" )
       })->then( sub {
-         my $delay = 0.1;
          # our access token should be invalidated
-         try_repeat_until_success {
+         retry_until_success {
             matrix_sync( $other_login )->main::expect_http_401
-            ->else_with_f( sub {
-               my ( $f ) = @_; delay( $delay *= 1.5 )->then( sub { $f } );
-            })
          };
       })->then_done(1);
    };

--- a/tests/14account/01change-password.pl
+++ b/tests/14account/01change-password.pl
@@ -98,8 +98,11 @@ test "After changing password, a different session no longer works",
          matrix_set_password( $user, $password, "my new password" )
       })->then( sub {
          # our access token should be invalidated
-         retry_until_success {
-            matrix_sync( $other_login )->main::expect_http_401
+         repeat_until_true {
+            matrix_sync( $other_login )->main::check_http_code(
+               401 => "ok",
+               200 => "redo",
+            );
          };
       })->then_done(1);
    };

--- a/tests/30rooms/03members-remote.pl
+++ b/tests/30rooms/03members-remote.pl
@@ -1,4 +1,3 @@
-use Future::Utils 0.18 qw( try_repeat );
 use List::Util qw( first );
 use List::UtilsBy qw( partition_by );
 
@@ -93,7 +92,7 @@ test "New room members see existing members' presence in room initialSync",
    do => sub {
       my ( $first_user, $user, $room_id, $room_alias ) = @_;
 
-      try_repeat {
+      retry_until_success {
          matrix_initialsync_room( $user, $room_id )->then( sub {
             my ( $body ) = @_;
 
@@ -108,10 +107,8 @@ test "New room members see existing members' presence in room initialSync",
                qw( presence last_active_ago ));
 
             Future->done(1);
-         })->else_with_f( sub {
-            my ( $f ) = @_; delay( 0.2 )->then( sub { $f } );
          });
-      } until => sub { !$_[0]->failure };
+      };
    };
 
 test "Existing members see new members' join events",

--- a/tests/30rooms/07ban.pl
+++ b/tests/30rooms/07ban.pl
@@ -84,12 +84,12 @@ test "Remote banned user is kicked and may not rejoin until unbanned",
          $body->{membership} eq "ban" or
             die "Expected banned user membership to be 'ban'";
 
-         retry_until_success( sub {
+         retry_until_success {
             matrix_get_room_state( $banned_user, $room_id,
                type      => "m.room.member",
                state_key => $banned_user->user_id,
             )->main::expect_http_403;
-         })
+         };
       })->then( sub {
          matrix_join_room( $banned_user, $room_id )
             ->main::expect_http_403;  # Must be unbanned first

--- a/tests/30rooms/07ban.pl
+++ b/tests/30rooms/07ban.pl
@@ -84,28 +84,42 @@ test "Remote banned user is kicked and may not rejoin until unbanned",
          $body->{membership} eq "ban" or
             die "Expected banned user membership to be 'ban'";
 
-         retry_until_success {
+         repeat_until_true {
             matrix_get_room_state( $banned_user, $room_id,
                type      => "m.room.member",
                state_key => $banned_user->user_id,
-            )->main::expect_http_403;
+            )->main::check_http_code(
+               403 => "ok",
+               200 => "redo",
+            );
          };
       })->then( sub {
-         matrix_join_room( $banned_user, $room_id )
-            ->main::expect_http_403;  # Must be unbanned first
+         # Must be unbanned first
+         matrix_join_room( $banned_user, $room_id )->main::check_http_code(
+            403 => "ok",
+            200 => "redo",
+         );
       })->then( sub {
+         # Must be unbanned first
          do_request_json_for( $creator,
             method => "POST",
             uri    => "/r0/rooms/$room_id/invite",
 
             content => { user_id => $banned_user->user_id },
-         )->main::expect_http_403;  # Must be unbanned first
+         )->main::check_http_code(
+            403 => "ok",
+            200 => "redo",
+         );
       })->then( sub {
+         # Must be unbanned first
          do_request_json_for( $creator,
             method => "POST",
             uri    => "/r0/rooms/$room_id/kick",
 
             content => { user_id => $banned_user->user_id },
-         )->main::expect_http_403;  # Must be unbanned first
+         )->main::check_http_code(
+            403 => "ok",
+            200 => "redo",
+         );
       });
    };

--- a/tests/30rooms/07ban.pl
+++ b/tests/30rooms/07ban.pl
@@ -1,5 +1,3 @@
-use Future::Utils qw( try_repeat_until_success );
-
 my $creator_fixture = local_user_fixture();
 
 my $banned_user_fixture = local_user_fixture();
@@ -86,7 +84,7 @@ test "Remote banned user is kicked and may not rejoin until unbanned",
          $body->{membership} eq "ban" or
             die "Expected banned user membership to be 'ban'";
 
-         try_repeat_until_success( sub {
+         retry_until_success( sub {
             matrix_get_room_state( $banned_user, $room_id,
                type      => "m.room.member",
                state_key => $banned_user->user_id,

--- a/tests/30rooms/13guestaccess.pl
+++ b/tests/30rooms/13guestaccess.pl
@@ -224,9 +224,9 @@ test "Guest users are kicked from guest_access rooms on revocation of guest_acce
 
                # This may fail a few times if the power level event hasn't federated yet.
                # So we retry.
-               retry_until_success( sub {
+               retry_until_success {
                   matrix_set_room_guest_access( $remote_user, $room_id, "forbidden" );
-               }),
+               },
             );
          })->then( sub {
             repeat_until_true {

--- a/tests/30rooms/13guestaccess.pl
+++ b/tests/30rooms/13guestaccess.pl
@@ -229,7 +229,7 @@ test "Guest users are kicked from guest_access rooms on revocation of guest_acce
                }),
             );
          })->then( sub {
-            retry_until_success( sub {
+            retry_until_success {
                matrix_get_room_membership( $local_user, $room_id, $guest_user )
                ->then( sub {
                   my ( $membership ) = @_;
@@ -238,7 +238,7 @@ test "Guest users are kicked from guest_access rooms on revocation of guest_acce
 
                   Future->done(1);
                })
-            })
+            };
          });
       })
    };
@@ -353,7 +353,7 @@ test "GET /publicRooms lists rooms",
             );
          }),
       )->then( sub {
-         retry_until_success( sub {
+         retry_until_success {
             $http->do_request_json(
                method => "GET",
                uri    => "/r0/publicRooms",
@@ -403,7 +403,7 @@ test "GET /publicRooms lists rooms",
 
                Future->done(1);
             })
-         })
+         };
       })
    };
 
@@ -447,7 +447,7 @@ test "GET /publicRooms includes avatar URLs",
             );
          }),
       )->then( sub {
-         retry_until_success( sub {
+         retry_until_success {
             $http->do_request_json(
                method => "GET",
                uri    => "/r0/publicRooms",
@@ -487,7 +487,7 @@ test "GET /publicRooms includes avatar URLs",
 
                Future->done(1);
             })
-         })
+         };
       });
    };
 

--- a/tests/30rooms/13guestaccess.pl
+++ b/tests/30rooms/13guestaccess.pl
@@ -1,4 +1,4 @@
-use Future::Utils qw( try_repeat_until_success repeat );
+use Future::Utils qw( repeat );
 
 test "Guest user cannot call /events globally",
    requires => [ guest_user_fixture() ],
@@ -224,12 +224,12 @@ test "Guest users are kicked from guest_access rooms on revocation of guest_acce
 
                # This may fail a few times if the power level event hasn't federated yet.
                # So we retry.
-               try_repeat_until_success( sub {
+               retry_until_success( sub {
                   matrix_set_room_guest_access( $remote_user, $room_id, "forbidden" );
                }),
             );
          })->then( sub {
-            try_repeat_until_success( sub {
+            retry_until_success( sub {
                matrix_get_room_membership( $local_user, $room_id, $guest_user )
                ->then( sub {
                   my ( $membership ) = @_;
@@ -353,7 +353,7 @@ test "GET /publicRooms lists rooms",
             );
          }),
       )->then( sub {
-         try_repeat_until_success( sub {
+         retry_until_success( sub {
             $http->do_request_json(
                method => "GET",
                uri    => "/r0/publicRooms",
@@ -447,7 +447,7 @@ test "GET /publicRooms includes avatar URLs",
             );
          }),
       )->then( sub {
-         try_repeat_until_success( sub {
+         retry_until_success( sub {
             $http->do_request_json(
                method => "GET",
                uri    => "/r0/publicRooms",

--- a/tests/30rooms/70publicroomslist.pl
+++ b/tests/30rooms/70publicroomslist.pl
@@ -30,7 +30,7 @@ test "Name/topic keys are correct",
          )
       } keys %rooms )
       ->then( sub {
-         retry_until_success( sub {
+         repeat_until_true {
             $http->do_request_json(
                method => "GET",
                uri    => "/r0/publicRooms",
@@ -42,7 +42,7 @@ test "Name/topic keys are correct",
                assert_json_keys( $body, qw( chunk ));
                assert_json_list( $body->{chunk} );
 
-               my %seen = map {
+               my %isOK = map {
                   $_ => 0,
                } keys ( %rooms );
 
@@ -72,6 +72,10 @@ test "Name/topic keys are correct",
                         assert_eq( $canonical_alias, $alias, "Incorrect canonical_alias" );
                         assert_eq( $room->{num_joined_members}, 1, "Incorrect member count" );
 
+                        # The rooms should get created "atomically", so we should never
+                        # see any out of the public rooms list in the wrong state. If
+                        # we see a room we expect it to already be in the right state.
+
                         if( defined $name ) {
                            assert_eq( $room_config->{name}, $name, 'room name' );
                         }
@@ -86,19 +90,15 @@ test "Name/topic keys are correct",
                            defined $room_config->{topic} and die "Expected not to find a topic";
                         }
 
-                        $seen{$alias_local} = 1;
+                        $isOK{$alias_local} = 1;
                      }
                   }
                }
 
-               foreach my $key ( keys %seen ) {
-                  $seen{$key} or die "Did not find a /publicRooms result for $key";
-               }
-
-               Future->done(1);
-            })
-         })
-      })
+               Future->done( all { $isOK{$_} } keys %isOK );
+            });
+         };
+      });
    };
 
 test "Can get remote public room list",

--- a/tests/30rooms/70publicroomslist.pl
+++ b/tests/30rooms/70publicroomslist.pl
@@ -1,6 +1,3 @@
-use Future::Utils qw( try_repeat_until_success );
-
-
 test "Name/topic keys are correct",
    requires => [ $main::API_CLIENTS[0], local_user_fixture() ],
 
@@ -33,7 +30,7 @@ test "Name/topic keys are correct",
          )
       } keys %rooms )
       ->then( sub {
-         try_repeat_until_success( sub {
+         retry_until_success( sub {
             $http->do_request_json(
                method => "GET",
                uri    => "/r0/publicRooms",

--- a/tests/41end-to-end-keys/06-device-lists.pl
+++ b/tests/41end-to-end-keys/06-device-lists.pl
@@ -1,5 +1,3 @@
-use Future::Utils qw( try_repeat_until_success );
-
 test "Local device key changes appear in v2 /sync",
    requires => [ local_user_fixtures( 2 ),
                  qw( can_sync ) ],
@@ -68,7 +66,7 @@ test "Local new device changes appear in v2 /sync",
       })->then( sub {
          matrix_login_again_with_user( $user2 )
       })->then( sub {
-         try_repeat_until_success ( sub {
+         retry_until_success ( sub {
             matrix_sync_again( $user1, timeout => 1000 )
             ->then( sub {
                my ( $body ) = @_;
@@ -114,7 +112,7 @@ test "Local delete device changes appear in v2 /sync",
              }
          });
       })->then( sub {
-         try_repeat_until_success( sub {
+         retry_until_success( sub {
             matrix_sync_again( $user1, timeout => 1000 )
             ->then( sub {
                my ( $body ) = @_;
@@ -154,7 +152,7 @@ test "Local update device changes appear in v2 /sync",
       })->then( sub {
          matrix_set_device_display_name( $user2, $user2->device_id, "wibble");
       })->then( sub {
-         try_repeat_until_success( sub {
+         retry_until_success( sub {
             matrix_sync_again( $user1, timeout => 1000 )
             ->then( sub {
                my ( $body ) = @_;
@@ -199,7 +197,7 @@ test "Can query remote device keys using POST after notification",
       })->then( sub {
          matrix_set_device_display_name( $user2, $user2->device_id, "test display name" ),
       })->then( sub {
-         try_repeat_until_success( sub {
+         retry_until_success( sub {
             matrix_sync_again( $user1, timeout => 1000 )
             ->then( sub {
                my ( $body ) = @_;
@@ -283,7 +281,7 @@ test "If remote user leaves room we no longer receive device updates",
       })->then( sub {
          matrix_set_device_display_name( $remote_leaver, $remote_leaver->device_id, "test display name" ),
       })->then( sub {
-         try_repeat_until_success( sub {
+         retry_until_success( sub {
             matrix_sync_again( $creator, timeout => 1000 )
             ->then( sub {
                my ( $body ) = @_;
@@ -306,7 +304,7 @@ test "If remote user leaves room we no longer receive device updates",
       })->then( sub {
          matrix_put_e2e_keys( $remote2, device_keys => { updated => "keys" } )
       })->then( sub {
-         try_repeat_until_success( sub {
+         retry_until_success( sub {
             matrix_sync_again( $creator, timeout => 1000 )
             ->then( sub {
                my ( $body ) = @_;

--- a/tests/41end-to-end-keys/06-device-lists.pl
+++ b/tests/41end-to-end-keys/06-device-lists.pl
@@ -66,7 +66,7 @@ test "Local new device changes appear in v2 /sync",
       })->then( sub {
          matrix_login_again_with_user( $user2 )
       })->then( sub {
-         retry_until_success ( sub {
+         retry_until_success {
             matrix_sync_again( $user1, timeout => 1000 )
             ->then( sub {
                my ( $body ) = @_;
@@ -84,7 +84,7 @@ test "Local new device changes appear in v2 /sync",
 
                Future->done(1);
             })
-         })
+         };
       });
    };
 
@@ -112,7 +112,7 @@ test "Local delete device changes appear in v2 /sync",
              }
          });
       })->then( sub {
-         retry_until_success( sub {
+         retry_until_success {
             matrix_sync_again( $user1, timeout => 1000 )
             ->then( sub {
                my ( $body ) = @_;
@@ -130,7 +130,7 @@ test "Local delete device changes appear in v2 /sync",
 
                Future->done(1);
             })
-         })
+         };
       });
    };
 
@@ -152,7 +152,7 @@ test "Local update device changes appear in v2 /sync",
       })->then( sub {
          matrix_set_device_display_name( $user2, $user2->device_id, "wibble");
       })->then( sub {
-         retry_until_success( sub {
+         retry_until_success {
             matrix_sync_again( $user1, timeout => 1000 )
             ->then( sub {
                my ( $body ) = @_;
@@ -170,7 +170,7 @@ test "Local update device changes appear in v2 /sync",
 
                Future->done(1);
             })
-         })
+         };
       });
    };
 
@@ -197,7 +197,7 @@ test "Can query remote device keys using POST after notification",
       })->then( sub {
          matrix_set_device_display_name( $user2, $user2->device_id, "test display name" ),
       })->then( sub {
-         retry_until_success( sub {
+         retry_until_success {
             matrix_sync_again( $user1, timeout => 1000 )
             ->then( sub {
                my ( $body ) = @_;
@@ -215,7 +215,7 @@ test "Can query remote device keys using POST after notification",
 
                Future->done( 1 )
             })
-         })
+         };
       })->then( sub {
          do_request_json_for( $user1,
             method  => "POST",
@@ -281,7 +281,7 @@ test "If remote user leaves room we no longer receive device updates",
       })->then( sub {
          matrix_set_device_display_name( $remote_leaver, $remote_leaver->device_id, "test display name" ),
       })->then( sub {
-         retry_until_success( sub {
+         retry_until_success {
             matrix_sync_again( $creator, timeout => 1000 )
             ->then( sub {
                my ( $body ) = @_;
@@ -296,7 +296,7 @@ test "If remote user leaves room we no longer receive device updates",
 
                Future->done( 1 )
             })
-         })
+         };
       })->then( sub {
          matrix_leave_room( $remote_leaver, $room_id )
       })->then( sub {
@@ -304,7 +304,7 @@ test "If remote user leaves room we no longer receive device updates",
       })->then( sub {
          matrix_put_e2e_keys( $remote2, device_keys => { updated => "keys" } )
       })->then( sub {
-         retry_until_success( sub {
+         retry_until_success {
             matrix_sync_again( $creator, timeout => 1000 )
             ->then( sub {
                my ( $body ) = @_;
@@ -324,7 +324,7 @@ test "If remote user leaves room we no longer receive device updates",
 
                Future->done( 1 )
             })
-         })
+         };
       })->then( sub {
          any { $remote_leaver->user_id eq $_ } @device_users_changed
             and die "user2 in changed list after leaving";

--- a/tests/50federation/37public-rooms.pl
+++ b/tests/50federation/37public-rooms.pl
@@ -26,7 +26,7 @@ test "Inbound federation can get public room list",
           },
         );
       })->then( sub {
-         retry_until_success {
+         repeat_until_true {
             $outbound_client->do_request_json(
                method   => "GET",
                hostname => $first_home_server,
@@ -38,10 +38,7 @@ test "Inbound federation can get public room list",
 
                assert_json_keys( $body, qw( chunk ) );
 
-               any { $_->{room_id} eq $room_id } @{ $body->{chunk} }
-                  or die "Room not in returned list";
-
-               Future->done( 1 );
+               Future->done( any { $_->{room_id} eq $room_id } @{ $body->{chunk} } );
             })
          };
       });

--- a/tests/50federation/37public-rooms.pl
+++ b/tests/50federation/37public-rooms.pl
@@ -1,6 +1,3 @@
-use Future::Utils qw( try_repeat_until_success );
-
-
 test "Inbound federation can get public room list",
    requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
                  local_user_and_room_fixtures(),
@@ -29,7 +26,7 @@ test "Inbound federation can get public room list",
           },
         );
       })->then( sub {
-         try_repeat_until_success( sub {
+         retry_until_success( sub {
             $outbound_client->do_request_json(
                method   => "GET",
                hostname => $first_home_server,

--- a/tests/50federation/37public-rooms.pl
+++ b/tests/50federation/37public-rooms.pl
@@ -26,7 +26,7 @@ test "Inbound federation can get public room list",
           },
         );
       })->then( sub {
-         retry_until_success( sub {
+         retry_until_success {
             $outbound_client->do_request_json(
                method   => "GET",
                hostname => $first_home_server,
@@ -43,6 +43,6 @@ test "Inbound federation can get public room list",
 
                Future->done( 1 );
             })
-         })
+         };
       });
    };

--- a/tests/52user-directory/01public.pl
+++ b/tests/52user-directory/01public.pl
@@ -16,7 +16,7 @@ test "User appears in user directory",
       })->then( sub {
          ( $room_id ) = @_;
 
-         retry_until_success( sub {
+         retry_until_success {
             do_request_json_for( $user,
                method  => "POST",
                uri     => "/unstable/user_directory/search",
@@ -36,7 +36,7 @@ test "User appears in user directory",
 
                Future->done( 1 );
             });
-         })
+         };
       });
    };
 
@@ -458,7 +458,7 @@ sub matrix_get_user_dir_synced
          preset => "public_chat",
       );
    })->then( sub {
-      retry_until_success( sub {
+      retry_until_success {
          do_request_json_for( $new_user,
             method  => "POST",
             uri     => "/unstable/user_directory/search",
@@ -476,14 +476,14 @@ sub matrix_get_user_dir_synced
 
             Future->done( $body )
          });
-      })->then( sub {
-         do_request_json_for( $user,
-            method  => "POST",
-            uri     => "/unstable/user_directory/search",
-            content => {
-               search_term => $search_term,
-            }
-         );
-      })
+      };
+   })->then( sub {
+      do_request_json_for( $user,
+         method  => "POST",
+         uri     => "/unstable/user_directory/search",
+         content => {
+            search_term => $search_term,
+         }
+      );
    })
 }

--- a/tests/52user-directory/01public.pl
+++ b/tests/52user-directory/01public.pl
@@ -16,7 +16,7 @@ test "User appears in user directory",
       })->then( sub {
          ( $room_id ) = @_;
 
-         retry_until_success {
+         repeat_until_true {
             do_request_json_for( $user,
                method  => "POST",
                uri     => "/unstable/user_directory/search",
@@ -31,10 +31,7 @@ test "User appears in user directory",
                assert_json_keys( $body, qw( results ) );
                assert_json_list( my $results = $body->{results} );
 
-               any { $_->{user_id} eq $user->user_id } @$results
-                  or die "user not in list";
-
-               Future->done( 1 );
+               Future->done( any { $_->{user_id} eq $user->user_id } @$results );
             });
          };
       });
@@ -458,7 +455,7 @@ sub matrix_get_user_dir_synced
          preset => "public_chat",
       );
    })->then( sub {
-      retry_until_success {
+      repeat_until_true {
          do_request_json_for( $new_user,
             method  => "POST",
             uri     => "/unstable/user_directory/search",
@@ -471,10 +468,7 @@ sub matrix_get_user_dir_synced
             assert_json_keys( $body, qw( results ) );
             assert_json_list( my $results = $body->{results} );
 
-            any { $_->{user_id} eq $new_user->user_id } @$results
-               or die "user not in list";
-
-            Future->done( $body )
+            Future->done( any { $_->{user_id} eq $new_user->user_id } @$results );
          });
       };
    })->then( sub {
@@ -485,5 +479,5 @@ sub matrix_get_user_dir_synced
             search_term => $search_term,
          }
       );
-   })
+   });
 }

--- a/tests/52user-directory/01public.pl
+++ b/tests/52user-directory/01public.pl
@@ -1,6 +1,3 @@
-use Future::Utils qw( try_repeat_until_success );
-
-
 test "User appears in user directory",
    requires => [ local_user_fixture() ],
 
@@ -19,7 +16,7 @@ test "User appears in user directory",
       })->then( sub {
          ( $room_id ) = @_;
 
-         try_repeat_until_success( sub {
+         retry_until_success( sub {
             do_request_json_for( $user,
                method  => "POST",
                uri     => "/unstable/user_directory/search",
@@ -461,7 +458,7 @@ sub matrix_get_user_dir_synced
          preset => "public_chat",
       );
    })->then( sub {
-      try_repeat_until_success( sub {
+      retry_until_success( sub {
          do_request_json_for( $new_user,
             method  => "POST",
             uri     => "/unstable/user_directory/search",

--- a/tests/60app-services/06publicroomlist.pl
+++ b/tests/60app-services/06publicroomlist.pl
@@ -11,7 +11,7 @@ sub get_room_list_synced
 
    my $check = $opts{check};
 
-   retry_until_success {
+   repeat_until_true {
       do_request_json_for( $user,
          method => "POST",
          uri    => "/r0/publicRooms",
@@ -63,8 +63,7 @@ test "AS can publish rooms in their own list",
             check => sub {
                my ( $body ) = @_;
 
-               any { $room_id eq $_->{room_id} } @{ $body->{chunk} }
-                  and die "AS public room in main list";
+               not any { $room_id eq $_->{room_id} } @{ $body->{chunk} }
             },
          )
       })->then( sub {
@@ -77,7 +76,6 @@ test "AS can publish rooms in their own list",
                my ( $body ) = @_;
 
                any { $room_id eq $_->{room_id} } @{ $body->{chunk} }
-                  or die "AS public room is not in the AS list";
             },
          )
       })->then( sub {
@@ -90,7 +88,6 @@ test "AS can publish rooms in their own list",
                my ( $body ) = @_;
 
                any { $room_id eq $_->{room_id} } @{ $body->{chunk} }
-                  or die "AS public room is not in the full room list";
             },
          )
       })->then( sub {
@@ -107,8 +104,7 @@ test "AS can publish rooms in their own list",
             check => sub {
                my ( $body ) = @_;
 
-               any { $room_id eq $_->{room_id} } @{ $body->{chunk} }
-                  and die "AS public room in AS list after deletion";
+               not any { $room_id eq $_->{room_id} } @{ $body->{chunk} }
             },
          )
       });
@@ -164,7 +160,6 @@ test "AS and main public room lists are separate",
                my ( $body ) = @_;
 
                any { $room_id eq $_->{room_id} } @{ $body->{chunk} }
-                  or die "Room not in main list";
             },
          )
       })->then( sub {
@@ -177,7 +172,6 @@ test "AS and main public room lists are separate",
                my ( $body ) = @_;
 
                any { $room_id eq $_->{room_id} } @{ $body->{chunk} }
-                  or die "Room is not in the AS list";
             },
          )
       })->then( sub {
@@ -201,8 +195,7 @@ test "AS and main public room lists are separate",
             check => sub {
                my ( $body ) = @_;
 
-               any { $room_id eq $_->{room_id} } @{ $body->{chunk} }
-                  and die "Room in AS list after deletion";
+               not any { $room_id eq $_->{room_id} } @{ $body->{chunk} }
             },
          )
       })->then( sub {
@@ -215,7 +208,6 @@ test "AS and main public room lists are separate",
                my ( $body ) = @_;
 
                any { $room_id eq $_->{room_id} } @{ $body->{chunk} }
-                  or die "Room not in main list after AS list deletion";
             },
          )
       })->then( sub {
@@ -228,7 +220,6 @@ test "AS and main public room lists are separate",
                my ( $body ) = @_;
 
                any { $room_id eq $_->{room_id} } @{ $body->{chunk} }
-                  or die "Room is not in the full room list after AS deletion";
             },
          )
       })

--- a/tests/60app-services/06publicroomlist.pl
+++ b/tests/60app-services/06publicroomlist.pl
@@ -11,7 +11,7 @@ sub get_room_list_synced
 
    my $check = $opts{check};
 
-   retry_until_success( sub {
+   retry_until_success {
       do_request_json_for( $user,
          method => "POST",
          uri    => "/r0/publicRooms",
@@ -20,7 +20,7 @@ sub get_room_list_synced
       )->then( sub {
          Future->done( $check->( @_ ) )
       })
-   });
+   };
 }
 
 

--- a/tests/60app-services/06publicroomlist.pl
+++ b/tests/60app-services/06publicroomlist.pl
@@ -1,6 +1,3 @@
-use Future::Utils qw( try_repeat_until_success );
-
-
 use constant AS_PREFIX => "/_matrix/app/unstable";
 
 
@@ -14,7 +11,7 @@ sub get_room_list_synced
 
    my $check = $opts{check};
 
-   try_repeat_until_success( sub {
+   retry_until_success( sub {
       do_request_json_for( $user,
          method => "POST",
          uri    => "/r0/publicRooms",


### PR DESCRIPTION
* Neatens up the `try_repeat_until_success` code with delays into a self-contained `retry_until_success`, which applies the delay internally.

* Adds a new utility function, `repeat_until_true`, which repeats a Future<boolean>-returning block of code until its result is true. An outright exceptional failure is not caught and retried (as it would be with `retry_until_success`) but is instead immediately thrown upwards.

The distinct naming of these two is intentional - anything with the word `try` or `retry` in its name implies that it has a failure-catching semantic to it that will somehow handle failures itself; anything without does not and will propagate like normal code.

* Adds a new future following method, `main::check_http_code`, for evaluating a 3-way case split on HTTP results between OK, retry (via the above), or outright failure.

* Adjusts many callsites within the body of the test suite to use these new functions.

Overall this has the effect that temporary "It's not ready yet" failures in tests will be repeated, but permanent "500 the server died"-style failures will stop immediately with a more obvious message, rather than waiting for the 10 second generic timeout due to infinite retry.