### PR TITLE
Make matrix_create_room_synced return the sync result

### DIFF
--- a/tests/10apidoc/09synced.pl
+++ b/tests/10apidoc/09synced.pl
@@ -11,12 +11,12 @@ push our @EXPORT, qw(
 
 =head2 matrix_do_and_wait_for_sync
 
-   my ( $action_result ) = matrix_do_and_wait_for_sync( $user,
+   my ( $action_result, $check_result ) = matrix_do_and_wait_for_sync( $user,
       do => sub {
          return some_action_that_returns_a_future();
       },
       check => sub {
-         my ( $sync_body, $action_result ) = @_
+         my ( $sync_body, $action_result ) = @_;
 
          # return a true value if the sync contains the action.
          # return a false value if the sync isn't ready yet.
@@ -70,7 +70,10 @@ sub matrix_do_and_wait_for_sync
          %params
       );
 
-      $finished->then( sub { Future->done( @action_result ); } );
+      $finished->then( sub {
+         my ( @check_result ) = @_;
+         Future->done( @action_result, @check_result );
+      } );
    });
 }
 

--- a/tests/10apidoc/30room-create.pl
+++ b/tests/10apidoc/30room-create.pl
@@ -193,6 +193,20 @@ sub room_alias_fixture
 }
 
 
+=head2 matrix_create_room_synced
+
+    my ( $room_id, $room_alias, $sync_body ) = matrix_create_room_synced( %params );
+
+Creates a new room, and waits for it to appear in the /sync response.
+
+The parameters are passed through to C<matrix_create_room>.
+
+The resultant future completes with three values: the room_id from the
+/createRoom response; the room_alias from the /createRoom response (which is
+non-standard and should not be relied upon); the /sync response.
+
+=cut
+
 sub matrix_create_room_synced
 {
    my ( $user, %params ) = @_;
@@ -201,6 +215,10 @@ sub matrix_create_room_synced
       do => sub {
          matrix_create_room( $user, %params );
       },
-      check => sub { exists $_[0]->{rooms}{join}{$_[1]} },
+      check => sub {
+         my ( $sync_body, $room_id ) = @_;
+         return 0 if not exists $sync_body->{rooms}{join}{$room_id};
+         return $sync_body;
+      },
    );
 }


### PR DESCRIPTION
It's useful to be able to inspect the /sync result without having to re-sync.