### PR TITLE
Force installation of Alien::Base::ModuleBuild

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,8 @@
 # vim:ft=perl
 
+# Sodium won't install without this.
+requires 'Alien::Base::ModuleBuild';
+
 requires 'Class::Method::Modifiers';
 requires 'Data::Dump';
 requires 'DBD::Pg';
@@ -26,9 +29,6 @@ requires 'Protocol::Matrix', '>= 0.02';
 requires 'Struct::Dumb', '>= 0.04';
 requires 'URI::Escape';
 requires 'YAML';
-
-# Sodium won't install without this.
-requires 'Alien::Base::ModuleBuild';
 
 # this is a right pain to install; use libcrypt-nacl-sodium-perl from matrix.org package repo if at all possible
 requires 'Crypt::NaCl::Sodium';

--- a/cpanfile
+++ b/cpanfile
@@ -27,5 +27,8 @@ requires 'Struct::Dumb', '>= 0.04';
 requires 'URI::Escape';
 requires 'YAML';
 
+# Sodium won't install without this.
+requires 'Alien::Base::ModuleBuild';
+
 # this is a right pain to install; use libcrypt-nacl-sodium-perl from matrix.org package repo if at all possible
 requires 'Crypt::NaCl::Sodium';


### PR DESCRIPTION
Apparently 'Alien::Sodium' (which is a dependency of 'Crypt::NaCl::Sodium') won't install unless Alien::Base::ModuleBuild is already installed.

I don't know how this ever worked :/