### PR TITLE
test make_join error passthrough

### DIFF
--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -1,3 +1,4 @@
+use JSON qw( decode_json );
 use List::UtilsBy qw( partition_by extract_by );
 
 use SyTest::Federation::Room;


### PR DESCRIPTION
this is a regression test for the fix in matrix-org/synapse#3639.