### PR TITLE
Tests for missing prevs in incoming transactions

### DIFF
--- a/lib/SyTest/Federation/Room.pm
+++ b/lib/SyTest/Federation/Room.pm
@@ -113,7 +113,7 @@ sub create_initial_events
 
    my $room_version = $args{room_version};
 
-   $self->create_event(
+   $self->create_and_insert_event(
       type => "m.room.create",
 
       content     => {
@@ -124,7 +124,7 @@ sub create_initial_events
       state_key   => "",
    );
 
-   $self->create_event(
+   $self->create_and_insert_event(
       type => "m.room.member",
 
       content     => { membership => "join" },
@@ -132,7 +132,7 @@ sub create_initial_events
       state_key   => $creator,
    );
 
-   $self->create_event(
+   $self->create_and_insert_event(
       type => "m.room.join_rules",
 
       content     => { join_rule => "public" },
@@ -145,12 +145,11 @@ sub create_initial_events
 
    $event = $room->create_event( %fields )
 
-Constructs a new event in the room and updates the current state, if it is a
-state event. This helper also fills in the C<depth>, C<prev_events> and
-C<auth_events> lists if they are absent from C<%fields>, meaning the caller
-does not have to. Any values that are passed are used instead, even if they
-are somehow invalid - this allows callers to construct intentionally-invalid
-events for testing purposes.
+Constructs a new event in the room. This helper also fills in the C<depth>,
+C<prev_events> and C<auth_events> lists if they are absent from C<%fields>,
+meaning the caller does not have to. Any values that are passed are used
+instead, even if they are somehow invalid - this allows callers to construct
+intentionally-invalid events for testing purposes.
 
 =cut
 
@@ -173,10 +172,27 @@ sub create_event
 
    $fields{prev_events} //= make_event_refs( @{ $self->{prev_events} } );
 
-   my $event = $self->{datastore}->create_event(
+   return $self->{datastore}->create_event(
       room_id => $self->room_id,
       %fields,
    );
+}
+
+=head2 create_and_insert_event
+
+   $event = $room->create_and_insert_event( %fields )
+
+Constructs a new event via C<create_event>, updates the current state, if it is a
+state event, and records the event as the room's next prev_event.
+
+=cut
+
+sub create_and_insert_event
+{
+   my $self = shift;
+   my %fields = @_;
+
+   my $event = $self->create_event( %fields );
 
    $self->_insert_event( $event );
 

--- a/lib/SyTest/Federation/Server.pm
+++ b/lib/SyTest/Federation/Server.pm
@@ -400,7 +400,7 @@ __PACKAGE__->mk_await_request_pair(
 );
 
 __PACKAGE__->mk_await_request_pair(
-   state_ids => [qw( :room_id )],
+   state_ids => [qw( :room_id ?event_id )],
 );
 
 __PACKAGE__->mk_await_request_pair(

--- a/tests/50federation/31room-send.pl
+++ b/tests/50federation/31room-send.pl
@@ -63,7 +63,7 @@ test "Inbound federation can receive events",
       )->then( sub {
          my ( $room ) = @_;
 
-         my $event = $room->create_event(
+         my $event = $room->create_and_insert_event(
             type => "m.room.message",
 
             sender  => $user_id,
@@ -110,7 +110,7 @@ test "Inbound federation can receive redacted events",
       )->then( sub {
          my ( $room ) = @_;
 
-         my $event = $room->create_event(
+         my $event = $room->create_and_insert_event(
             type => "m.room.message",
 
             sender  => $user_id,

--- a/tests/50federation/33room-get-missing-events.pl
+++ b/tests/50federation/33room-get-missing-events.pl
@@ -24,7 +24,7 @@ test "Outbound federation can request missing events",
          my $latest_event = $room->get_current_state_event( "m.room.member", $user_id );
 
          # Generate but don't send an event
-         $missing_event = $room->create_event(
+         $missing_event = $room->create_and_insert_event(
             type => "m.room.message",
 
             sender  => $user_id,
@@ -35,10 +35,10 @@ test "Outbound federation can request missing events",
 
          # Generate another one and do send it so it will refer to the
          # previous in its prev_events field
-         my $sent_event = $room->create_event(
+         my $sent_event = $room->create_and_insert_event(
             type => "m.room.message",
 
-            # This would be done by $room->create_event anyway but lets be
+            # This would be done by $room->create_and_insert_event anyway but lets be
             #   sure for this test
             prev_events => [
                [ $missing_event->{event_id}, $missing_event->{hashes} ],

--- a/tests/50federation/34room-backfill.pl
+++ b/tests/50federation/34room-backfill.pl
@@ -17,7 +17,7 @@ test "Outbound federation can backfill events",
       );
 
       # Create some past messages to backfill from
-      $room->create_event(
+      $room->create_and_insert_event(
          type => "m.room.message",
 
          sender  => $creator_id,

--- a/tests/50federation/35room-invite.pl
+++ b/tests/50federation/35room-invite.pl
@@ -78,7 +78,7 @@ sub invite_server
 
    my $room_id = $room->room_id;
 
-   my $invitation = $room->create_event(
+   my $invitation = $room->create_and_insert_event(
      type => "m.room.member",
 
      content   => { membership => "invite" },

--- a/tests/50federation/36-state.pl
+++ b/tests/50federation/36-state.pl
@@ -118,7 +118,7 @@ test "Outbound federation requests /state_ids and correctly handles 404",
          ( $room ) = @_;
 
          # Generate but don't send an event
-         my $missing_event = $room->create_event(
+         my $missing_event = $room->create_and_insert_event(
             type => "m.room.message",
 
             sender  => $user_id,
@@ -129,10 +129,10 @@ test "Outbound federation requests /state_ids and correctly handles 404",
 
          # Generate another one and do send it so it will refer to the
          # previous in its prev_events field
-         $sent_event = $room->create_event(
+         $sent_event = $room->create_and_insert_event(
             type => "m.room.message",
 
-            # This would be done by $room->create_event anyway but lets be
+            # This would be done by $room->create_and_insert_event anyway but lets be
             #   sure for this test
             prev_events => [
                [ $missing_event->{event_id}, $missing_event->{hashes} ],
@@ -202,7 +202,7 @@ test "Outbound federation requests /state_ids and asks for missing state",
          ( $room ) = @_;
 
          # Generate but don't send an event
-         my $missing_event = $room->create_event(
+         my $missing_event = $room->create_and_send_event(
             type => "m.room.message",
 
             sender  => $user_id,
@@ -211,7 +211,7 @@ test "Outbound federation requests /state_ids and asks for missing state",
             },
          );
 
-         $missing_state = $room->create_event(
+         $missing_state = $room->create_and_insert_event(
             type      => "m.room.topic",
             state_key => "",
 
@@ -223,10 +223,10 @@ test "Outbound federation requests /state_ids and asks for missing state",
 
          # Generate another one and do send it so it will refer to the
          # previous in its prev_events field
-         $sent_event = $room->create_event(
+         $sent_event = $room->create_and_insert_event(
             type => "m.room.message",
 
-            # This would be done by $room->create_event anyway but lets be
+            # This would be done by $room->create_and_insert_event anyway but lets be
             #   sure for this test
             prev_events => [
                [ $missing_event->{event_id}, $missing_event->{hashes} ],

--- a/tests/50federation/36-state.pl
+++ b/tests/50federation/36-state.pl
@@ -363,8 +363,9 @@ test "Outbound federation requests missing prev_events and then asks for /state_
                      map { $_->{event_id} } values( %state ),
                   ],
                   auth_chain_ids => [
-                     # XXX I'm not really sure why we have to return our
-                     # auth_events here, when they are already in the event
+                     # XXX we're supposed to return the whole auth chain here,
+                     # not just y's auth_events. It doesn't matter too much
+                     # here though.
                      map { $_->[0] } @{ $missing_event_y->{auth_events} },
                   ],
                };

--- a/tests/50federation/36-state.pl
+++ b/tests/50federation/36-state.pl
@@ -1,3 +1,14 @@
+sub get_state_ids_from_server {
+   my ( $outbound_client, $server, $room_id, $event_id ) = @_;
+
+   return $outbound_client->do_request_json(
+      method   => "GET",
+      hostname => $server,
+      uri      => "/state_ids/$room_id/",
+      params   => { event_id => $event_id },
+   );
+}
+
 test "Inbound federation can get state for a room",
    requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
                  local_user_and_room_fixtures(),
@@ -67,13 +78,9 @@ test "Inbound federation can get state_ids for a room",
       )->then( sub {
          ( $room ) = @_;
 
-         $outbound_client->do_request_json(
-            method   => "GET",
-            hostname => $first_home_server,
-            uri      => "/state_ids/$room_id/",
-            params   => {
-               event_id => $room->{prev_events}[-1]->{event_id},
-            }
+         get_state_ids_from_server(
+            $outbound_client, $first_home_server,
+            $room_id, $room->{prev_events}[-1]->{event_id},
          );
       })->then( sub {
          my ( $body ) = @_;
@@ -170,9 +177,9 @@ test "Outbound federation requests /state_ids and correctly handles 404",
       })->then_done(1);
    };
 
-test "Outbound federation requests /state_ids and asks for missing state",
-   # Disabled as Synapse now checks the state of the missing item's ancestors instead
-   bug => "DISABLED",
+
+
+test "Outbound federation requests missing prev_events and then asks for /state_ids and resolves the state",
    requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO[0],
                  local_user_and_room_fixtures( user_opts => { with_events => 1 } ),
                  federation_user_id_fixture() ],
@@ -181,11 +188,37 @@ test "Outbound federation requests /state_ids and asks for missing state",
       my ( $outbound_client, $inbound_server, $info, $creator, $room_id, $user_id ) = @_;
       my $first_home_server = $info->server_name;
 
-      my $local_server_name = $outbound_client->server_name;
+      # in this test, we're going to create a DAG like this:
+      #
+      #      A
+      #     /
+      #    B  (Y)
+      #   / \ /
+      #   |  X
+      #   \ /
+      #    C
+      #
+      # So we start with A and B, and then send C, which has prev_events (B,
+      # X). We expect the remote server to request the missing events, and we
+      # respond with X, which has another prev_event Y, which we don't send
+      # proactively.
+      #
+      # In this case, we don't expect the remote server to go on requesting
+      # missing events indefinitely - rather we expect it to stop after one
+      # round and instead request the state at Y.
+      #
+      # In order to test the state resolution, we also have a couple of made-up
+      # state events, S and T, which we stick in the response when we get the
+      # state request.
+      #
+      # XXX: the number of rounds of get_missing_events which the server does
+      # is an implementation detail - Synapse only does one round, but it is of
+      # course valid to keep going for a while. We may need to update this test
+      # to handle alternative implementations.
 
+      my $pl_event_id;
       my $room;
-      my $sent_event;
-      my $missing_state;
+      my $sent_event_b;
 
       # make sure that the sytest user has permission to alter the state
       matrix_change_room_powerlevels( $creator, $room_id, sub {
@@ -193,6 +226,9 @@ test "Outbound federation requests /state_ids and asks for missing state",
 
          $levels->{users}->{$user_id} = 100;
       })->then( sub {
+         my ( $body ) = @_;
+         $pl_event_id = $body->{event_id};
+
          $outbound_client->join_room(
             server_name => $first_home_server,
             room_id     => $room_id,
@@ -201,118 +237,208 @@ test "Outbound federation requests /state_ids and asks for missing state",
       })->then( sub {
          ( $room ) = @_;
 
-         # Generate but don't send an event
-         my $missing_event = $room->create_and_send_event(
-            type => "m.room.message",
+         # Create and send B
+         $sent_event_b = $room->create_and_insert_event(
+            type => "test_state",
+            state_key => "B",
 
             sender  => $user_id,
             content => {
-               body => "Message missing",
+               body => "event_b",
             },
          );
-
-         $missing_state = $room->create_and_insert_event(
-            type      => "m.room.topic",
-            state_key => "",
-
-            sender  => $user_id,
-            content => {
-               topic => "Test topic",
-            },
-         );
-
-         # Generate another one and do send it so it will refer to the
-         # previous in its prev_events field
-         $sent_event = $room->create_and_insert_event(
-            type => "m.room.message",
-
-            # This would be done by $room->create_and_insert_event anyway but lets be
-            #   sure for this test
-            prev_events => [
-               [ $missing_event->{event_id}, $missing_event->{hashes} ],
-            ],
-
-            sender  => $user_id,
-            content => {
-               body => "Message sent",
-            },
-         );
-
-         log_if_fail "Missing message: " . $missing_event->{event_id};
-         log_if_fail "Missing topic: " . $missing_state->{event_id};
-         log_if_fail "Sent message: " . $sent_event->{event_id};
 
          Future->needs_all(
-            $inbound_server->await_request_state_ids( $room_id )
-            ->then( sub {
-               my ( $req ) = @_;
-
-               log_if_fail "Got /state_ids request";
-
-               my @auth_event_ids = map { $_->{event_id} } $room->current_state_events;
-
-               # Don't need to be exact, synapse handles failure gracefully
-               $req->respond_json( {
-                  pdu_ids => [ $missing_state->{event_id}, @auth_event_ids ],
-                  auth_chain_ids => [ @auth_event_ids ],
-               } );
-
-               Future->done(1);
+            $outbound_client->send_event(
+               event       => $sent_event_b,
+               destination => $first_home_server,
+            ),
+            await_event_for( $creator, filter => sub {
+               ( $_[0]->{event_id} // '' ) eq $sent_event_b->{event_id};
             }),
-            $inbound_server->await_request_event( $missing_state->{event_id} )
-            ->then( sub {
-               my ( $req ) = @_;
+         );
+      })->then( sub {
+         # Generate our "missing" events
+         my $missing_event_y = $room->create_event(
+            type => "test_state",
+            state_key => "Y",
 
-               log_if_fail "Got /event/ request";
+            sender  => $user_id,
+            content => {
+               body => "event_y",
+            },
+         );
 
-               # Don't need to be exact, synapse handles failure gracefully
-               $req->respond_json( {
-                  pdus => [ $missing_state ],
-               } );
+         my $missing_event_x = $room->create_event(
+            type => "m.room.message",
 
-               Future->done(1);
-            }),
+            sender  => $user_id,
+            content => {
+               body => "event_x",
+            },
+            prev_events => SyTest::Federation::Room::make_event_refs(
+               @{ $room->{prev_events} }, $missing_event_y,
+            ),
+         );
+
+         my $missing_state_s = $room->create_event(
+            type => "m.room.power_levels",
+            state_key => "",
+            sender  => $user_id,
+            content => {
+               users => {
+                  $user_id => 100,
+               },
+            },
+         );
+
+         my $missing_state_t = $room->create_event(
+            type => "test_state",
+            state_key => "T",
+            sender  => $user_id,
+            content => { topic => "how now" },
+         );
+
+         # Now create and send our regular event C.
+         my $sent_event_c = $room->create_and_insert_event(
+            type => "m.room.message",
+
+            prev_events => SyTest::Federation::Room::make_event_refs(
+               @{ $room->{prev_events} }, $missing_event_x,
+            ),
+
+            sender  => $user_id,
+            content => {
+               body => "event_c",
+            },
+         );
+
+         log_if_fail "Missing events X, Y: " . $missing_event_x->{event_id} .
+            ", " . $missing_event_y->{event_id};
+         log_if_fail "Sent events B, C: " . $sent_event_b->{event_id} .
+            ", " . $sent_event_c->{event_id};
+
+         Future->needs_all(
+            $outbound_client->send_event(
+               event       => $sent_event_c,
+               destination => $first_home_server,
+            ),
+
             $inbound_server->await_request_get_missing_events( $room_id )
             ->then( sub {
                my ( $req ) = @_;
 
-               log_if_fail "Got /missing_events request";
+               my $body = $req->body_from_json;
+               log_if_fail "/get_missing_events request", $body;
 
-               # We return no events to force the remote to ask for state
+               assert_deeply_eq(
+                  $body->{latest_events},
+                  [ $sent_event_c->{event_id } ],
+                  "latest_events in /get_missing_events request",
+               );
+
+               # just return X
                $req->respond_json( {
-                  events => [],
+                  events => [ $missing_event_x ],
                } );
 
                Future->done(1);
             }),
 
-            $outbound_client->send_event(
-               event       => $sent_event,
-               destination => $first_home_server,
-            ),
-         );
-      })->then( sub {
-         # creator user should eventually receive the sent event
-         await_event_for( $creator, filter => sub {
-            my ( $event ) = @_;
-            return $event->{type} eq "m.room.message" &&
-                   $event->{event_id} eq $sent_event->{event_id};
-         })->on_done( sub {
-            log_if_fail "Creator received sent event";
+            $inbound_server->await_request_state_ids(
+               $room_id, $missing_event_y->{event_id},
+            )->then( sub {
+               my ( $req ) = @_;
+               log_if_fail "/state_ids request";
+
+               # build a state map from the room's current state and our extra events
+               my %state = %{ $room->{current_state} };
+               foreach my $event ( $missing_state_s, $missing_state_t ) {
+                  my $k = join "\0", $event->{type}, $event->{state_key};
+                  $state{$k} = $event;
+               }
+
+               my $resp = {
+                  pdu_ids => [
+                     map { $_->{event_id} } values( %state ),
+                  ],
+                  auth_chain_ids => [
+                     # XXX I'm not really sure why we have to return our
+                     # auth_events here, when they are already in the event
+                     map { $_->[0] } @{ $missing_event_y->{auth_events} },
+                  ],
+               };
+
+               log_if_fail "/state_ids response", $resp;
+
+               $req->respond_json( $resp );
+
+               Future->done(1);
+            }),
+         )->then( sub {
+            # creator user should eventually receive the events
+            Future->needs_all(
+               await_event_for( $creator, filter => sub {
+                  ( $_[0]->{event_id} // '' ) eq $sent_event_c->{event_id};
+               }),
+               await_event_for( $creator, filter => sub {
+                  ( $_[0]->{event_id} // '' ) eq $missing_event_x->{event_id};
+               }),
+            );
+         })->then( sub {
+            # check the 'current' state of the room after state resolution
+            matrix_get_room_state_by_type( $creator, $room_id ) -> then( sub {
+               my ( $state ) = @_;
+               log_if_fail "final room state", $state;
+
+               assert_eq(
+                  $state->{"m.room.power_levels"}->{""}->{"event_id"},
+                  $pl_event_id,
+                  "power_levels event after state res",
+               );
+
+               assert_eq(
+                  $state->{"test_state"}->{"B"}->{"event_id"},
+                  $sent_event_b->{event_id},
+                  "test_state B after state res",
+               );
+
+               assert_eq(
+                  $state->{"test_state"}->{"T"}->{"event_id"},
+                  $missing_state_t->{event_id},
+                  "test_state T after state res",
+               );
+
+               assert_eq(
+                  $state->{"test_state"}->{"Y"}->{"event_id"},
+                  $missing_event_y->{event_id},
+                  "test_state Y after state res",
+               );
+
+               Future->done(1);
+            });
+         })->then( sub {
+            # check state at X
+            get_state_ids_from_server(
+               $outbound_client, $first_home_server,
+               $room_id, $missing_event_x->{event_id},
+            )->then( sub {
+               my ( $body ) = @_;
+               my $state_ids = $body->{pdu_ids};
+               log_if_fail "State at X", $state_ids;
+               for my $ev (
+                  $pl_event_id,
+                  $missing_state_t->{event_id},
+                  $sent_event_b->{event_id},
+                  $missing_event_y->{event_id},
+               ) {
+                  any { $_ eq $ev } @{ $state_ids }
+                     or die "State $ev missing at X";
+               }
+
+               Future->done(1);
+            });
          });
-      })->then( sub {
-         matrix_get_room_state( $creator, $room_id,
-            type      => "m.room.topic",
-            state_key => "",
-         );
-      })->then( sub {
-         my ( $body ) = @_;
-
-         log_if_fail "Returned body", $body;
-
-         assert_eq( $body->{topic}, $missing_state->{content}{topic} );
-
-         Future->done( 1 );
       });
    };
 

--- a/tests/50federation/41power-levels.pl
+++ b/tests/50federation/41power-levels.pl
@@ -85,7 +85,7 @@ test "Remote servers should reject attempts by non-creators to set the power lev
       );
       my $room_id = $room->{room_id};
 
-      $room->create_event(
+      $room->create_and_insert_event(
          type => "m.room.member",
          content     => { membership => "join" },
          sender      => $sytest_user_id_b,
@@ -105,7 +105,7 @@ test "Remote servers should reject attempts by non-creators to set the power lev
             or die "no membership for $sytest_user_id_b";
 
          # now synapse should reject an attempt by user b to set the power levels.
-         my $pl = $room->create_event(
+         my $pl = $room->create_and_insert_event(
             sender    => $sytest_user_id_b,
             type      => "m.room.power_levels",
             state_key => "",


### PR DESCRIPTION
This tries to test the things that are fixed in https://github.com/matrix-org/synapse/pull/3968.

(The first commit is a bit of a refactor; the second updates a currently-disabled test to do something useful.)