### PR TITLE
Use the from query parameter when querying /messages

### DIFF
--- a/tests/10apidoc/34room-messages.pl
+++ b/tests/10apidoc/34room-messages.pl
@@ -141,7 +141,7 @@ test "GET /rooms/:room_id/messages returns a message",
          matrix_sync( $user )
       })->then( sub {
          my ( $sync_body ) = @_;
-         my $token = $sync_body->{rooms}->{join}->{$room_id}->{timeline}->{next_batch};
+         my $token = $sync_body->{rooms}->{join}->{$room_id}->{timeline}->{prev_batch};
 
          do_request_json_for( $user,
             method => "GET",
@@ -179,7 +179,7 @@ test "GET /rooms/:room_id/messages lazy loads members correctly",
          matrix_sync( $user )
       })->then( sub {
          my ( $sync_body ) = @_;
-         my $token = $sync_body->{rooms}->{join}->{$room_id}->{timeline}->{next_batch};
+         my $token = $sync_body->{rooms}->{join}->{$room_id}->{timeline}->{prev_batch};
 
          do_request_json_for( $user,
             method => "GET",

--- a/tests/10apidoc/34room-messages.pl
+++ b/tests/10apidoc/34room-messages.pl
@@ -138,12 +138,20 @@ test "GET /rooms/:room_id/messages returns a message",
       matrix_send_room_text_message( $user, $room_id,
          body => "Here is the message content",
       )->then( sub {
+         matrix_sync($user)
+      })->then( sub {
+         my ( $sync_body ) = @_;
+         my $token = $sync_body->{next_batch};
+
          do_request_json_for( $user,
             method => "GET",
             uri    => "/r0/rooms/$room_id/messages",
 
             # With no params this does "forwards from END"; i.e. nothing useful
-            params => { dir => "b" },
+            params => {
+                dir => "b",
+                from => $token,
+            },
          )
       })->then( sub {
          my ( $body ) = @_;
@@ -168,6 +176,11 @@ test "GET /rooms/:room_id/messages lazy loads members correctly",
       matrix_send_room_text_message( $user, $room_id,
          body => "Here is the message content",
       )->then( sub {
+         matrix_sync($user)
+      })->then( sub {
+         my ( $sync_body ) = @_;
+         my $token = $sync_body->{next_batch};
+
          do_request_json_for( $user,
             method => "GET",
             uri    => "/r0/rooms/$room_id/messages",
@@ -176,6 +189,7 @@ test "GET /rooms/:room_id/messages lazy loads members correctly",
             params => {
                dir => "b",
                filter => '{ "lazy_load_members" : true }',
+               from => $token,
             },
          )
       })->then( sub {
@@ -210,12 +224,18 @@ sub matrix_get_room_messages
 
    $params{dir} ||= "b";
 
-   do_request_json_for( $user,
-      method => "GET",
-      uri    => "/r0/rooms/$room_id/messages",
+   matrix_sync($user)->then( sub {
+      my ( $sync_body ) = @_;
 
-      params => \%params,
-   );
+      $params{from} ||= $sync_body->{next_batch};
+
+      do_request_json_for( $user,
+         method => "GET",
+         uri    => "/r0/rooms/$room_id/messages",
+
+         params => \%params,
+      );
+   });
 }
 
 sub matrix_send_room_text_message_synced

--- a/tests/10apidoc/34room-messages.pl
+++ b/tests/10apidoc/34room-messages.pl
@@ -138,10 +138,10 @@ test "GET /rooms/:room_id/messages returns a message",
       matrix_send_room_text_message( $user, $room_id,
          body => "Here is the message content",
       )->then( sub {
-         matrix_sync($user)
+         matrix_sync( $user )
       })->then( sub {
          my ( $sync_body ) = @_;
-         my $token = $sync_body->{next_batch};
+         my $token = $sync_body->{rooms}->{join}->{$room_id}->{timeline}->{next_batch};
 
          do_request_json_for( $user,
             method => "GET",
@@ -176,16 +176,15 @@ test "GET /rooms/:room_id/messages lazy loads members correctly",
       matrix_send_room_text_message( $user, $room_id,
          body => "Here is the message content",
       )->then( sub {
-         matrix_sync($user)
+         matrix_sync( $user )
       })->then( sub {
          my ( $sync_body ) = @_;
-         my $token = $sync_body->{next_batch};
+         my $token = $sync_body->{rooms}->{join}->{$room_id}->{timeline}->{next_batch};
 
          do_request_json_for( $user,
             method => "GET",
             uri    => "/r0/rooms/$room_id/messages",
 
-            # With no params this does "forwards from END"; i.e. nothing useful
             params => {
                dir => "b",
                filter => '{ "lazy_load_members" : true }',
@@ -224,7 +223,7 @@ sub matrix_get_room_messages
 
    $params{dir} ||= "b";
 
-   matrix_sync($user)->then( sub {
+   matrix_sync( $user )->then( sub {
       my ( $sync_body ) = @_;
 
       $params{from} ||= $sync_body->{next_batch};


### PR DESCRIPTION
This is #532 except I messed up and somehow merged it into `develop`, so I reverted that and am opening the PR again.

Original initial comment from the original PR:

While Synapse supports requests to `/messages` without a `from` query parameter, the specs mentions it as required (cf https://matrix.org/docs/spec/client_server/r0.4.0.html#get-matrix-client-r0-rooms-roomid-messages), therefore SyTest should always call this endpoint with this parameter set.

This PR adds a request to `/sync` before every request to `/messages` and uses the value of the `prev_batch` field from the `/sync` response as the value for `/message`'s `from` parameter.

Unresolved (at the time I'm writing this) review available in the original PR. Will solve it (soon-ish) then re-request a review.