### PR TITLE
Fixes to how we handle failures in test fixtures

### DIFF
--- a/run-tests.pl
+++ b/run-tests.pl
@@ -364,6 +364,21 @@ sub repeat_until_true(&)
    }  until => sub { $_[0]->get };
 }
 
+# wrapper around Future::with_cancel which works around a bug whereby the
+# returned future does not keep a reference to the old future, which means it
+# may get garbage-collected.
+# (Ref: https://rt.cpan.org/Ticket/Display.html?id=122920)
+#
+# (also sets the label as a potential debugging aid)
+sub without_cancel
+{
+   my ( $future ) = @_;
+   my $new = $future->without_cancel;
+   $new->{oldref} = $future;
+   $new->set_label( "without_cancel(" . ( $future->label // $future ) . ")" );
+   return $new;
+}
+
 my @log_if_fail_lines;
 my $test_start_time;
 
@@ -429,7 +444,7 @@ sub fixture
 
       sub { $f_start->done( @_ ) unless $f_start->is_ready },
 
-      Future->needs_all( @req_futures )
+      Future->needs_all( map { without_cancel($_) } @req_futures )
          ->then( $setup )
          ->set_label( $name ),
 
@@ -541,7 +556,7 @@ sub _run_test
 
    my $success = eval {
       my @reqs;
-      my $f_setup = Future->needs_all( @req_futures )
+      my $f_setup = Future->needs_all( map { without_cancel($_) } @req_futures )
          ->on_done( sub { @reqs = @_ } )
          ->on_fail( sub { die "fixture failed - $_[0]\n" } );
 

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -558,7 +558,7 @@ sub _run_test
       my @reqs;
       my $f_setup = Future->needs_all( map { without_cancel($_) } @req_futures )
          ->on_done( sub { @reqs = @_ } )
-         ->on_fail( sub { die "fixture failed - $_[0]\n" } );
+         ->else( sub { die "fixture failed - $_[0]\n" } );
 
       my $f_test = $f_setup;
 


### PR DESCRIPTION
A couple of fixes to make sure that things carry on when fixtures fail