### PR TITLE
dos2unix all the scripts

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,8 @@ RUN apt-get -qq install -y \
     git \
     locales \
     haproxy \
-    jq
+    jq \
+    dos2unix
 
 # Set up the locales, as the default Debian image only has C, and PostgreSQL needs the correct locales to make a UTF-8 database
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
@@ -37,6 +38,7 @@ ENV LC_ALL en_US.UTF-8
 # repo root, not the docker folder
 ADD install-deps.pl ./install-deps.pl
 ADD cpanfile ./cpanfile
+RUN dos2unix ./cpanfile ./install-deps.pl
 RUN perl ./install-deps.pl
 RUN rm cpanfile install-deps.pl
 

--- a/docker/Dockerfile-synapsepy2
+++ b/docker/Dockerfile-synapsepy2
@@ -10,4 +10,5 @@ RUN mkdir /src
 # The dockerfile context, when ran by the buildscript, will actually be the
 # repo root, not the docker folder
 ADD docker/synapse_sytest.sh /synapse_sytest.sh
+RUN dos2unix /synapse_sytest.sh
 ENTRYPOINT /synapse_sytest.sh

--- a/docker/Dockerfile-synapsepy3
+++ b/docker/Dockerfile-synapsepy3
@@ -10,4 +10,5 @@ RUN mkdir /src
 # The dockerfile context, when ran by the buildscript, will actually be the
 # repo root, not the docker folder
 ADD docker/synapse_sytest.sh /synapse_sytest.sh
+RUN dos2unix /synapse_sytest.sh
 ENTRYPOINT /synapse_sytest.sh

--- a/docker/synapse_sytest.sh
+++ b/docker/synapse_sytest.sh
@@ -52,9 +52,11 @@ $PYTHON -m virtualenv -p $PYTHON /venv/
 /venv/bin/pip install -q --no-cache-dir lxml psycopg2
 
 # Make sure all Perl deps are installed -- this is done in the docker build so will only install packages added since the last Docker build
+dos2unix ./install-deps.pl
 ./install-deps.pl
 
 # Run the tests
+dos2unix ./run-tests.pl
 TEST_STATUS=0
 if [ -n "$WORKERS" ]
 then


### PR DESCRIPTION
This should have no effect for not-windows environments. This is only a problem for Windows users that get their line endings swapped out to be CRLF regardless of IDE/Git settings - Docker for Windows messes with the line endings unintentionally. 