### PR TITLE
Show count of succeeded tests in test output

### DIFF
--- a/lib/SyTest/Output/TAP.pm
+++ b/lib/SyTest/Output/TAP.pm
@@ -79,10 +79,11 @@ package SyTest::Output::TAP::Test {
    sub num             { shift->{num}         }
    sub expect_fail     { shift->{expect_fail} }
    sub multi           { shift->{multi}       }
+   sub passed  :lvalue { shift->{passed}      }
    sub skipped :lvalue { shift->{skipped}     }
-   sub failed :lvalue  { shift->{failed}      }
+   sub failed  :lvalue { shift->{failed}      }
    sub failure :lvalue { shift->{failure}     }
-   sub subnum :lvalue  { shift->{subnum}      }
+   sub subnum  :lvalue { shift->{subnum}      }
 
    sub start {
       my $self = shift;

--- a/lib/SyTest/Output/Term.pm
+++ b/lib/SyTest/Output/Term.pm
@@ -108,10 +108,13 @@ sub enter_multi_test
 sub final_pass
 {
    shift;
-   my ( $expected_fail, $skipped_count ) = @_;
+   my ( $expected_fail, $passed_count, $skipped_count ) = @_;
    print "\n${GREEN_B}All tests PASSED${RESET}";
    if( $expected_fail ) {
       print " (with $expected_fail expected failures)";
+   }
+   if( $passed_count ) {
+      print " (with $passed_count passes)";
    }
    if( $skipped_count ) {
       print " (with ${YELLOW_B}$skipped_count skipped${RESET} tests)";
@@ -152,6 +155,8 @@ sub status
       sprintf( "Tests: %d / %d", $args{done}, $args{tests} ),
       ( $args{failed} ? sprintf( "${RED_B}%d FAIL${RESET_FG}", $args{failed} )
                       : "OK" ),
+      ( $args{passed} ? sprintf( "${GREEN_B}%d PASSED${RESET_FG}", $args{passed} )
+                       : () ),
       ( $args{skipped} ? sprintf( "${YELLOW_B}%d SKIPPED${RESET_FG}", $args{skipped} )
                        : () );
 
@@ -171,6 +176,7 @@ package SyTest::Output::Term::Test {
    sub name            { shift->{name}        }
    sub expect_fail     { shift->{expect_fail} }
    sub multi           { shift->{multi}       }
+   sub passed :lvalue  { shift->{passed}      }
    sub skipped :lvalue { shift->{skipped}     }
    sub failed :lvalue  { shift->{failed}      }
    sub failure :lvalue { shift->{failure}     }
@@ -185,7 +191,10 @@ package SyTest::Output::Term::Test {
          _morepartial $message;
    }
 
-   sub pass { }
+   sub pass {
+      my $self = shift;
+      $self->passed++;
+   }
 
    sub fail
    {

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -774,11 +774,13 @@ TEST: {
 my $done_count = 0;
 my $failed_count = 0;
 my $expected_fail_count = 0;
+my $passed_count = 0;
 my $skipped_count = 0;
 
 $OUTPUT->status(
    tests   => scalar @TESTS,
    done    => $done_count,
+   passed  => $passed_count,
    failed  => $failed_count,
    skipped => $skipped_count,
 );
@@ -803,6 +805,10 @@ foreach my $test ( @TESTS ) {
 
    $done_count++;
 
+   if( $t->passed ) {
+      $passed_count++;
+   }
+
    if( $t->skipped ) {
       $skipped_count++;
    }
@@ -823,6 +829,7 @@ foreach my $test ( @TESTS ) {
    $OUTPUT->status(
       tests   => scalar @TESTS,
       done    => $done_count,
+      passed  => $passed_count,
       failed  => $failed_count,
       skipped => $skipped_count,
    );
@@ -869,7 +876,7 @@ if( $failed_count ) {
    exit 1;
 }
 else {
-   $OUTPUT->final_pass( $expected_fail_count, $skipped_count );
+   $OUTPUT->final_pass( $expected_fail_count, $passed_count, $skipped_count );
    exit 0;
 }
 


### PR DESCRIPTION
Makes it easier to see new test pass amount while continuously making changes.

Closes #437.