### PR TITLE
[WIP] Dendrite: Print homeserver output by default

### DIFF
--- a/lib/SyTest/Homeserver/ProcessManager.pm
+++ b/lib/SyTest/Homeserver/ProcessManager.pm
@@ -79,7 +79,7 @@ sub _start_process
 
    my $fut = $self->loop->new_future;
 
-   my $proc_info = ProcessInfo( undef, $fut, [], 0 );
+   my $proc_info = ProcessInfo( undef, $fut, [], 1 );
 
    my $on_output = sub {
       my ( $stream, $buffref, $eof ) = @_;


### PR DESCRIPTION
Print out the server logs during tests by default.

I don't know if this change is Dendrite-specific, as I don't have a Synapse sytest environment set up. If anyone could tell me if this change override's the `-S` option for Synapse, do let me know :)