### PR TITLE
Support for synapse#5124

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -217,6 +217,8 @@ sub start
 
         user_agent_suffix => "homeserver[". $self->{hs_index} . "]",
 
+        require_membership_for_aliases => "false",
+
         $self->{recaptcha_config} ? (
            recaptcha_siteverify_api => $self->{recaptcha_config}->{siteverify_api},
            recaptcha_public_key     => $self->{recaptcha_config}->{public_key},
@@ -230,8 +232,6 @@ sub start
            cas_config
            app_service_config_files
         ),
-
-        require_membership_for_aliases => "false",
    } );
 
    $self->{paths}{log} = $log;

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -230,6 +230,8 @@ sub start
            cas_config
            app_service_config_files
         ),
+
+        require_membership_for_aliases => "false",
    } );
 
    $self->{paths}{log} = $log;


### PR DESCRIPTION
Config changes for https://github.com/matrix-org/synapse/pull/5124

Longer term solution would be to not have sytest rely on setting aliases without being in the room.