### PR TITLE
Print whether a pass on an expected fail occurred in TAP results

### DIFF
--- a/lib/SyTest/Output/TAP.pm
+++ b/lib/SyTest/Output/TAP.pm
@@ -131,19 +131,22 @@ package SyTest::Output::TAP::Test {
          $self->failure = "${\$self->failed} subtests failed" if $self->failed and not length $self->failure;
       }
 
+      my $name = $self->name;
+
       if( !$self->failed ) {
-         my $name = $self->name;
          $name .= " (${\$self->subnum} subtests)" if $self->multi;
 
-         print "ok ${\$self->num} $name\n";
-      }
-      else {
+         print "ok ${\$self->num} " .
+            ( $self->expect_fail ? "(expected fail) " : "" ) .
+            $name .
+            ( $self->expect_fail ? " # TODO passed but expected fail" : "" ) . "\n";
+      } else {
          # for expected fails, theoretically all we need to do is write the
          # TODO, but Jenkins' 'TAP Test results' page is arse and doesn't distinguish
          # between expected and unexpected fails, so stick it in the name too.
          print "not ok ${\$self->num} " .
             ( $self->expect_fail ? "(expected fail) " : "" ) .
-            $self->name .
+            $name .
             ( $self->expect_fail ? " # TODO expected fail" : "" ) . "\n";
 
          print "# $_\n" for split m/\n/, $self->failure;


### PR DESCRIPTION
#452 brought white/blacklist sytest features which we make use of in Dendrite. Our specific use case involves having a set of known tests that Dendrite passes on (and thus the CI runs on), and people can grow the list alongside their feature/bugfix PRs. Test that do not fit into the white/blacklist are not skipped, but marked as "Expected fail", specifically so that they would still run, however if a test passed that wasn't on the white/blacklist, we would become aware of including it.

The only problem is that the message telling you that a test passed on expected fail isn't printed in TAP results, which is what we'd be using in our CI setup. Thus this PR was born to add this output to TAP results as well. We already do this for when a test fails, but we need it for when an expected fail test passes as well.

### TL;DR

We're whitelisting Test 1, GET /register yields a set of flows. Can you spot the difference in output?

Before this change:

```
# Started server-0
ok 1 GET /register yields a set of flows
    Test 2 POST /register can create a user...
ok 2 POST /register can create a user
    Test 3 POST /register downcases capitals in usernames...
ok 3 POST /register downcases capitals in usernames
    Test 4 POST /register rejects registration of usernames with '!'...
ok 4 POST /register rejects registration of usernames with '!'
    Test 5 POST /register rejects registration of usernames with '"'...
ok 5 POST /register rejects registration of usernames with '"'
    Test 6 POST /register rejects registration of usernames with ':'...
ok 6 POST /register rejects registration of usernames with ':'
    Test 7 POST /register rejects registration of usernames with '?'...
ok 7 POST /register rejects registration of usernames with '?'
    Test 8 POST /register rejects registration of usernames with '\'...
ok 8 POST /register rejects registration of usernames with '\'
    Test 9 POST /register rejects registration of usernames with '@'...
ok 9 POST /register rejects registration of usernames with '@'
    Test 10 POST /register rejects registration of usernames with '['...
ok 10 POST /register rejects registration of usernames with '['
    Test 11 POST /register rejects registration of usernames with ']'...
```

After this change:

```
# Started server-0
ok 1 GET /register yields a set of flows
    Test 2 POST /register can create a user...
ok 2 (expected fail) POST /register can create a user # TODO passed but expected fail
    Test 3 POST /register downcases capitals in usernames...
ok 3 (expected fail) POST /register downcases capitals in usernames # TODO passed but expected fail
    Test 4 POST /register rejects registration of usernames with '!'...
ok 4 (expected fail) POST /register rejects registration of usernames with '!' # TODO passed but expected fail
    Test 5 POST /register rejects registration of usernames with '"'...
ok 5 (expected fail) POST /register rejects registration of usernames with '"' # TODO passed but expected fail
    Test 6 POST /register rejects registration of usernames with ':'...
ok 6 (expected fail) POST /register rejects registration of usernames with ':' # TODO passed but expected fail
    Test 7 POST /register rejects registration of usernames with '?'...
ok 7 (expected fail) POST /register rejects registration of usernames with '?' # TODO passed but expected fail
    Test 8 POST /register rejects registration of usernames with '\'...
ok 8 (expected fail) POST /register rejects registration of usernames with '\' # TODO passed but expected fail
    Test 9 POST /register rejects registration of usernames with '@'...
ok 9 (expected fail) POST /register rejects registration of usernames with '@' # TODO passed but expected fail
    Test 10 POST /register rejects registration of usernames with '['...
```