### PR TITLE
Drop sequences from postgres database

### DIFF
--- a/lib/SyTest/Homeserver.pm
+++ b/lib/SyTest/Homeserver.pm
@@ -341,6 +341,15 @@ sub _clear_db_pg
          $dbh->do( "DROP TABLE $tablename CASCADE" ) or
             die $dbh->errstr;
       }
+
+      foreach my $row ( @{ $dbh->selectall_arrayref(
+         "SELECT c.relname FROM pg_class c LEFT JOIN pg_namespace n ON n.oid = c.relnamespace WHERE relkind='S' AND n.nspname='public'"
+      ) } ) {
+         my ( $seqname ) = @$row;
+
+         $dbh->do( "DROP SEQUENCE $seqname" ) or
+            die $dbh->errstr;
+      }
    }
 }
 


### PR DESCRIPTION
When we clear out a postgres database, we should make sure to drop any defined
sequences.

(This is needed to make the tests pass against
https://github.com/matrix-org/synapse/commit/df8246d, which introduces a
standalone SEQUENCE object).