### PR TITLE
Ensure encryption state is copied on room upgrade

### DIFF
--- a/tests/30rooms/60version_upgrade.pl
+++ b/tests/30rooms/60version_upgrade.pl
@@ -298,6 +298,7 @@ test "/upgrade copies important state to the new room",
          "m.room.guest_access" => { guest_access => "forbidden" },
          "m.room.history_visibility" => { history_visibility => "joined" },
          "m.room.avatar" => { url => "http://something" },
+         "m.room.encryption" => { algorithm => "m.megolm.v1.aes-sha2" },
       );
 
       my $f = Future->done(1);


### PR DESCRIPTION
Requests to check `m.room.encryption` events are copied over on a room upgrade.