### PR TITLE
Move critical test flag to homeserver configuration file

### DIFF
--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -50,15 +50,25 @@ is described in more detail in the following sections.
     Provides an ``ARRAY`` reference giving a list of named requirements and
     fixture objects.
 
-``critical``
-    If true and the test fails, the entire test run will bail out at this
-    point; no further tests will be attempted at all.
+A test can be considered "critical", meaning that if the test fails, the
+entire test run will bail out, and no further tests will be attempted.
+Whether a test is critical is homeserver specific, and is therefore set in
+the respective homeserver configuration file.
 
 A call to ``test`` is a simplified version of ``multi_test`` which produces
 only a single line of test output indicating success or failure automatically.
 A call to ``multi_test`` can make use of additional functions within the body
 in order to report success or failure of multiple steps within it. Aside from
 this difference, the two behave identically.
+
+Different Homeserver Implementations
+------------------------------------
+
+Sytest supports running its suite of tests over multiple different homeserver
+implementations. The currently supported homeservers are Synapse and
+Dendrite, though SyTest's modular design allows for testing any
+implementation through homeserver configuration files stored in
+``lib/SyTest/Homeserver`` and ``lib/SyTest/HomeserverFactory``.
 
 Code Blocks
 -----------

--- a/lib/SyTest/HomeserverFactory/Dendrite.pm
+++ b/lib/SyTest/HomeserverFactory/Dendrite.pm
@@ -73,4 +73,11 @@ sub create_server
    return $self->{impl}->new( %params );
 }
 
+sub get_critical_tests
+{
+   return (
+
+   );
+}
+
 1;

--- a/lib/SyTest/HomeserverFactory/Synapse.pm
+++ b/lib/SyTest/HomeserverFactory/Synapse.pm
@@ -102,6 +102,15 @@ sub create_server
    return $self->{impl}->new( %params );
 }
 
+sub get_critical_tests
+{
+   return (
+       'POST [^ ]+ register can create a user',
+       'POST /createRoom makes a public room',
+       'POST /rooms/:room_id/join can join a room',
+       'POST /rooms/:room_id/leave can leave a room'
+   );
+}
 
 package SyTest::HomeserverFactory::Synapse::ViaDendron;
 use base qw( SyTest::HomeserverFactory::Synapse );

--- a/lib/SyTest/HomeserverFactory/Synapse.pm
+++ b/lib/SyTest/HomeserverFactory/Synapse.pm
@@ -105,10 +105,10 @@ sub create_server
 sub get_critical_tests
 {
    return (
-       'POST [^ ]+ register can create a user',
+       'POST \S+ register can create a user',
        'POST /createRoom makes a public room',
        'POST /rooms/:room_id/join can join a room',
-       'POST /rooms/:room_id/leave can leave a room'
+       'POST /rooms/:room_id/leave can leave a room',
    );
 }
 

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -528,7 +528,7 @@ sub require_stub
 }
 
 struct Test => [qw(
-   file name multi expect_fail critical proves requires check do timeout
+   file name multi expect_fail proves requires check do timeout
 )];
 
 my @TESTS;
@@ -547,7 +547,7 @@ sub _push_test
    }
 
    push @TESTS, Test( $filename, $name, $multi,
-      @params{qw( expect_fail critical proves requires check do timeout )} );
+      @params{qw( expect_fail proves requires check do timeout )} );
 }
 
 sub _run_test
@@ -820,7 +820,8 @@ foreach my $test ( @TESTS ) {
 
       last if $STOP_ON_FAIL and not $test->expect_fail;
 
-      if( $test->critical ) {
+      # Check if this was a critical test
+      if( grep { $test->name =~ m/$_/ } $HS_FACTORY->get_critical_tests() ) {
          warn "This CRITICAL test has failed - bailing out\n";
          last;
       }

--- a/tests/10apidoc/01register.pl
+++ b/tests/10apidoc/01register.pl
@@ -55,8 +55,6 @@ test "POST /register can create a user",
    requires => [ $main::API_CLIENTS[0],
                  qw( can_register_dummy_flow ) ],
 
-   critical => 1,
-
    do => sub {
       my ( $http ) = @_;
 

--- a/tests/10apidoc/30room-create.pl
+++ b/tests/10apidoc/30room-create.pl
@@ -4,8 +4,6 @@ my $user_fixture = local_user_fixture();
 test "POST /createRoom makes a public room",
    requires => [ $user_fixture ],
 
-   critical => 1,
-
    do => sub {
       my ( $user ) = @_;
 

--- a/tests/10apidoc/33room-members.pl
+++ b/tests/10apidoc/33room-members.pl
@@ -21,8 +21,6 @@ test "POST /rooms/:room_id/join can join a room",
    requires => [ local_user_fixture(), $room_fixture,
                  qw( can_get_room_membership )],
 
-   critical => 1,
-
    do => sub {
       my ( $user, $room_id, undef ) = @_;
 
@@ -232,8 +230,6 @@ test "POST /join/:room_alias can join a room with custom content",
 test "POST /rooms/:room_id/leave can leave a room",
    requires => [ local_user_fixture(), $room_fixture,
                  qw( can_get_room_membership )],
-
-   critical => 1,
 
    do => sub {
       my ( $joiner_to_leave, $room_id, undef ) = @_;


### PR DESCRIPTION
The critical flag for a test is no longer set in the test itself, but in `lib/HomeserverFactory/<name>.pl`. This allows us to run the full testsuite against homeservers which are still ongoing in development, and makes viewing which tests are critical for each homeserver fairly convenient.

To manage this, an `id` was assigned to each test which could be referenced when specifying which tests were critical. The ids were generated by taking the test name, lowercasing, changing spaces to underscores, and removing the `$` from variable names. Test ids should be updated if the test name ever changes, and vice versa.

Also changed some documentation and added some preliminary information about homeserver-specific configuration file. Some further documentation on what is needed to add sytest compatibility for a completely new homeserver should also be added at some point.