### PR TITLE
Add regression test for #4169

### DIFF
--- a/tests/41end-to-end-keys/07-backup.pl
+++ b/tests/41end-to-end-keys/07-backup.pl
@@ -359,7 +359,7 @@ test "Can create more than 10 backup versions",
 
       repeat( sub {
          matrix_create_key_backup( $user );
-      }, foreach => [ 0 .. 10 ]);
+      }, foreach => [ 0 .. 10 ], while => sub { $_[0] -> is_done });
    };
 
 

--- a/tests/41end-to-end-keys/07-backup.pl
+++ b/tests/41end-to-end-keys/07-backup.pl
@@ -349,10 +349,9 @@ test "Deleted & recreated backups are empty",
       });
    };
 
+# regression test for https://github.com/matrix-org/synapse/issues/4169
 test "Can create more than 10 backup versions",
    requires => [ $fixture ],
-
-   bug => 'synapse/4169',
 
    do => sub {
       my ( $user ) = @_;

--- a/tests/41end-to-end-keys/07-backup.pl
+++ b/tests/41end-to-end-keys/07-backup.pl
@@ -1,3 +1,5 @@
+use Future::Utils qw( repeat );
+
 my $fixture = local_user_fixture();
 
 test "Can create backup version",
@@ -345,6 +347,19 @@ test "Deleted & recreated backups are empty",
 
          Future->done(1);
       });
+   };
+
+test "Can create more than 10 backup versions",
+   requires => [ $fixture ],
+
+   bug => 'synapse/4169',
+
+   do => sub {
+      my ( $user ) = @_;
+
+      repeat( sub {
+         matrix_create_key_backup( $user );
+      }, foreach => [ 0 .. 10 ]);
    };
 
 


### PR DESCRIPTION
Test for https://github.com/matrix-org/synapse/pull/4113

If this fails, it keeps going through the 10 versions which isn't ideal. I tried using the repeat+foreach+while to terminate it but couldn't get it to abort. Feedback welcome on the right runes to make this happen.