### PR TITLE
Use sytest develop for Dendrite master

### DIFF
--- a/docker/dendrite_sytest.sh
+++ b/docker/dendrite_sytest.sh
@@ -11,6 +11,10 @@ then
 else
     # Otherwise, try and find out what the branch that the Dendrite checkout is using. Fall back to develop if it's not a branch.
     branch_name="$(git --git-dir=/src/.git symbolic-ref HEAD 2>/dev/null)" || branch_name="develop"
+    
+    # If we're using the master branch of Dendrite, use the develop branch of sytest,
+    # as master is Dendrite's development branch
+    if [ "$branch_name" == "master" ] && branch_name="develop"
 
     # Try and fetch the branch
     echo "Trying to get same-named sytest branch..."


### PR DESCRIPTION
Dendrite's default development branch is `master`. However, this then means that when you submit a job for the `master` branch, you get the old `master` branch of Sytest. If you instead base off a custom branch such as `anoa/friendship`, you'll then get the more up-to-date `develop` branch of Sytest.

This is all sorts of wacko, so instead we just check to see if the test is for Dendrite's `master` branch, and if so make sure we use Sytest `develop`.