### PR TITLE
Enable synapse replication torturing

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -201,11 +201,6 @@ sub start
         # so this is effectively the minimum.
         bcrypt_rounds => 4,
 
-        # torture the replication protocol a bit, to replicate bugs.
-        # (value is the number of ms to wait before sending out each batch of
-        # updates.)
-        replication_torture_level => 50,
-
         # If we're using dendron-style split workers, we need to disable these
         # things in the main process
         start_pushers         => ( not $self->{dendron} ),
@@ -231,6 +226,7 @@ sub start
         map {
            defined $self->{$_} ? ( $_ => $self->{$_} ) : ()
         } qw(
+           replication_torture_level
            cas_config
            app_service_config_files
         ),
@@ -597,6 +593,12 @@ sub _init
    $self->SUPER::_init( @_ );
 
    $self->{dendron} = delete $args->{dendron_binary};
+   if( delete $args->{torture_replication} ) {
+      # torture the replication protocol a bit, to replicate bugs.
+      # (value is the number of ms to wait before sending out each batch of
+      # updates.)
+      $self->{replication_torture_level} = 50;
+   }
 
    my $idx = $self->{hs_index};
    $self->{ports}{dendron} = main::alloc_port( "dendron[$idx]" );

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -194,15 +194,17 @@ sub start
 
         perspectives => { servers => {} },
 
-        # Stack traces are useful
-        full_twisted_stacktraces => "true",
-
         listeners => $listeners,
 
         # we reduce the number of bcrypt rounds to make generating users
         # faster, but note that python's bcrypt complains if rounds < 4,
         # so this is effectively the minimum.
         bcrypt_rounds => 4,
+
+        # torture the replication protocol a bit, to replicate bugs.
+        # (value is the number of ms to wait before sending out each batch of
+        # updates.)
+        replication_torture_level => 50,
 
         # If we're using dendron-style split workers, we need to disable these
         # things in the main process

--- a/lib/SyTest/HomeserverFactory/Synapse.pm
+++ b/lib/SyTest/HomeserverFactory/Synapse.pm
@@ -75,7 +75,6 @@ sub print_usage
 
    -ENAME, -ENAME=VALUE         - pass extra argument NAME or NAME=VALUE to the
                                   homeserver.
-
 EOF
 }
 
@@ -112,6 +111,7 @@ sub _init
    $self->SUPER::_init( @_ );
    $self->{impl} = "SyTest::Homeserver::Synapse::ViaDendron";
    $self->{args}{dendron_binary} = "";
+   $self->{args}{torture_replication} = 0;
 }
 
 sub get_options
@@ -120,6 +120,7 @@ sub get_options
 
    return (
       'dendron-binary=s' => \$self->{args}{dendron_binary},
+      'torture-replication+' => \$self->{args}{torture_replication},
       $self->SUPER::get_options(),
    );
 }
@@ -133,6 +134,8 @@ sub print_usage
    print STDERR <<EOF;
 
        --dendron-binary PATH    - path to the 'dendron' binary
+
+       --torture-replication    - enable torturing of the replication protocol
 EOF
 }
 


### PR DESCRIPTION
See https://github.com/matrix-org/synapse/pull/4902 for the synapse bit of this

(and kill off old unused option)

I'm not actually sure if we want to enable this before we've had a chance to fix the failures it introduces?