### PR TITLE
Install go in dendrite docker file, remove extra dep from synapse

### DIFF
--- a/docker/Dockerfile-dendrite
+++ b/docker/Dockerfile-dendrite
@@ -1,6 +1,12 @@
 FROM matrixdotorg/sytest:latest
 
-RUN apt-get -qq install -y dos2unix
+# Install Go 1.11
+RUN mkdir -p /goroot /gopath
+RUN wget -q https://dl.google.com/go/go1.11.10.linux-amd64.tar.gz -O go.tar.gz
+RUN tar xf go.tar.gz -C /goroot --strip-components=1
+ENV GOROOT=/goroot
+ENV GOPATH=/gopath
+ENV PATH="/goroot/bin:${PATH}"
 
 # PostgreSQL setup
 ENV PGHOST=/var/run/postgresql

--- a/docker/Dockerfile-synapsepy2
+++ b/docker/Dockerfile-synapsepy2
@@ -1,7 +1,7 @@
 FROM matrixdotorg/sytest:latest
 
 RUN apt-get -qq update && apt-get -qq install -y \
-    python python-dev python-virtualenv dos2unix eatmydata
+    python python-dev python-virtualenv eatmydata
 
 ENV PYTHON=python2
 ENV PGDATA=/var/lib/postgresql/data

--- a/docker/Dockerfile-synapsepy3
+++ b/docker/Dockerfile-synapsepy3
@@ -1,7 +1,7 @@
 FROM matrixdotorg/sytest:latest
 
 RUN apt-get -qq update && apt-get -qq install -y \
-    python3 python3-dev python3-virtualenv dos2unix eatmydata
+    python3 python3-dev python3-virtualenv eatmydata
 
 ENV PYTHON=python3
 ENV PGDATA=/var/lib/postgresql/data

--- a/docker/dendrite_sytest.sh
+++ b/docker/dendrite_sytest.sh
@@ -57,6 +57,6 @@ rsync --ignore-missing-args -av server-0 server-1 /logs --include "*/" --include
 
 # Write out JUnit for CircleCI
 mkdir -p /logs/sytest
-perl /tap-to-junit-xml.pl --puretap --input=/logs/results.tap --output=/logs/sytest/results.xml "SyTest"
+perl ./tap-to-junit-xml.pl --puretap --input=/logs/results.tap --output=/logs/sytest/results.xml "SyTest"
 
 exit $TEST_STATUS


### PR DESCRIPTION
Dendrite's docker file didn't have `go` installed which is necessary for CircleCI on Dendrite's repo. It also had an incorrect path for the `tap-to-junit-xml.pl` script.

Additionally `dos2unix` was being installed in the `sytest` docker image, and then again in the `sytest-synapse*` images, so that was removed.