### PR TITLE
Disable ip range federation blacklist under Sytest

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -201,6 +201,10 @@ sub start
         # so this is effectively the minimum.
         bcrypt_rounds => 4,
 
+        # We remove the ip range blacklist which by default blocks federation
+        # connections to local homeservers, of which sytest uses extensively
+        federation_ip_range_blacklist => [],
+
         # If we're using dendron-style split workers, we need to disable these
         # things in the main process
         start_pushers         => ( not $self->{dendron} ),


### PR DESCRIPTION
By default the federation blacklist prevents federation traffic to localhost addresses, which is upsetting to Sytest.

Disabled it in Sytest's config. Testing is instead done as part of Synapse's unit tests.

Synapse PR: https://github.com/matrix-org/synapse/pull/5043