### PR TITLE
Better diagnostics from synapse startup

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -94,6 +94,7 @@ sub start
 {
    my $self = shift;
 
+   my $hs_index = $self->{hs_index};
    my $port = $self->{ports}{synapse};
    my $output = $self->{output};
 
@@ -242,10 +243,13 @@ sub start
    $output->diag( "Generating config for port $port" );
 
    my @config_command = (
-      @synapse_command, "--generate-config", "--report-stats=no"
+      @synapse_command, "--generate-config", "--report-stats=no",
    );
 
-   my @command = $self->wrap_synapse_command( @synapse_command );
+   my @command = (
+      $self->wrap_synapse_command( @synapse_command ),
+      @{ $self->{extra_args} },
+   );
 
    my $env = {
       "PYTHONPATH" => $pythonpath,
@@ -257,27 +261,33 @@ sub start
 
    my $started_future = $loop->new_future;
 
-   $output->diag( "Starting server with command " . join( " ", @config_command ));
+   $output->diag(
+      "Creating config for server $hs_index with command "
+         . join( " ", @config_command ),
+   );
 
-   $loop->run_child(
+   $loop->open_process(
       setup => [ env => $env ],
-
       command => [ @config_command ],
 
       on_finish => sub {
-         my ( $pid, $exitcode, $stdout, $stderr ) = @_;
+         my ( $proc, $exitcode ) = @_;
 
          if( $exitcode != 0 ) {
-            $started_future->fail( "Server failed to start: exitcode " . ( $exitcode >> 8 ));
+            $started_future->fail( "Server failed to generate config: exitcode " . ( $exitcode >> 8 ));
             return
          }
 
-         $output->diag( "Starting server for port $port" );
+         $output->diag(
+            "Starting server $hs_index for port $port with command "
+               . join( " ", @command ),
+         );
+
          $self->add_child(
             $self->{proc} = IO::Async::Process->new(
                setup => [ env => $env ],
 
-               command => [ @command, @{ $self->{extra_args} } ],
+               command => \@command,
 
                on_finish => $self->_capture_weakself( 'on_finish' ),
             )
@@ -387,16 +397,18 @@ sub on_finish
    my $self = shift;
    my ( $process, $exitcode ) = @_;
 
+   my $hs_index = $self->{hs_index};
+
    say $self->pid . " stopped";
 
    my $port = $self->{ports}{synapse};
 
    if( $exitcode > 0 ) {
       if( WIFEXITED($exitcode) ) {
-         warn "Main homeserver process exited " . WEXITSTATUS($exitcode) . "\n";
+         warn "Main homeserver process for server $hs_index exited " . WEXITSTATUS($exitcode) . "\n";
       }
       else {
-         warn "Main homeserver process failed - code=$exitcode\n";
+         warn "Main homeserver process for server $hs_index failed - code=$exitcode\n";
       }
 
       print STDERR "\e[1;35m[server $port}]\e[m: $_\n"


### PR DESCRIPTION
* Include the server number in starting/stopping messages
* Be clear whether it's the config-gen or main process which is failing
* Don't swallow stdout/err from the config-gen process