### PR TITLE
Add configuration for recaptcha auth to Dendrite

### DIFF
--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -109,6 +109,15 @@ sub _get_config
          private_key => $self->{paths}{matrix_key},
          federation_certificates => [$self->{paths}{tls_cert}],
          registration_shared_secret => "reg_secret",
+
+         $self->{recaptcha_config} ? (
+            # here "true" gets written as a quote-less string, which in yaml is
+            # a boolean value
+            enable_registration_captcha => "true",
+            recaptcha_siteverify_api => $self->{recaptcha_config}->{siteverify_api},
+            recaptcha_public_key     => $self->{recaptcha_config}->{public_key},
+            recaptcha_private_key    => $self->{recaptcha_config}->{private_key},
+         ) : (),
       },
 
       media => {


### PR DESCRIPTION
Allows sytest to configure recaptcha registration/login on Dendrite.