### PR TITLE
Dendrite: Use key=value for pg config rather than uri

### DIFF
--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -81,21 +81,25 @@ sub _get_config
 
    my %db_config = $self->_get_dbconfig(
       type => 'pg',
-      args => {
-         host => "localhost",
-      },
+      args => {},
    );
 
-   my $db_uri = sprintf(
-      'postgres://%s:%s@%s/%s',
-      $db_config{args}->{user},
-      $db_config{args}->{password},
-      $db_config{args}->{host},
-      $db_config{args}->{database},
-   );
+   my $db_uri = sprintf('dbname=%s', $db_config{args}->{database});
+
+   if( exists $db_config{args}->{user} ) {
+      $db_uri .= sprintf( " user=%s", $db_config{args}->{user} );
+   }
+
+   if( exists $db_config{args}->{password} ) {
+      $db_uri .= sprintf( " password=%s", $db_config{args}->{password} );
+   }
+
+   if( exists $db_config{args}->{host} ) {
+      $db_uri .= sprintf( " host=%s", $db_config{args}->{host} );
+   }
 
    if( exists $db_config{args}->{sslmode} ) {
-      $db_uri .= sprintf( "?sslmode=%s", $db_config{args}->{sslmode} );
+      $db_uri .= sprintf( " sslmode=%s", $db_config{args}->{sslmode} );
    }
 
    return (


### PR DESCRIPTION
This makes it easier to not specify various params