### PR TITLE
Add tests for transfer of tags and dm status on room upgrade

### DIFF
--- a/tests/30rooms/60version_upgrade.pl
+++ b/tests/30rooms/60version_upgrade.pl
@@ -75,27 +75,25 @@ sub is_direct_room {
    my ( $user, $room_id ) = @_;
 
    # Download account data events from sync
-   matrix_sync( $user )->then( sub {
-      my ( $sync_body ) = @_;
-
+   matrix_get_account_data( $user, "m.direct" )->then( sub {
       # Should only have the m.direct event in account_data
-      my $account_data = $sync_body->{account_data}{events};
+      my ( $data ) = @_;
+
+      log_if_fail "m.direct account data", $data;
 
       # Check if the room_id is in the list of direct rooms
-      foreach my $event ( @$account_data ) {
-         if ( $event->{type} eq "m.direct" ) {
-            my $room_ids = $event->{content}{$user->user_id};
+      foreach my $user_id ( keys %{ $data } ) {
+         my $room_ids = $data->{$user_id};
 
-            # Return whether the given room ID is in the response
-            foreach my $rid (@$room_ids) {
-               if ( $rid eq $room_id ) {
-                  return Future->done( 1 );
-               }
+         # Return whether the given room ID is in the response
+         foreach my $room (@$room_ids) {
+            if ( $room eq $room_id ) {
+               return Future->done( 1 );
             }
          }
       }
 
-      # Didn't find an m.direct event with our room ID
+      # Didn't find an direct romo with our room ID
       Future->done( 0 );
    });
 }

--- a/tests/30rooms/60version_upgrade.pl
+++ b/tests/30rooms/60version_upgrade.pl
@@ -106,9 +106,14 @@ sub upgrade_room_synced {
          my ( $sync_body, $new_room_id ) = @_;
          return 0 if not exists $sync_body->{rooms}{join}{$new_room_id};
          my $tl = $sync_body->{rooms}{join}{$new_room_id}{timeline}{events};
+         my $st = $sync_body->{rooms}{join}{$new_room_id}{state}{events};
          log_if_fail "New room timeline", $tl;
+         log_if_fail "New room state", $st;
 
          foreach my $ev ( @$tl ) {
+            $received_event_counts{$ev->{type}} += 1;
+         }
+         foreach my $ev ( @$st ) {
             $received_event_counts{$ev->{type}} += 1;
          }
 

--- a/tests/30rooms/60version_upgrade.pl
+++ b/tests/30rooms/60version_upgrade.pl
@@ -93,7 +93,7 @@ sub is_direct_room {
          }
       }
 
-      # Didn't find an direct romo with our room ID
+      # Didn't find a direct room with our room ID
       Future->done( 0 );
    });
 }


### PR DESCRIPTION
Synapse PR: https://github.com/matrix-org/synapse/pull/4412

Adds 2 tests to check that the same room tags and `m.direct` status is set on a room before and after an upgrade.