### PR TITLE
Add diagnostics to test runner

### DIFF
--- a/run-tests.pl
+++ b/run-tests.pl
@@ -467,7 +467,8 @@ sub fixture
 
             warn( "$name: input fixture failed with $reason" )
                if ( $VERBOSE >= 3 );
-         })->then( $setup )->on_done( sub {
+         })->then( $setup )
+         ->on_done( sub {
             $OUTPUT->diag( "Fixture $name now ready" ) if ( $VERBOSE >= 2 );
          })->set_label( $name ),
 


### PR DESCRIPTION
If we're called with -vv, print some diagnostics about running tests and
fixtures, to help with tracking down mysterious fails.