### PR TITLE
Fix bash typo in dendrite docker script

### DIFF
--- a/docker/dendrite_sytest.sh
+++ b/docker/dendrite_sytest.sh
@@ -14,7 +14,7 @@ else
     
     # If we're using the master branch of Dendrite, use the develop branch of sytest,
     # as master is Dendrite's development branch
-    if [ "$branch_name" == "master" ] && branch_name="develop"
+    [ "$branch_name" == "master" ] && branch_name="develop"
 
     # Try and fetch the branch
     echo "Trying to get same-named sytest branch..."


### PR DESCRIPTION
Short ifs don't actually have an `if`.

```
user@anoa:~/code/sytest/docker$ [ "bla" == "bla" ] && echo "hi"
hi
user@anoa:~/code/sytest/docker$ [ "bla" == "bla2" ] && echo "hi"
user@anoa:~/code/sytest/docker$ 
```