### PR TITLE
Fix 'Future is not yet complete' fail

### DIFF
--- a/run-tests.pl
+++ b/run-tests.pl
@@ -423,11 +423,12 @@ sub fixture
       $teardown ? sub {
          my ( $self ) = @_;
          my $result_f = $self->result;
+
          $self->result = Future->fail(
             "This Fixture has been torn down and cannot be used again"
          );
 
-         if( $self->result->is_ready ) {
+         if( $result_f->is_ready ) {
             return $teardown->( $result_f->get );
          }
          else {


### PR DESCRIPTION
If a Fixture is being torn down before it has run (for example because all other
fixtures in the same `requires` list have failed), it was possible for us to
try to get the result from an incomplete Future. This looks like a typo, so fix
it to wait for the right future.