### PR TITLE
Include unique ID in generated user IDs

### DIFF
--- a/run-tests.pl
+++ b/run-tests.pl
@@ -25,6 +25,7 @@ use List::Util 1.33 qw( first all any maxstr max );
 use Struct::Dumb 0.04;
 use MIME::Base64 qw( decode_base64 );
 use Time::HiRes qw( time );
+use Date::Format qw( time2str );
 
 use Data::Dump::Filtered;
 Data::Dump::Filtered::add_dump_filter( sub {
@@ -55,6 +56,10 @@ our %SYNAPSE_ARGS = (
 our $WANT_TLS = 1;  # This is shared with the test scripts
 
 our $BIND_HOST = "localhost";
+
+# a unique ID for this test run. It is used in some tests to create user IDs
+# and the like.
+our $TEST_RUN_ID = time2str( '%Y%m%d%H%M%S', time() );
 
 my %FIXED_BUGS;
 

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -25,7 +25,7 @@ use List::Util 1.33 qw( first all any maxstr max );
 use Struct::Dumb 0.04;
 use MIME::Base64 qw( decode_base64 );
 use Time::HiRes qw( time );
-use Date::Format qw( time2str );
+use POSIX qw( strftime );
 
 use Data::Dump::Filtered;
 Data::Dump::Filtered::add_dump_filter( sub {
@@ -59,7 +59,7 @@ our $BIND_HOST = "localhost";
 
 # a unique ID for this test run. It is used in some tests to create user IDs
 # and the like.
-our $TEST_RUN_ID = time2str( '%Y%m%d%H%M%S', time() );
+our $TEST_RUN_ID = strftime( '%Y%m%dT%H%M%S', gmtime() );
 
 my %FIXED_BUGS;
 

--- a/tests/10apidoc/01register.pl
+++ b/tests/10apidoc/01register.pl
@@ -66,7 +66,7 @@ test "POST /register can create a user",
             auth => {
                type => "m.login.dummy",
             },
-            username => "01register-user",
+            username => "01register-user-".$TEST_RUN_ID,
             password => "s3kr1t",
          },
       )->then( sub {
@@ -84,7 +84,7 @@ my $next_anon_uid = 1;
 
 sub sprintf_localpart
 {
-   sprintf "ANON-%d", $next_anon_uid++
+   sprintf "ANON-%s-%d", $TEST_RUN_ID, $next_anon_uid++
 }
 
 sub localpart_fixture

--- a/tests/10apidoc/33room-members.pl
+++ b/tests/10apidoc/33room-members.pl
@@ -404,7 +404,7 @@ sub matrix_create_and_join_room
 
    matrix_create_room( $creator,
       %options,
-      room_alias_name => sprintf( "test-%d", $next_alias++ ),
+      room_alias_name => sprintf( "test-%s-%d", $TEST_RUN_ID, $next_alias++ ),
    )->then( sub {
       ( $room_id, $room_alias_fullname ) = @_;
 


### PR DESCRIPTION
This makes it easier to run repeated test runs against the same HS instance.