### PR TITLE
Check that `/rooms/{roomId}/join` responds with the room id

### DIFF
--- a/tests/10apidoc/33room-members.pl
+++ b/tests/10apidoc/33room-members.pl
@@ -31,7 +31,14 @@ test "POST /rooms/:room_id/join can join a room",
          uri    => "/r0/rooms/$room_id/join",
 
          content => {},
-      );
+      )->then( sub {
+         my ( $body ) = @_;
+
+         $body->{room_id} eq $room_id or
+            die "Expected 'room_id' to be $room_id";
+
+         Future->done(1);
+      });
    },
 
    check => sub {


### PR DESCRIPTION
Spec about this endpoint: https://matrix.org/docs/spec/client_server/r0.3.0.html#post-matrix-client-r0-rooms-roomid-join
This field isn't currently returned by synapse, PR to fix that: https://github.com/matrix-org/synapse/pull/2986

Signed-off-by: Jonas Platte