### PR TITLE
Use URI->path_segments instead of ->path

### DIFF
--- a/lib/SyTest/Federation/Server.pm
+++ b/lib/SyTest/Federation/Server.pm
@@ -70,19 +70,25 @@ sub on_request
    my $self = shift;
    my ( $req ) = @_;
 
-   my $path = $req->path;
-   unless( $path =~ s{^/_matrix/}{} ) {
+   my $uri = $req->as_http_request->uri;
+   my @pc = $uri->path_segments;
+
+   # Remove the initial empty component as it ought to be an absolute request
+   shift @pc if $pc[0] eq "";
+
+   unless( $pc[0] eq "_matrix" ) {
       $req->respond( HTTP::Response->new( 404, "Not Found", [ Content_Length => 0 ] ) );
       return;
    }
+   shift @pc;
 
    $self->adopt_future(
       ( # 'key' requests don't need to be signed
-         $path =~ m{^key/}
+         $pc[0] eq "key"
             ? Future->done
             : $self->_check_authorization( $req )
       )->then( sub {
-         $self->_dispatch( $path, $req )
+         $self->_dispatch( $req, @pc )
       })->else_with_f( sub {
          my ( $f, undef, $name ) = @_;
          return $f unless $name and $name eq "matrix_auth";
@@ -179,9 +185,8 @@ sub _check_authorization
 sub _dispatch
 {
    my $self = shift;
-   my ( $path, $req ) = @_;
+   my ( $req, @pc ) = @_;
 
-   my @pc = split m{/}, $path;
    my @trial;
    while( @pc ) {
       push @trial, shift @pc;


### PR DESCRIPTION
The

    $uri->path

method returns the raw string from the incoming HTTP request, complete with `%xx` encoding if present.

We should use the convenience utility

    $uri->path_components

Which splits the path on literal `/` bytes, and then `%xx`-decodes each of the components individually.