### PR TITLE
Fix the fact that printing PDUs changes them

### DIFF
--- a/lib/SyTest/Federation/Datastore.pm
+++ b/lib/SyTest/Federation/Datastore.pm
@@ -191,7 +191,7 @@ sub create_event
 
       event_id         => $self->next_event_id,
       origin           => $self->server_name,
-      origin_server_ts => int( time() * 1000 ),
+      origin_server_ts => JSON::number( int( time() * 1000 )),
    };
 
    $self->sign_event( $event );

--- a/lib/SyTest/Federation/Room.pm
+++ b/lib/SyTest/Federation/Room.pm
@@ -162,7 +162,7 @@ sub create_event
    );
    $fields{auth_events} //= make_event_refs( @auth_events ),
 
-   $fields{depth} //= $self->next_depth;
+   $fields{depth} //= JSON::number($self->next_depth);
 
    $fields{prev_events} //= make_event_refs( @{ $self->{prev_events} } );
 
@@ -269,7 +269,7 @@ sub make_join_protoevent
 
       auth_events      => make_event_refs( @auth_events ),
       content          => { membership => "join" },
-      depth            => $self->next_depth,
+      depth            => JSON::number($self->next_depth),
       prev_events      => make_event_refs( @{ $self->{prev_events} } ),
       room_id          => $self->room_id,
       sender           => $user_id,

--- a/lib/SyTest/Federation/Server.pm
+++ b/lib/SyTest/Federation/Server.pm
@@ -255,7 +255,7 @@ sub on_request_federation_v1_event
 
    Future->done( json => {
       origin           => $self->server_name,
-      origin_server_ts => $self->time_ms,
+      origin_server_ts => JSON::number( $self->time_ms ),
       pdus             => [
          $event,
       ]

--- a/lib/SyTest/HTTPServer/Request.pm
+++ b/lib/SyTest/HTTPServer/Request.pm
@@ -3,7 +3,8 @@ use 5.014; # ${^GLOBAL_PHASE}
 use base qw( Net::Async::HTTP::Server::Request );
 
 use HTTP::Response;
-use JSON qw( decode_json encode_json );
+use JSON;
+my $json = JSON->new->convert_blessed;
 
 use constant JSON_MIME_TYPE => "application/json";
 
@@ -32,16 +33,16 @@ sub body_from_json
       croak "Cannot ->body_from_json with Content-Type: $type";
    }
 
-   return decode_json $self->body;
+   return $json->decode( $self->body );
 }
 
 sub respond_json
 {
    my $self = shift;
-   my ( $json, %opts ) = @_;
+   my ( $body, %opts ) = @_;
 
    my $response = HTTP::Response->new( $opts{code} // 200 );
-   $response->add_content( encode_json $json );
+   $response->add_content( $json->encode( $body ));
    $response->content_type( JSON_MIME_TYPE );
    $response->content_length( length $response->content );
 


### PR DESCRIPTION
This is a workaround for a tragic, tragic tale which comes down to the fact that Perl lacks a proper way to distinguish between a string and a number.

Following the Perl philosophy of "I'm going to guess what you meant and usually get it wrong", the JSON encoder therefore has to guess whether you're trying to send '"0"' or '0', which it does by digging in the guts of the interpreter to see whether the scalar in question was last referred to as a string or a number.

However, the pretty-printer used by `log_if_fail`, `Data::Dump`, wants to print numbers, which of course means processing them as strings, so the "I think I'm a string" bit gets set on the relevant scalar. Which means, hilariously, that if you try to `log_if_fail` an event, everything breaks.

So... the workaround for this is to wrap things that we want to stay as numbers with our `JSON::number` class; we then need to tell the JSON encoder to use blessed objects' `TO_JSON` method rather than barfing (hence, `convert_blessed`).

Because why would you ever want to tell numbers and strings apart.