### PR TITLE
Set bcrypt_rounds = 4

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -15,6 +15,15 @@ requires 'IO::Async::SSL';
 requires 'IO::Socket::IP', '>= 0.04';
 requires 'IO::Socket::SSL';
 requires 'JSON';
+
+# since List::MoreUtils 0.423 (or so), just installing 'List::MoreUtils'
+# doesn't give us a working version
+# (https://rt.cpan.org/Public/Bug/Display.html?id=122875 appears to relate to
+# this).
+#
+# Empirically installing List::MoreUtils::XS first seems to fix it.
+requires 'List::MoreUtils::XS';
+
 requires 'List::MoreUtils';
 requires 'List::Util', '>= 1.33';
 requires 'List::UtilsBy', '>= 0.10';

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -189,7 +189,10 @@ sub start
 
         listeners => $listeners,
 
-        bcrypt_rounds => 0,
+        # we reduce the number of bcrypt rounds to make generating users
+        # faster, but note that python's bcrypt complains if rounds < 4,
+        # so this is effectively the minimum.
+        bcrypt_rounds => 4,
 
         # If we're using dendron-style split workers, we need to disable these
         # things in the main process


### PR DESCRIPTION
to stop breakage occuring with modern python bcrypt