### PR TITLE
Test script: don't abort if server logs missing

### DIFF
--- a/docker/synapse_sytest.sh
+++ b/docker/synapse_sytest.sh
@@ -64,11 +64,9 @@ else
 fi
 
 # Copy out the logs
-mkdir -p /logs/server-0/
-mkdir -p /logs/server-1/
+mkdir -p /logs
 cp results.tap /logs/results.tap
-rsync --ignore-errors -av server-0/ /logs/server-0 --include="*.log.*" --include="*.log" --exclude="*"
-rsync --ignore-errors -av server-1/ /logs/server-1 --include="*.log.*" --include="*.log" --exclude="*"
+rsync --ignore-missing-args -av server-0 server-1 /logs --include "*/" --include="*.log.*" --include="*.log" --exclude="*"
 
 # Write out JUnit for CircleCI
 mkdir -p /logs/sytest


### PR DESCRIPTION
rsync returns an error if its input directory is missing, which aborts the
script. The input directories will be missing if the server never gets
started.

To make it easier, combine the rsyncs into one command (which requires some
fiddling with the include filters).