### PR TITLE
Ensure that events from erased users are redacted over federation

### DIFF
--- a/tests/30rooms/32erasure.pl
+++ b/tests/30rooms/32erasure.pl
@@ -1,0 +1,74 @@
+# Copyright 2018 New Vector Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+use List::Util qw( first );
+
+test "Only original members of the room can see messages from erased users",
+   requires => [ local_user_and_room_fixtures(), local_user_fixture(), local_user_fixture() ],
+
+   do => sub {
+      my ( $creator, $room_id, $member, $joiner ) = @_;
+
+      my $message_id;
+      matrix_join_room_synced( $member, $room_id )
+      ->then( sub {
+         matrix_send_room_text_message( $creator, $room_id, body => "body1" );
+      })->then( sub {
+         ( $message_id ) = @_;
+         matrix_join_room_synced( $joiner, $room_id );
+      })->then( sub {
+         # now both users should see the message event
+         matrix_sync( $joiner, limit => 4 );
+      })->then( sub {
+         my ( $body ) = @_;
+
+         my $room = $body->{rooms}{join}{$room_id};
+         my $events = $room->{timeline}->{events};
+         log_if_fail "messages for joining user before erasure", $events;
+
+         my $e = first { $_->{event_id} eq $message_id } @$events;
+         assert_eq( $e->{type}, "m.room.message", "event type" );
+         assert_eq( $e->{content}->{body}, "body1", "event content body" );
+
+         matrix_deactivate_account( $creator, erase => JSON::true );
+      })->then( sub {
+         # now the original member should see the message event, but the joiner
+         # should see a redacted version
+         matrix_sync( $member );
+      })->then( sub {
+         my ( $body ) = @_;
+
+         my $room = $body->{rooms}{join}{$room_id};
+         my $events = $room->{timeline}->{events};
+         log_if_fail "messages for original member after erasure", $events;
+
+         my $e = first { $_->{event_id} eq $message_id } @$events;
+         assert_eq( $e->{type}, "m.room.message", "event type" );
+         assert_eq( $e->{content}->{body}, "body1", "event content body" );
+
+         matrix_sync( $joiner );
+      })->then( sub {
+         my ( $body ) = @_;
+
+         my $room = $body->{rooms}{join}{$room_id};
+         my $events = $room->{timeline}->{events};
+         log_if_fail "messages for joining user after erasure", $events;
+
+         my $e = first { $_->{event_id} eq $message_id } @$events;
+         assert_eq( $e->{type}, "m.room.message", "event type" );
+         assert_deeply_eq( $e->{content}, {}, "event content" );
+
+         Future->done(1);
+      });
+   };

--- a/tests/50federation/32room-getevent.pl
+++ b/tests/50federation/32room-getevent.pl
@@ -45,3 +45,75 @@ test "Inbound federation can return events",
       });
    };
 
+
+test "Inbound federation redacts events from erased users",
+   requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
+                 local_user_and_room_fixtures(),
+                 federation_user_id_fixture() ],
+
+   do => sub {
+      my ( $outbound_client, $info, $creator, $room_id, $user_id ) = @_;
+      my $first_home_server = $info->server_name;
+
+      my $message_id;
+
+      $outbound_client->join_room(
+         server_name => $first_home_server,
+         room_id     => $room_id,
+         user_id     => $user_id,
+      )->then( sub {
+         my ( $room ) = @_;
+
+         # have the creator send a message into the room, which we will try to
+         # fetch.
+         matrix_send_room_text_message( $creator, $room_id, body => "body1" );
+      })->then( sub {
+         ( $message_id ) = @_;
+
+         $outbound_client->do_request_json(
+            method   => "GET",
+            hostname => $first_home_server,
+            uri      => "/event/$message_id/",
+         );
+      })->then( sub {
+         my ( $body ) = @_;
+         log_if_fail "Fetched event before erasure", $body;
+
+         assert_json_keys( $body, qw( origin origin_server_ts pdus ));
+         assert_json_list( my $events = $body->{pdus} );
+
+         @$events == 1 or
+            die "Expected 1 event, found " . scalar(@$events);
+         my ( $event ) = @$events;
+
+         # Check that the content is right
+         assert_eq( $event->{content}->{body}, "body1" );
+
+         # now do the erasure
+         matrix_deactivate_account( $creator, erase => JSON::true );
+      })->then( sub {
+         # re-fetch the event
+         $outbound_client->do_request_json(
+            method   => "GET",
+            hostname => $first_home_server,
+            uri      => "/event/$message_id/",
+         );
+      })->then( sub {
+         my ( $body ) = @_;
+         log_if_fail "Fetched event after erasure", $body;
+
+         assert_json_keys( $body, qw( origin origin_server_ts pdus ));
+         assert_json_list( my $events = $body->{pdus} );
+
+         @$events == 1 or
+            die "Expected 1 event, found " . scalar(@$events);
+         my ( $event ) = @$events;
+
+         # Check that the content has been redacted
+         exists $event->{content}->{body} and
+            die "Event was not redacted";
+
+         Future->done(1);
+      });
+   };
+


### PR DESCRIPTION
This is a regression test for matrix-org/synapse#3547. It builds on #464.