### PR TITLE
Test sending v2 invites to server

### DIFF
--- a/lib/SyTest/Federation/Client.pm
+++ b/lib/SyTest/Federation/Client.pm
@@ -119,7 +119,7 @@ sub send_transaction
    $self->do_request_json(
       method   => "PUT",
       hostname => $params{destination},
-      uri      => "/send/$ts/",
+      uri      => "/v1/send/$ts/",
 
       content => \%transaction,
    );
@@ -176,7 +176,7 @@ sub join_room
    $self->do_request_json(
       method   => "GET",
       hostname => $server_name,
-      uri      => "/make_join/$room_id/$user_id"
+      uri      => "/v1/make_join/$room_id/$user_id"
    )->then( sub {
       my ( $body ) = @_;
 
@@ -197,7 +197,7 @@ sub join_room
       $self->do_request_json(
          method   => "PUT",
          hostname => $server_name,
-         uri      => "/send_join/$room_id/$member_event{event_id}",
+         uri      => "/v1/send_join/$room_id/$member_event{event_id}",
 
          content => \%member_event,
       )->then( sub {
@@ -253,7 +253,7 @@ sub get_remote_forward_extremities
    $self->do_request_json(
       method   => "GET",
       hostname => $server_name,
-      uri      => "/make_join/$room_id/$user_id",
+      uri      => "/v1/make_join/$room_id/$user_id",
    )->then( sub {
       my ( $resp ) = @_;
 

--- a/tests/50federation/00prepare.pl
+++ b/tests/50federation/00prepare.pl
@@ -48,7 +48,7 @@ sub create_federation_server
 
       my $outbound_client = SyTest::Federation::Client->new(
          datastore => $datastore,
-         uri_base  => "/_matrix/federation/v1",
+         uri_base  => "/_matrix/federation",
         );
       $loop->add( $outbound_client );
 

--- a/tests/50federation/10query-profile.pl
+++ b/tests/50federation/10query-profile.pl
@@ -57,7 +57,7 @@ test "Inbound federation can query profile data",
          $outbound_client->do_request_json(
             method   => "GET",
             hostname => $info->server_name,
-            uri      => "/query/profile",
+            uri      => "/v1/query/profile",
 
             params => {
                user_id => $user->user_id,

--- a/tests/50federation/11query-directory.pl
+++ b/tests/50federation/11query-directory.pl
@@ -71,7 +71,7 @@ test "Inbound federation can query room alias directory",
          $outbound_client->do_request_json(
             method   => "GET",
             hostname => $first_home_server,
-            uri      => "/query/directory",
+            uri      => "/v1/query/directory",
 
             params => {
                room_alias => $room_alias,

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -219,7 +219,7 @@ test "Inbound federation can receive room-join requests",
       $outbound_client->do_request_json(
          method   => "GET",
          hostname => $first_home_server,
-         uri      => "/make_join/$room_id/$user_id",
+         uri      => "/v1/make_join/$room_id/$user_id",
       )->then( sub {
          my ( $body ) = @_;
          log_if_fail "make_join body", $body;
@@ -278,7 +278,7 @@ test "Inbound federation can receive room-join requests",
          $outbound_client->do_request_json(
             method   => "PUT",
             hostname => $first_home_server,
-            uri      => "/send_join/$room_id/$event{event_id}",
+            uri      => "/v1/send_join/$room_id/$event{event_id}",
 
             content => \%event,
          )
@@ -356,7 +356,7 @@ test "Inbound federation rejects attempts to join v1 rooms from servers without 
          $outbound_client->do_request_json(
             method   => "GET",
             hostname => $first_home_server,
-            uri      => "/make_join/$room_id/$user_id",
+            uri      => "/v1/make_join/$room_id/$user_id",
             params   => {
                ver => [qw/2 abc def/],
             },
@@ -393,7 +393,7 @@ test "Inbound federation rejects attempts to join v2 rooms from servers lacking 
          $outbound_client->do_request_json(
             method   => "GET",
             hostname => $first_home_server,
-            uri      => "/make_join/$room_id/$user_id",
+            uri      => "/v1/make_join/$room_id/$user_id",
          );
       })->main::expect_http_400()
       ->then( sub {
@@ -427,7 +427,7 @@ test "Inbound federation rejects attempts to join v2 rooms from servers only sup
          $outbound_client->do_request_json(
             method   => "GET",
             hostname => $first_home_server,
-            uri      => "/make_join/$room_id/$user_id",
+            uri      => "/v1/make_join/$room_id/$user_id",
             params   => {
                ver => ["1"],
             },
@@ -464,7 +464,7 @@ test "Inbound federation accepts attempts to join v2 rooms from servers with sup
          $outbound_client->do_request_json(
             method   => "GET",
             hostname => $first_home_server,
-            uri      => "/make_join/$room_id/$user_id",
+            uri      => "/v1/make_join/$room_id/$user_id",
             params   => {
                ver => [qw/abc vdh-test-version def/],
             },

--- a/tests/50federation/32room-getevent.pl
+++ b/tests/50federation/32room-getevent.pl
@@ -24,7 +24,7 @@ test "Inbound federation can return events",
          $outbound_client->do_request_json(
             method   => "GET",
             hostname => $first_home_server,
-            uri      => "/event/$member_event->{event_id}/",
+            uri      => "/v1/event/$member_event->{event_id}/",
          );
       })->then( sub {
          my ( $body ) = @_;
@@ -73,7 +73,7 @@ test "Inbound federation redacts events from erased users",
          $outbound_client->do_request_json(
             method   => "GET",
             hostname => $first_home_server,
-            uri      => "/event/$message_id/",
+            uri      => "/v1/event/$message_id/",
          );
       })->then( sub {
          my ( $body ) = @_;
@@ -96,7 +96,7 @@ test "Inbound federation redacts events from erased users",
          $outbound_client->do_request_json(
             method   => "GET",
             hostname => $first_home_server,
-            uri      => "/event/$message_id/",
+            uri      => "/v1/event/$message_id/",
          );
       })->then( sub {
          my ( $body ) = @_;

--- a/tests/50federation/33room-get-missing-events.pl
+++ b/tests/50federation/33room-get-missing-events.pl
@@ -136,7 +136,7 @@ foreach my $vis (qw( world_readable shared invite joined )) {
             $outbound_client->do_request_json(
                method   => "POST",
                hostname => $first_home_server,
-               uri      => "/get_missing_events/" . $room->room_id,
+               uri      => "/v1/get_missing_events/" . $room->room_id,
 
                content => {
                   earliest_events => [ $creation_event->{event_id} ],

--- a/tests/50federation/34room-backfill.pl
+++ b/tests/50federation/34room-backfill.pl
@@ -157,7 +157,7 @@ test "Inbound federation can backfill events",
          $outbound_client->do_request_json(
             method   => "GET",
             hostname => $first_home_server,
-            uri      => "/backfill/$room_id/",
+            uri      => "/v1/backfill/$room_id/",
 
             params => {
                v     => $join_event->{prev_events}[0][0],
@@ -219,7 +219,7 @@ test "Backfill checks the events requested belong to the room",
          $outbound_client->do_request_json(
             method   => "GET",
             hostname => $first_home_server,
-            uri      => "/backfill/$pub_room_id/",
+            uri      => "/v1/backfill/$pub_room_id/",
 
             params => {
                v     => $priv_event_id,

--- a/tests/50federation/35room-invite.pl
+++ b/tests/50federation/35room-invite.pl
@@ -71,7 +71,7 @@ test "Inbound federation can receive invites",
 
 sub invite_server
 {
-   my ( $room, $creator_id, $user, $inbound_server) = @_;
+   my ( $room, $creator_id, $user, $inbound_server ) = @_;
 
    my $outbound_client = $inbound_server->client;
    my $first_home_server = $user->http->server_name;
@@ -110,7 +110,7 @@ sub invite_server
      $outbound_client->do_request_json(
          method   => "PUT",
          hostname => $first_home_server,
-         uri      => "/invite/$room_id/$invitation->{event_id}",
+         uri      => "/v1/invite/$room_id/$invitation->{event_id}",
 
          content => $invitation,
      )->then( sub {

--- a/tests/50federation/35room-invite.pl
+++ b/tests/50federation/35room-invite.pl
@@ -212,8 +212,8 @@ sub do_v1_invite_request
    )->then( sub {
       my ( $response ) = @_;
 
-      # $response seems to arrive with an extraneous layer of wrapping as
-      # the result of a synapse implementation bug (SYN-490).
+      # $response arrives with an extraneous layer of wrapping as the result of
+      # a synapse implementation bug (matrix-org/synapse#1383).
       (ref $response eq "ARRAY") or die "V1 invite response must be an array";
 
       $response->[0] == 200 or

--- a/tests/50federation/36-state.pl
+++ b/tests/50federation/36-state.pl
@@ -4,7 +4,7 @@ sub get_state_ids_from_server {
    return $outbound_client->do_request_json(
       method   => "GET",
       hostname => $server,
-      uri      => "/state_ids/$room_id/",
+      uri      => "/v1/state_ids/$room_id/",
       params   => { event_id => $event_id },
    );
 }
@@ -32,7 +32,7 @@ test "Inbound federation can get state for a room",
          $outbound_client->do_request_json(
             method   => "GET",
             hostname => $first_home_server,
-            uri      => "/state/$room_id/",
+            uri      => "/v1/state/$room_id/",
             params   => {
                event_id => $room->{prev_events}[-1]->{event_id},
             }
@@ -635,7 +635,7 @@ test "Getting state checks the events requested belong to the room",
          $outbound_client->do_request_json(
             method   => "GET",
             hostname => $first_home_server,
-            uri      => "/state/$pub_room_id/",
+            uri      => "/v1/state/$pub_room_id/",
 
             params => {
                event_id => $priv_event_id,
@@ -677,7 +677,7 @@ test "Getting state IDs checks the events requested belong to the room",
          $outbound_client->do_request_json(
             method   => "GET",
             hostname => $first_home_server,
-            uri      => "/state_ids/$pub_room_id/",
+            uri      => "/v1/state_ids/$pub_room_id/",
 
             params => {
                event_id => $priv_event_id,

--- a/tests/50federation/37public-rooms.pl
+++ b/tests/50federation/37public-rooms.pl
@@ -30,7 +30,7 @@ test "Inbound federation can get public room list",
             $outbound_client->do_request_json(
                method   => "GET",
                hostname => $first_home_server,
-               uri      => "/publicRooms",
+               uri      => "/v1/publicRooms",
             )->then( sub {
                my ( $body ) = @_;
 

--- a/tests/50federation/42query-auth.pl
+++ b/tests/50federation/42query-auth.pl
@@ -32,7 +32,7 @@ test "Querying auth checks the events requested belong to the room",
          $outbound_client->do_request_json(
             method   => "POST",
             hostname => $first_home_server,
-            uri      => "/query_auth/$pub_room_id/$priv_event_id",
+            uri      => "/v1/query_auth/$pub_room_id/$priv_event_id",
 
             content => {
                auth_chain => [], # This is part of the exploit


### PR DESCRIPTION
This PR is in two parts.

In the second part I've tried to reuse as much code as possible between `invite_server` using v1 and v2 APIs, but it feels fairly ming :/   Alternate suggestions welcome.

Tests https://github.com/matrix-org/synapse/pull/4402