### PR TITLE
close sockets when stopping federation

### DIFF
--- a/tests/50federation/35room-invite.pl
+++ b/tests/50federation/35room-invite.pl
@@ -302,6 +302,13 @@ foreach my $error_code ( 403, 500, -1 ) {
                # error on make_leave
                $federation_server->close();
 
+               # close any connected sockets too, otherwise synapse will
+               # just reuse the connection.
+               foreach my $child ( $federation_server->children() ) {
+                  log_if_fail "closing", $child;
+                  $child->close();
+               }
+
                return matrix_leave_room( $user, $room_id );
             }
             else {


### PR DESCRIPTION
when we stop a federation server, we need to close the active sockets too, otherwise they hang around like zombies.

mmm, brainz.

(This is needed to make https://github.com/matrix-org/synapse/pull/4427 pass)