### PR TITLE
Configure Dendrite to log to file

### DIFF
--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -131,6 +131,14 @@ sub _get_config
             federation_sender public_rooms_api naffka appservice
          ),
       },
+
+      logging => [{
+         type => 'file',
+         level => 'debug',
+         params => {
+            path => "$self->{hs_dir}/dendrite-logs",
+         },
+      }],
    );
 }
 


### PR DESCRIPTION
Add a section to Dendrite's generated configuration file to log to files on top of logging to the standard output.

I set the log level to `debug` as I assume users will look at log files to understand precisely what's going on when running tests (even though afaik there's no debug logs in Dendrite yet so that doesn't make a difference right now, but might in the future).