### PR TITLE
Include all the events we should in auth_events

### DIFF
--- a/lib/SyTest/Federation/Room.pm
+++ b/lib/SyTest/Federation/Room.pm
@@ -158,6 +158,8 @@ sub create_event
 
    my @auth_events = grep { defined } (
       $self->get_current_state_event( "m.room.create" ),
+      $self->get_current_state_event( "m.room.join_rules" ),
+      $self->get_current_state_event( "m.room.power_levels" ),
       $self->get_current_state_event( "m.room.member", $fields{sender} ),
    );
    $fields{auth_events} //= make_event_refs( @auth_events ),


### PR DESCRIPTION
When we make an outbound federation request, we should include the power_levels
and the join_rules in the auth_events.