### PR TITLE
Only run fixture teardown if fixture was successful

### DIFF
--- a/run-tests.pl
+++ b/run-tests.pl
@@ -467,7 +467,7 @@ sub fixture
             "This Fixture has been torn down and cannot be used again"
          );
 
-         if( $result_f->is_ready ) {
+         if( $result_f->is_done ) {
             return $teardown->( $result_f->get );
          }
          else {


### PR DESCRIPTION
If a Fixture failed, then don't try to tear it down, otherwise we'll get an
untimely death in the test run.