### PR TITLE
Improve behaviour when we can't start homeserver

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -255,6 +255,8 @@ sub start
 
    my $started_future = $loop->new_future;
 
+   $output->diag( "Starting server with command " . join( " ", @config_command ));
+
    $loop->run_child(
       setup => [ env => $env ],
 
@@ -264,8 +266,8 @@ sub start
          my ( $pid, $exitcode, $stdout, $stderr ) = @_;
 
          if( $exitcode != 0 ) {
-            print STDERR $stderr;
-            exit $exitcode;
+            $started_future->fail( "Server failed to start: exitcode " . ( $exitcode >> 8 ));
+            return
          }
 
          $output->diag( "Starting server for port $port" );


### PR DESCRIPTION
Rather than calling exit() without explanation, propagate an error through the
futures.

When a homeserver fails to start (either because we can't run the
command, or because we time out waiting for it to start), log the error
clearly.

*Then*, if it's the first HS, abort the test run.