### PR TITLE
Pass all matrix_create_room options through

### DIFF
--- a/tests/30rooms/21receipts.pl
+++ b/tests/30rooms/21receipts.pl
@@ -117,7 +117,7 @@ multi_test "Read receipts are visible to /initialSync",
    };
 
 test "Read receipts are sent as events",
-   requires => [ local_user_and_room_fixtures( with_events => 1 ),
+   requires => [ local_user_and_room_fixtures( user_opts => { with_events => 1 }),
                  qw( can_post_room_receipts )],
 
    do => sub {

--- a/tests/30rooms/70publicroomslist.pl
+++ b/tests/30rooms/70publicroomslist.pl
@@ -25,8 +25,7 @@ test "Name/topic keys are correct",
          matrix_create_room( $user,
             visibility      => "public",
             room_alias_name => $alias_local,
-            name            => $room->{name},
-            topic           => $room->{topic},
+            %{$room},
          )
       } keys %rooms )
       ->then( sub {

--- a/tests/50federation/31room-send.pl
+++ b/tests/50federation/31room-send.pl
@@ -45,7 +45,7 @@ test "Outbound federation can send events",
 
 test "Inbound federation can receive events",
    requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures( with_events => 1 ),
+                 local_user_and_room_fixtures( user_opts => { with_events => 1 }),
                  federation_user_id_fixture() ],
 
    do => sub {

--- a/tests/50federation/33room-get-missing-events.pl
+++ b/tests/50federation/33room-get-missing-events.pl
@@ -1,6 +1,6 @@
 test "Outbound federation can request missing events",
    requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures( with_events => 1 ),
+                 local_user_and_room_fixtures( user_opts => { with_events => 1 }),
                  federation_user_id_fixture() ],
 
    do => sub {

--- a/tests/50federation/36-state.pl
+++ b/tests/50federation/36-state.pl
@@ -98,7 +98,7 @@ test "Inbound federation can get state_ids for a room",
 
 test "Outbound federation requests /state_ids and correctly handles 404",
    requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures( with_events => 1 ),
+                 local_user_and_room_fixtures( user_opts => { with_events => 1 } ),
                  federation_user_id_fixture() ],
 
    do => sub {
@@ -174,7 +174,7 @@ test "Outbound federation requests /state_ids and asks for missing state",
    # Disabled as Synapse now checks the state of the missing item's ancestors instead
    bug => "DISABLED",
    requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures( with_events => 1 ),
+                 local_user_and_room_fixtures( user_opts => { with_events => 1 } ),
                  federation_user_id_fixture() ],
 
    do => sub {


### PR DESCRIPTION
It's annoying to have to edit each time createRoom gets a new knob. Just pass everything through.

There are a couple of related changes to make this work:

* in matrix_create_and_join_room, filter out the options which apply to that function before calling matrix_create_room

* in local_user_and_room_fixtures, distinguish between opts which are meant for the user fixture and those that are meant for the room fixture - and then update the handful of points which actually pass in such options

* the 'publicroomslist' test used to pass 'undef' for a couple of parameters to matrix_create_room; that was wrongheaded and we should not pass those params at all.