### PR TITLE
Add tests for creating rooms with names, topics, and avatars

### DIFF
--- a/tests/10apidoc/30room-create.pl
+++ b/tests/10apidoc/30room-create.pl
@@ -69,7 +69,6 @@ test "POST /createRoom makes a private room with invites",
 
          content => {
             visibility => "private",
-            # TODO: This doesn't actually appear in the API docs yet
             invite     => [ $invitee->user_id ],
          },
       )->then( sub {
@@ -77,6 +76,129 @@ test "POST /createRoom makes a private room with invites",
 
          assert_json_keys( $body, qw( room_id ));
          assert_json_nonempty_string( $body->{room_id} );
+
+         Future->done(1);
+      });
+   };
+
+test "POST /createRoom makes a room with a name",
+   requires => [ $user_fixture, local_user_fixture(),
+                 qw( can_create_private_room )],
+
+   proves => [qw( can_createroom_with_name )],
+
+   do => sub {
+      my ( $user ) = @_;
+
+      do_request_json_for( $user,
+         method => "POST",
+         uri    => "/r0/createRoom",
+
+         content => {
+            name => "Test Room"
+         },
+      )->then( sub {
+         my ( $body ) = @_;
+
+         assert_json_keys( $body, qw( room_id ));
+         assert_json_nonempty_string( $body->{room_id} );
+
+         my ( $room_id ) = $body->{room_id};
+
+         do_request_json_for( $user,
+            method => "GET",
+            uri    => "/r0/rooms/$room_id/state/m.room.name",
+         )
+      })->then( sub {
+         my ( $state ) = @_;
+
+         log_if_fail "state", $state;
+
+         assert_json_keys( $state, qw( name ));
+         assert_json_nonempty_string( $state->{name} );
+         assert_eq( $state->{name}, "Test Room", "room name" );
+
+         Future->done(1);
+      });
+   };
+
+test "POST /createRoom makes a room with a topic",
+   requires => [ $user_fixture, local_user_fixture(),
+                 qw( can_create_private_room )],
+
+   proves => [qw( can_createroom_with_topic )],
+
+   do => sub {
+      my ( $user ) = @_;
+
+      do_request_json_for( $user,
+         method => "POST",
+         uri    => "/r0/createRoom",
+
+         content => {
+            topic => "Test Room"
+         },
+      )->then( sub {
+         my ( $body ) = @_;
+
+         assert_json_keys( $body, qw( room_id ));
+         assert_json_nonempty_string( $body->{room_id} );
+
+         my ( $room_id ) = $body->{room_id};
+
+         do_request_json_for( $user,
+            method => "GET",
+            uri    => "/r0/rooms/$room_id/state/m.room.topic",
+         )
+      })->then( sub {
+         my ( $state ) = @_;
+
+         log_if_fail "state", $state;
+
+         assert_json_keys( $state, qw( topic ));
+         assert_json_nonempty_string( $state->{topic} );
+         assert_eq( $state->{topic}, "Test Room", "room topic" );
+
+         Future->done(1);
+      });
+   };
+
+test "POST /createRoom makes a room with an avatar",
+   requires => [ $user_fixture, local_user_fixture(),
+                 qw( can_create_private_room )],
+
+   proves => [qw( can_createroom_with_avatar )],
+
+   do => sub {
+      my ( $user ) = @_;
+
+      do_request_json_for( $user,
+         method => "POST",
+         uri    => "/r0/createRoom",
+
+         content => {
+            avatar => "mxc://localhost/test_val"
+         },
+      )->then( sub {
+         my ( $body ) = @_;
+
+         assert_json_keys( $body, qw( room_id ));
+         assert_json_nonempty_string( $body->{room_id} );
+
+         my ( $room_id ) = $body->{room_id};
+
+         do_request_json_for( $user,
+            method => "GET",
+            uri    => "/r0/rooms/$room_id/state/m.room.avatar",
+         )
+      })->then( sub {
+         my ( $state ) = @_;
+
+         log_if_fail "state", $state;
+
+         assert_json_keys( $state, qw( url ));
+         assert_json_nonempty_string( $state->{url} );
+         assert_eq( $state->{url}, "mxc://localhost/test_val", "room avatar" );
 
          Future->done(1);
       });


### PR DESCRIPTION
Creating rooms with avatars is under a proposal at the time of writing.

Spec: https://github.com/matrix-org/matrix-doc/pull/1326
Synapse: https://github.com/matrix-org/synapse/pull/3417