### PR TITLE
Don't set PYTHONPATH when running synapse

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -220,12 +220,6 @@ sub start
       }
    }
 
-   my $pythonpath = (
-      exists $ENV{PYTHONPATH}
-      ? "$self->{synapse_dir}:$ENV{PYTHONPATH}"
-      : "$self->{synapse_dir}"
-   );
-
    my @synapse_command = ( $self->{python} );
 
    if( $self->{coverage} ) {
@@ -248,7 +242,6 @@ sub start
    my @command = $self->wrap_synapse_command( @synapse_command );
 
    my $env = {
-      "PYTHONPATH" => $pythonpath,
       "PATH" => $ENV{PATH},
       "PYTHONDONTWRITEBYTECODE" => "Don't write .pyc files",
    };


### PR DESCRIPTION
Setting PYTHONPATH runs the risk of picking up random files from elsewhere in
the synapse readme (for instance, we might accidentally import something from
the 'tests' hierarchy).

Our recommendation for installing synapse (and what the sytest docker image
does) is to install it into the virtualenv. This means that there is no need to
set PYTHONPATH any more.