### PR TITLE
Provide a mechanism to let fixtures skip tests

### DIFF
--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -205,7 +205,7 @@ require that fixture will be marked as failures. However, if the future fails
 with a reason beginning with the special string ``SKIP``, then any tests which
 require it are instead skipped. This can be used to differentiate between tests
 which we were unable to run due to constraints when setting up the test
-environment, as opposeed to those where setup steps that should have succeeded
+environment, as opposed to those where setup steps that should have succeeded
 did not.
 
 The intented use for fixtures is that test files will provide wrapper functions

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -200,6 +200,14 @@ main kinds of fixtures:
   over the lifetime of the test. These are fixtures that have a ``teardown``
   block.
 
+In general, if the future returned by ``setup`` fails, then any tests which
+require that fixture will be marked as failures. However, if the future fails
+with a reason beginning with the special string ``SKIP``, then any tests which
+require it are instead skipped. This can be used to differentiate between tests
+which we were unable to run due to constraints when setting up the test
+environment, as opposeed to those where setup steps that should have succeeded
+did not.
+
 The intented use for fixtures is that test files will provide wrapper functions
 that create a new fixture object to encapsulate some common setup pattern that
 later tests may require. Later tests can then simply invoke that function as

--- a/lib/SyTest/Output/Term.pm
+++ b/lib/SyTest/Output/Term.pm
@@ -213,20 +213,20 @@ package SyTest::Output::Term::Test {
       my $self = shift;
       my ( $reason ) = @_;
 
-      _printline "  ${YELLOW_B}SKIP${RESET} ${\$self->name} due to $reason\n";
-
-      $self->skipped++;
+      $self->skipped .= $reason;
    }
 
    sub leave
    {
       my $self = shift;
 
-      return if $self->skipped;
-
       _morepartial "   ${CYAN}+--- " if $self->multi;
 
-      if( !$self->failed ) {
+      if( $self->skipped ) {
+         my $reason = $self->skipped;
+         _finishpartial "${YELLOW_B}SKIP${RESET} due to $reason";
+      }
+      elsif( !$self->failed ) {
          _finishpartial "${GREEN}PASS${RESET}";
 
          if( $self->expect_fail ) {

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -522,7 +522,6 @@ sub _run_test
       }
    }
 
-   $t->start;
    $f_start->done;
 
    my ( $success, $reason ) = _run_test0( $t, $test, \@req_futures );
@@ -712,6 +711,8 @@ foreach my $test ( @TESTS ) {
 
    my $t = $OUTPUT->$m( $test->name, $test->expect_fail );
    local $RUNNING_TEST = $t;
+
+   $t->start;
 
    _run_test( $t, $test );
 

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -550,7 +550,7 @@ sub _run_test
 # Helper for _run_test. Waits for the req_futures to become ready, then runs
 # the test itself and waits for the test to complete.
 #
-# returns a pair [$res, $reason] where $res is one of:
+# returns a pair ($res, $reason) where $res is one of:
 #  1 - success
 #  0 - skipped
 #  undef - failure
@@ -570,8 +570,8 @@ sub _run_test0
             # if any of the fixtures failed with a special 'SKIP' result, then skip
             # the test rather than failing it.
             if ( $reason =~ /^SKIP(: *(.*))?$/ ) {
-               my $r = ": $2" // '';
-               $skip_reason = "failing fixture$r";
+               $skip_reason = "failing fixture";
+               $skip_reason .= ": $2" if defined $2;
             }
             die "fixture failed - $_[0]\n"
          } );


### PR DESCRIPTION
In some situations, it turns out to make more sense to skip tests when certain fixtures fail than to fail them. Make it so that if a fixture fails with "SKIP: ...", then we skip any tests which require it rather than failing them.

(This PR includes 3 commits which it may be useful to review individually.)