### PR TITLE
Add a test for /invited_users 403ing on remote groups when not a member

### DIFF
--- a/tests/53groups/03local.pl
+++ b/tests/53groups/03local.pl
@@ -96,7 +96,7 @@ test "Remove other from local group",
    };
 
 
-push our @EXPORT, qw( matrix_invite_group_user matrix_accept_group_invite matrix_get_joined_groups matrix_leave_group matrix_join_group );
+push our @EXPORT, qw( matrix_invite_group_user matrix_accept_group_invite matrix_get_joined_groups matrix_leave_group matrix_join_group matrix_get_invited_group_users );
 
 
 =head2 matrix_invite_group_user
@@ -222,4 +222,34 @@ sub matrix_get_joined_groups
       method => "GET",
       uri    => "/r0/joined_groups",
    );
+}
+
+=head2 matrix_get_invited_group_users
+
+    matrix_get_invited_group_users( $group_id, $user )
+
+Get a list of invited group members. Returns the body of the response, which
+is in the form:
+
+    {
+        chunk => [
+            {
+                user_id     => '@someone:example.org',
+                avatar_url  => 'mxc://example.org/something',
+                displayname => 'Example User'
+            }
+        ],
+        total_user_count_estimate => 1
+    }
+
+=cut
+
+sub matrix_get_invited_group_users
+{
+    my ( $group_id, $user ) = @_;
+
+    do_request_json_for( $user,
+        method => "GET",
+        uri    => "/r0/groups/$group_id/invited_users"
+    )
 }

--- a/tests/53groups/04remote-group.pl
+++ b/tests/53groups/04remote-group.pl
@@ -58,5 +58,21 @@ test "Remove self from remote group",
       });
    };
 
+test "Listing invited users of a remote group when not a member returns a 403",
+    requires => [ local_admin_fixture( with_events => 0 ), remote_user_fixture( with_events => 0 ) ],
+
+    do => sub {
+        my ( $creator, $user ) = @_;
+
+        my $group_id;
+
+        matrix_create_group( $creator )
+        ->then( sub {
+            ( $group_id ) = @_;
+
+            matrix_get_invited_group_users( $group_id, $user )
+            -> main::expect_http_403;
+        });
+    };
 
 # TODO: Test kicks


### PR DESCRIPTION
For https://github.com/matrix-org/synapse/pull/3969

(this is expected to fail with a 500 because the current behaviour of synapse is broken)