### PR TITLE
Sign join event when sending over federation

### DIFF
--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -183,6 +183,8 @@ test "Inbound federation can receive room-join requests",
             origin_server_ts => $inbound_server->time_ms,
          );
 
+         $datastore->sign_event( \%event );
+
          $outbound_client->do_request_json(
             method   => "PUT",
             hostname => $first_home_server,


### PR DESCRIPTION
We also remove some of the `prev_state` checks, as that field isn't used anymore.