### PR TITLE
Print sytest sha1 during CI run

### DIFF
--- a/docker/synapse_sytest.sh
+++ b/docker/synapse_sytest.sh
@@ -24,6 +24,9 @@ else
 
 fi
 
+sytest_commit="$(git rev-parse HEAD)" || sytest_commit="Unknown"
+echo "Running on sytest commit $sytest_commit"
+
 # PostgreSQL setup
 if [ -n "$POSTGRES" ]
 then


### PR DESCRIPTION
To address https://riot.im/experimental/#/room/#synapse-dev:matrix.org/$154816555286JknwK:sw1v.org

Prints the commit hash of sytest that we're using for a run.