### PR TITLE
Tests for m.login.sso

### DIFF
--- a/tests/12login/02cas.pl
+++ b/tests/12login/02cas.pl
@@ -26,6 +26,77 @@ my $CAS_SUCCESS = <<'EOF';
 </cas:serviceResponse>
 EOF
 
+test "login types include SSO",
+   requires => [ $main::API_CLIENTS[0] ],
+
+   check => sub {
+      my ( $http ) = @_;
+
+      $http->do_request_json(
+         uri => "/r0/login",
+      )->then( sub {
+         my ( $body ) = @_;
+
+         assert_json_keys( $body, qw( flows ));
+         ref $body->{flows} eq "ARRAY" or die "Expected 'flows' as a list";
+
+         die "m.login.sso was not listed" unless
+            any { $_->{type} eq "m.login.sso" } @{ $body->{flows} };
+
+         Future->done( 1 );
+      });
+   };
+
+
+my $cas_login_fixture = fixture(
+   requires => [ $main::API_CLIENTS[0] ],
+
+   setup => sub {
+      my ( $http ) = @_;
+
+      $http->do_request_json(
+         uri => "/r0/login",
+      )->then( sub {
+         my ( $body ) = @_;
+
+         assert_json_keys( $body, qw( flows ));
+         ref $body->{flows} eq "ARRAY" or die "Expected 'flows' as a list";
+
+         die "SKIP: no m.login.cas" unless
+            any { $_->{type} eq "m.login.cas" } @{ $body->{flows} };
+
+         Future->done( 1 );
+      });
+   },
+);
+
+
+test "/login/cas/redirect redirects if the old m.login.cas login type is listed",
+   requires => [
+      $main::TEST_SERVER_INFO, $main::API_CLIENTS[0], $cas_login_fixture,
+   ],
+
+   do => sub {
+      my ( $test_server_info, $http ) = @_;
+
+      my $REDIRECT_URL = "https://client?p=http%3A%2F%2Fserver";
+
+      $http->do_request(
+         method => "GET",
+         uri    => "/r0/login/cas/redirect",
+         params => {
+            redirectUrl => $REDIRECT_URL,
+         },
+         max_redirects => 0,
+      )->main::expect_http_302->then( sub {
+         my ( $resp ) = @_;
+         my $loc = $resp->header( "Location" );
+         my $expected = $test_server_info->client_location . "/cas/login?";
+         die "unexpected location '$loc' (expected '$expected...')" unless
+            $loc =~ /^\Q$expected/;
+         Future->done(1);
+      });
+   };
 
 test "Can login with new user via CAS",
    requires => [
@@ -45,13 +116,13 @@ test "Can login with new user via CAS",
       # the ticket our mocked-up CAS server "generates"
       my $CAS_TICKET = "goldenticket";
 
-      # step 1: client sends request to /login/cas/redirect
+      # step 1: client sends request to /login/sso/redirect
       # step 2: synapse should redirect to the cas server.
       Future->needs_all(
          wait_for_cas_request( "/cas/login" ),
          $http->do_request(
             method => "GET",
-            uri    => "/api/v1/login/cas/redirect",
+            uri    => "/r0/login/sso/redirect",
             params => {
                redirectUrl => $REDIRECT_URL,
             },


### PR DESCRIPTION
MSC1721 renames m.login.cas to m.login.sso, so we should update the tests
accordingly.