### PR TITLE
Fix apt incantation in dockerfiles

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,8 +3,7 @@ FROM debian:stretch
 ENV DEBIAN_FRONTEND noninteractive
 
 # Install base dependencies that Python or Go would require
-RUN apt-get -qq update
-RUN apt-get -qq install -y \
+RUN apt-get -qq update && apt-get -qq install -y \
     build-essential \
     perl \
     wget \

--- a/docker/Dockerfile-synapsepy2
+++ b/docker/Dockerfile-synapsepy2
@@ -1,7 +1,7 @@
 FROM matrixdotorg/sytest:latest
 
-RUN apt-get -qq update
-RUN apt-get -qq install -y python python-dev python-virtualenv dos2unix eatmydata
+RUN apt-get -qq update && apt-get -qq install -y \
+    python python-dev python-virtualenv dos2unix eatmydata
 
 ENV PYTHON=python2
 ENV PGDATA=/var/lib/postgresql/data

--- a/docker/Dockerfile-synapsepy3
+++ b/docker/Dockerfile-synapsepy3
@@ -1,7 +1,7 @@
 FROM matrixdotorg/sytest:latest
 
-RUN apt-get -qq update
-RUN apt-get -qq install -y python3 python3-dev python3-virtualenv dos2unix eatmydata
+RUN apt-get -qq update && apt-get -qq install -y \
+    python3 python3-dev python3-virtualenv dos2unix eatmydata
 
 ENV PYTHON=python3
 ENV PGDATA=/var/lib/postgresql/data


### PR DESCRIPTION
We need to combine the update and install into one dockerfile command. If we do
not, docker can choose to use a cached version of (base image + `apt-get
update`), which is out-of-date, so that the install fails.

Combining them into one RUN command means that docker will always run the
update if it's going to run the install.