### PR TITLE
Update registration username tests

### DIFF
--- a/lib/SyTest/HTTPClient.pm
+++ b/lib/SyTest/HTTPClient.pm
@@ -12,7 +12,7 @@ use base qw( Net::Async::HTTP );
 Net::Async::HTTP->VERSION( '0.36' ); # PUT content bugfix
 
 use JSON;
-my $json = JSON->new->convert_blessed;
+my $json = JSON->new->convert_blessed(1)->utf8(1);
 
 use Future 0.33; # ->catch
 use List::Util qw( any );

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -44,6 +44,9 @@ use Module::Pluggable
    search_path => [ "SyTest::HomeserverFactory" ],
    require     => 1;
 
+
+binmode(STDOUT, ":utf8");
+
 our $WANT_TLS = 1;  # This is shared with the test scripts
 
 our $BIND_HOST = "localhost";

--- a/tests/10apidoc/01register.pl
+++ b/tests/10apidoc/01register.pl
@@ -428,7 +428,7 @@ sub local_admin_fixture
       setup => sub {
          my ( $http, $localpart ) = @_;
 
-         matrix_register_user_via_secret( $http, $localpart, is_admin => 1, %args );
+         matrix_v1_register_user_via_secret( $http, $localpart, is_admin => 1, %args );
       },
    );
 }


### PR DESCRIPTION
/register now allows uppercase usernames, and downcases them.

It should still reject special characters though.