### PR TITLE
Remove unnecessary method argument for matrix_get_room_account_data

### DIFF
--- a/tests/10apidoc/44account_data.pl
+++ b/tests/10apidoc/44account_data.pl
@@ -62,7 +62,7 @@ sub matrix_get_account_data
 
 =head2 matrix_get_room_account_data
 
-    matrix_get_account_data( $user, $room_id, $type, $content )->get;
+    matrix_get_account_data( $user, $room_id, $type )->get;
 
 Get account data for the user for a room.
 
@@ -70,7 +70,7 @@ Get account data for the user for a room.
 
 sub matrix_get_room_account_data
 {
-   my ( $user, $room_id, $type, $content ) = @_;
+   my ( $user, $room_id, $type ) = @_;
 
    do_request_json_for( $user,
       method  => "GET",


### PR DESCRIPTION
Presumably a copy/paste error, but we don't need a $content argument in this function.

No functions pass one in anyways.