### PR TITLE
Fix up rejected pusher tests and add helper functions

### DIFF
--- a/run-tests.pl
+++ b/run-tests.pl
@@ -794,7 +794,10 @@ sub SyTest::pass_on_done
 {
    my $self = shift;
    my ( $message ) = @_;
-   $self->on_done( sub { $RUNNING_TEST->ok( 1, $message ) } );
+   $self->on_done( sub {
+      log_if_fail "Passed stage: $message";
+      $RUNNING_TEST->ok( 1, $message )
+   } );
 }
 
 sub list_symbols

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -451,6 +451,38 @@ sub log_if_fail
    push @log_if_fail_lines, split m/\n/, pp( $structure ) if @_ > 1;
 }
 
+
+=head2 wait_for_while
+
+   wait_for_while( $future, $do )
+
+Repeatedly calls function $do until $future resolves. Used when it is necessary
+to do an action several times before a condition happens.
+
+=cut
+
+sub wait_for_while
+{
+   my ( $wait_f, $do ) = @_;
+
+   my $finished = 0;
+
+   Future->needs_all(
+      $wait_f->then( sub {
+         $finished = 1;
+
+         Future->done( 1 )
+      }),
+      repeat_until_true {
+         $do->()
+         ->then( sub {
+            Future->done( $finished )
+         })
+      }
+   )
+}
+
+
 struct Fixture => [qw( name requires start result teardown )], predicate => "is_Fixture";
 
 my $fixture_count = 0;


### PR DESCRIPTION
The sytest HTTP server will drop incoming requests on the floor if no tests are actively awaiting on the path, which is problematic for things like pushers where synapse waits for previous requests to complete before attempting new ones. This leads to races where a request is sent before/after the test has called `await_http_request`. To fix this, we add a concept of "default responders", i.e. handlers that will get called for registered paths when no tests are currently awaiting.

We also add a `wait_for_while` helper function that repeatedly calls a function until a future resolves, making it easier to e.g. keep sending messages until the sytest receives a push