### PR TITLE
Add diagnostics to `await_connectable`

### DIFF
--- a/lib/SyTest/Homeserver.pm
+++ b/lib/SyTest/Homeserver.pm
@@ -138,7 +138,7 @@ sub await_connectable
       })
    } while => sub { !$_[0]->failure and !$_[0]->get };
 
-   $fut -> on_done( sub {
+   $fut->on_done( sub {
       $output->diag( "Connected to server $port" );
    });
 

--- a/lib/SyTest/Homeserver.pm
+++ b/lib/SyTest/Homeserver.pm
@@ -115,7 +115,11 @@ sub await_connectable
    my $attempts = 25;
    my $delay    = 0.05;
 
-   repeat {
+   my $output = $self->{output};
+
+   $output->diag( "Connecting to server $port" );
+
+   my $fut = repeat {
       $loop->connect(
          host     => $host,
          service  => $port,
@@ -132,7 +136,13 @@ sub await_connectable
          $loop->delay_future( after => $delay )
               ->then_done(0);
       })
-   } while => sub { !$_[0]->failure and !$_[0]->get }
+   } while => sub { !$_[0]->failure and !$_[0]->get };
+
+   $fut -> on_done( sub {
+      $output->diag( "Connected to server $port" );
+   });
+
+   return $fut;
 }
 
 1;

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -281,12 +281,8 @@ sub start
             )
          );
 
-         $output->diag( "Connecting to server $port" );
-
          $self->adopt_future(
             $self->await_connectable( $bind_host, $self->_start_await_port )->then( sub {
-               $output->diag( "Connected to server $port" );
-
                $started_future->done;
             })
          );


### PR DESCRIPTION
- they are generally useful, so don't need to be limited to Synapse