### PR TITLE
Add --server-implementation option

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -20,24 +20,6 @@ use POSIX qw( strftime WIFEXITED WEXITSTATUS );
 
 use YAML ();
 
-sub new
-{
-   my $class = shift;
-   my %args = @_;
-
-   if( delete $args{haproxy} ) {
-      $class = "SyTest::Homeserver::Synapse::ViaHaproxy";
-   }
-   elsif( $args{dendron} ) {
-      $class = "SyTest::Homeserver::Synapse::ViaDendron";
-   }
-   else {
-      $class = "SyTest::Homeserver::Synapse::Direct";
-   }
-
-   return $class->SUPER::new( %args );
-}
-
 sub _init
 {
    my $self = shift;

--- a/lib/SyTest/HomeserverFactory.pm
+++ b/lib/SyTest/HomeserverFactory.pm
@@ -1,0 +1,39 @@
+# Copyright 2017 New Vector Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package SyTest::HomeserverFactory;
+
+# get the name of this implementation, by which it can be referenced with -I
+sub name
+{
+   my $cls = "" . shift;
+   $cls =~ s/^SyTest::HomeserverFactory:://;
+   return $cls;
+}
+
+sub new
+{
+   my $class = shift;
+   my %params = @_;
+
+   my $self = bless {}, $class;
+
+   $self->_init( \%params );
+
+   return $self;
+}
+
+sub _init {}
+
+1;

--- a/lib/SyTest/HomeserverFactory.pm
+++ b/lib/SyTest/HomeserverFactory.pm
@@ -14,10 +14,12 @@
 
 package SyTest::HomeserverFactory;
 
-# get the name of this implementation, by which it can be referenced with -I
+# get the name of this implementation, by which it can be referenced with -I.
+#
+# Intented to be called as a class method: $FACTORY_CLASS->name
 sub name
 {
-   my $cls = "" . shift;
+   my $cls = shift;
    $cls =~ s/^SyTest::HomeserverFactory:://;
    return $cls;
 }

--- a/lib/SyTest/HomeserverFactory/Synapse.pm
+++ b/lib/SyTest/HomeserverFactory/Synapse.pm
@@ -1,0 +1,58 @@
+# Copyright 2017 New Vector Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+use strict;
+use warnings;
+
+require SyTest::Homeserver::Synapse;
+
+package SyTest::HomeserverFactory::Synapse;
+use base qw( SyTest::HomeserverFactory );
+
+sub _init
+{
+   my $self = shift;
+   $self->{impl} = "SyTest::Homeserver::Synapse::Direct";
+   $self->SUPER::_init( @_ );
+}
+
+sub create_server
+{
+   my $self = shift;
+   return $self->{impl}->new( @_ );
+}
+
+
+package SyTest::HomeserverFactory::Synapse::ViaDendron;
+use base qw( SyTest::HomeserverFactory::Synapse );
+
+sub _init
+{
+   my $self = shift;
+   $self->{impl} = "SyTest::Homeserver::Synapse::ViaDendron";
+   $self->SUPER::_init( @_ );
+}
+
+
+package SyTest::HomeserverFactory::Synapse::ViaHaproxy;
+use base qw( SyTest::HomeserverFactory::Synapse::ViaDendron );
+
+sub _init
+{
+   my $self = shift;
+   $self->{impl} = "SyTest::Homeserver::Synapse::ViaHaproxy";
+   $self->SUPER::_init( @_ );
+}
+
+1;

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -38,9 +38,14 @@ use Module::Pluggable
    search_path => [ "SyTest::Output" ],
    require     => 1;
 
+use Module::Pluggable
+   sub_name    => "homeserver_factories",
+   search_path => [ "SyTest::HomeserverFactory" ],
+   require     => 1;
+
 # A number of commandline arguments exist simply for passing values through to
-# the way that synapse is started by tests/05synapse.pl. We'll collect them
-# all in one place for neatness
+# the way that the server is started by tests/05homeserver.pl. We'll collect
+# them all in one place for neatness
 our %SYNAPSE_ARGS = (
    directory  => "../synapse",
    python     => "python",
@@ -59,8 +64,10 @@ our $BIND_HOST = "localhost";
 my %FIXED_BUGS;
 
 my $STOP_ON_FAIL;
+my $SERVER_IMPL = undef;
 
 GetOptions(
+   'I|server-implementation=s' => \$SERVER_IMPL,
    'C|client-log+' => \my $CLIENT_LOG,
    'S|server-log+' => \$SYNAPSE_ARGS{log},
    'server-grep=s' => \$SYNAPSE_ARGS{log_filter},
@@ -81,8 +88,14 @@ GetOptions(
 
    'coverage+' => \$SYNAPSE_ARGS{coverage},
 
-   'dendron=s' => \$SYNAPSE_ARGS{dendron},
-   'haproxy'   => \$SYNAPSE_ARGS{haproxy},
+   # these two are superceded by -I, but kept for backwards compat
+   'dendron=s' => sub {
+      $SERVER_IMPL = 'Synapse::ViaDendron' unless $SERVER_IMPL;
+      $SYNAPSE_ARGS{dendron} = $_[1];
+   },
+   'haproxy'   => sub {
+      $SERVER_IMPL = 'Synapse::ViaHaproxy' unless $SERVER_IMPL;
+   },
 
 
    # These are now unused, but retaining arguments for commandline parsing support
@@ -128,10 +141,22 @@ sub usage
 {
    my ( $exitcode ) = @_;
 
-   print STDERR <<'EOF';
+   my @output_formats =
+      map { $_->FORMAT }
+      grep { $_->can( "FORMAT" ) } output_formats();
+
+   my @homeserver_implementations =
+      map { $_->name() } homeserver_factories();
+
+   format STDERR =
 run-tests.pl: [options...] [test-file]
 
 Options:
+   -I, --server-implementation  - specify the type of homeserver to start.
+                                  Supported implementations:
+                                   ~~ @<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+                                      shift( @homeserver_implementations ) || ''
+
    -C, --client-log             - enable logging of requests made by the
                                   internal HTTP client. Also logs the internal
                                   HTTP server.
@@ -148,7 +173,10 @@ Options:
    -a, --all                    - don't stop after the first failed test;
                                   attempt as many as possible
 
-   -O, --output-format FORMAT   - set the style of test output report
+   -O, --output-format FORMAT   - set the style of test output report.
+                                  Supported formats:
+                                   ~~ @<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+                                      shift( @output_formats ) || ''
 
    -w, --wait-at-end            - pause for input before shutting down testing
                                   synapse servers
@@ -170,13 +198,19 @@ Options:
 
    -ENAME,  -ENAME=VALUE        - pass extra argument NAME or NAME=VALUE
 
-EOF
+.
 
+   write STDERR;
    exit $exitcode;
 }
 
 my $OUTPUT = first { $_->can( "FORMAT") and $_->FORMAT eq $OUTPUT_FORMAT } output_formats()
    or die "Unrecognised output format $OUTPUT_FORMAT\n";
+
+$SERVER_IMPL = 'Synapse' unless $SERVER_IMPL;
+my $hs_factory_class = first { $_->name() eq $SERVER_IMPL } homeserver_factories()
+   or die "Unrecognised server implementation $SERVER_IMPL\n";
+our $HS_FACTORY = $hs_factory_class -> new();
 
 # Turn warnings into $OUTPUT->diag calls
 $SIG{__WARN__} = sub {


### PR DESCRIPTION
Begin the process of making the HS impl more pluggable. Add a
--server-implementation option, which is then used to find a factory which
will instantiate the homeserver class.