### PR TITLE
Use v1 rooms for federation tests

### DIFF
--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -206,7 +206,7 @@ test "Outbound federation passes make_join failures through to the client",
 test "Inbound federation can receive room-join requests",
    requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
                  $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures(),
+                 local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                  federation_user_id_fixture() ],
 
    do => sub {
@@ -350,6 +350,7 @@ test "Inbound federation rejects attempts to join v1 rooms from servers without 
 
       matrix_create_room(
          $creator_user,
+         room_version => "1",
       )->then( sub {
          my ( $room_id ) = @_;
 

--- a/tests/50federation/31room-send.pl
+++ b/tests/50federation/31room-send.pl
@@ -47,7 +47,10 @@ test "Outbound federation can send events",
 
 test "Inbound federation can receive events",
    requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures( user_opts => { with_events => 1 }),
+                 local_user_and_room_fixtures(
+                   user_opts => { with_events => 1 },
+                   room_opts => { room_version => "1" },
+                 ),
                  federation_user_id_fixture() ],
 
    do => sub {
@@ -94,7 +97,10 @@ test "Inbound federation can receive events",
 
 test "Inbound federation can receive redacted events",
    requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures( user_opts => { with_events => 1 }),
+                 local_user_and_room_fixtures(
+                   user_opts => { with_events => 1 },
+                   room_opts => { room_version => "1" },
+                 ),
                  federation_user_id_fixture() ],
 
    do => sub {

--- a/tests/50federation/32room-getevent.pl
+++ b/tests/50federation/32room-getevent.pl
@@ -1,6 +1,6 @@
 test "Inbound federation can return events",
    requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures(),
+                 local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                  federation_user_id_fixture() ],
 
    do => sub {
@@ -48,7 +48,7 @@ test "Inbound federation can return events",
 
 test "Inbound federation redacts events from erased users",
    requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures(),
+                 local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                  federation_user_id_fixture() ],
 
    do => sub {
@@ -118,4 +118,3 @@ test "Inbound federation redacts events from erased users",
          }
       });
    };
-

--- a/tests/50federation/33room-get-missing-events.pl
+++ b/tests/50federation/33room-get-missing-events.pl
@@ -1,6 +1,9 @@
 test "Outbound federation can request missing events",
    requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures( user_opts => { with_events => 1 }),
+                 local_user_and_room_fixtures(
+                    user_opts => { with_events => 1 },
+                    room_opts => { room_version => "1" },
+                   ),
                  federation_user_id_fixture() ],
 
    do => sub {
@@ -102,7 +105,7 @@ test "Outbound federation can request missing events",
 foreach my $vis (qw( world_readable shared invite joined )) {
    test "Inbound federation can return missing events for $vis visibility",
       requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
-                    local_user_and_room_fixtures(),
+                    local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                     federation_user_id_fixture() ],
 
       do => sub {

--- a/tests/50federation/34room-backfill.pl
+++ b/tests/50federation/34room-backfill.pl
@@ -131,7 +131,7 @@ test "Outbound federation can backfill events",
 
 test "Inbound federation can backfill events",
    requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures(),
+                 local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                  federation_user_id_fixture() ],
 
    do => sub {
@@ -194,8 +194,8 @@ test "Inbound federation can backfill events",
 
 test "Backfill checks the events requested belong to the room",
    requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures(),
-                 local_user_and_room_fixtures(),
+                 local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
+                 local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                  federation_user_id_fixture() ],
    do => sub {
       my ( $outbound_client, $info, $priv_creator, $priv_room_id,

--- a/tests/50federation/35room-invite.pl
+++ b/tests/50federation/35room-invite.pl
@@ -1,5 +1,6 @@
 test "Outbound federation can send invites",
-   requires => [ local_user_and_room_fixtures(), $main::INBOUND_SERVER, federation_user_id_fixture() ],
+   requires => [ local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
+                 $main::INBOUND_SERVER, federation_user_id_fixture() ],
 
    do => sub {
       my ( $user, $room_id, $inbound_server, $invitee_id ) = @_;

--- a/tests/50federation/36-state.pl
+++ b/tests/50federation/36-state.pl
@@ -11,7 +11,7 @@ sub get_state_ids_from_server {
 
 test "Inbound federation can get state for a room",
    requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures(),
+                 local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                  federation_user_id_fixture() ],
 
    do => sub {
@@ -61,7 +61,7 @@ test "Inbound federation can get state for a room",
 
 test "Inbound federation of state requires event_id as a mandatory paramater",
    requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures(),
+                 local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                  federation_user_id_fixture() ],
 
    do => sub {
@@ -80,7 +80,7 @@ test "Inbound federation of state requires event_id as a mandatory paramater",
 
 test "Inbound federation can get state_ids for a room",
    requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures(),
+                 local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                  federation_user_id_fixture() ],
 
    do => sub {
@@ -125,7 +125,7 @@ test "Inbound federation can get state_ids for a room",
 
 test "Inbound federation of state_ids requires event_id as a mandatory paramater",
    requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures(),
+                 local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                  federation_user_id_fixture() ],
 
    do => sub {
@@ -143,7 +143,10 @@ test "Inbound federation of state_ids requires event_id as a mandatory paramater
 
 test "Federation rejects inbound events where the prev_events cannot be found",
    requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures( user_opts => { with_events => 1 } ),
+                 local_user_and_room_fixtures(
+                    user_opts => { with_events => 1 },
+                    room_opts => { room_version => "1" },
+                 ),
                  federation_user_id_fixture() ],
 
    do => sub {
@@ -224,7 +227,10 @@ test "Federation rejects inbound events where the prev_events cannot be found",
 
 test "Outbound federation requests missing prev_events and then asks for /state_ids and resolves the state",
    requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures( user_opts => { with_events => 1 } ),
+                 local_user_and_room_fixtures(
+                    user_opts => { with_events => 1 },
+                    room_opts => { room_version => "1" },
+                  ),
                  federation_user_id_fixture() ],
 
    do => sub {
@@ -489,7 +495,10 @@ test "Outbound federation requests missing prev_events and then asks for /state_
 
 test "Federation handles empty auth_events in state_ids sanely",
    requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures( user_opts => { with_events => 1 } ),
+                 local_user_and_room_fixtures(
+                    user_opts => { with_events => 1 },
+                    room_opts => { room_version => "1" },
+                 ),
                  federation_user_id_fixture() ],
 
    do => sub {
@@ -643,8 +652,8 @@ test "Federation handles empty auth_events in state_ids sanely",
 
 test "Getting state checks the events requested belong to the room",
    requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures(),
-                 local_user_and_room_fixtures(),
+                 local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
+                 local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                  federation_user_id_fixture() ],
    do => sub {
       my ( $outbound_client, $info, $priv_creator, $priv_room_id,
@@ -685,8 +694,8 @@ test "Getting state checks the events requested belong to the room",
 
 test "Getting state IDs checks the events requested belong to the room",
    requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures(),
-                 local_user_and_room_fixtures(),
+                 local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
+                 local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                  federation_user_id_fixture() ],
    do => sub {
       my ( $outbound_client, $info, $priv_creator, $priv_room_id,
@@ -757,7 +766,7 @@ test "Should not be able to take over the room by pretending there is no PL even
    requires => [
       $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO[0],
       # Create user and a publicly joinable room on the synapse.
-      local_user_and_room_fixtures(),
+      local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
       # Pick a user_id for our evil federation user.
       federation_user_id_fixture()
    ],

--- a/tests/50federation/37public-rooms.pl
+++ b/tests/50federation/37public-rooms.pl
@@ -1,6 +1,6 @@
 test "Inbound federation can get public room list",
    requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures(),
+                 local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                  federation_user_id_fixture() ],
 
    do => sub {

--- a/tests/50federation/38receipts.pl
+++ b/tests/50federation/38receipts.pl
@@ -1,5 +1,5 @@
 test "Outbound federation sends receipts",
-   requires => [ local_user_and_room_fixtures(),
+   requires => [ local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                  federation_user_id_fixture(),
                  $main::OUTBOUND_CLIENT,
                  $main::INBOUND_SERVER,

--- a/tests/50federation/40devicelists.pl
+++ b/tests/50federation/40devicelists.pl
@@ -1,5 +1,6 @@
 test "Local device key changes get to remote servers",
-   requires => [ local_user_fixture(), $main::INBOUND_SERVER, federation_user_id_fixture(), room_alias_name_fixture() ],
+   requires => [ local_user_fixture( room_opts => { room_version => "1" } ),
+                 $main::INBOUND_SERVER, federation_user_id_fixture(), room_alias_name_fixture() ],
 
    check => sub {
       my ( $user, $inbound_server, $creator_id, $room_alias_name ) = @_;
@@ -61,7 +62,8 @@ test "Local device key changes get to remote servers",
 
 
 test "Server correctly handles incoming m.device_list_update",
-   requires => [ local_user_fixture(), $main::INBOUND_SERVER, $main::OUTBOUND_CLIENT,
+   requires => [ local_user_fixture( room_opts => { room_version => "1" } ),
+                 $main::INBOUND_SERVER, $main::OUTBOUND_CLIENT,
                  $main::HOMESERVER_INFO[0],  federation_user_id_fixture(),
                  room_alias_name_fixture() ],
 

--- a/tests/50federation/42query-auth.pl
+++ b/tests/50federation/42query-auth.pl
@@ -2,8 +2,8 @@ use Future::Utils qw( repeat );
 
 test "Querying auth checks the events requested belong to the room",
    requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures(),
-                 local_user_and_room_fixtures(),
+                 local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
+                 local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                  federation_user_id_fixture() ],
    do => sub {
       my ( $outbound_client, $info, $priv_creator, $priv_room_id,

--- a/tests/50federation/50no-deextrem-outliers.pl
+++ b/tests/50federation/50no-deextrem-outliers.pl
@@ -1,6 +1,9 @@
 test "Forward extremities remain so even after the next events are populated as outliers",
       requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures( user_opts => { with_events => 1 } ),
+                 local_user_and_room_fixtures(
+                    user_opts => { with_events => 1 },
+                    room_opts => { room_version => "1" },
+                  ),
                  federation_user_id_fixture() ],
 
    do => sub {

--- a/tests/50federation/51transactions.pl
+++ b/tests/50federation/51transactions.pl
@@ -1,6 +1,7 @@
 test "Server correctly handles transactions that break edu limits",
    requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures(), room_alias_name_fixture() ],
+                 local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
+                 room_alias_name_fixture() ],
 
    do => sub {
       my ( $outbound_client, $inbound_server, $info, $creator, $room_id, $room_alias_name ) = @_;

--- a/tests/50federation/52soft-fail.pl
+++ b/tests/50federation/52soft-fail.pl
@@ -1,6 +1,9 @@
 test "Inbound federation correctly soft fails events",
    requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO[0],
-                 local_user_and_room_fixtures( user_opts => { with_events => 1 }),
+                 local_user_and_room_fixtures(
+                    user_opts => { with_events => 1 },
+                    room_opts => { room_version => "1" },
+                 ),
                  federation_user_id_fixture() ],
 
    do => sub {
@@ -146,6 +149,7 @@ test "Inbound federation accepts a second soft-failed event",
       $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO[0],
       local_user_and_room_fixtures(
          user_opts => { with_events => 1 },
+         room_opts => { room_version => "1" }
       ),
       federation_user_id_fixture(),
    ],
@@ -331,6 +335,7 @@ test "Inbound federation correctly handles soft failed events as extremities",
       $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO[0],
       local_user_and_room_fixtures(
          user_opts => { with_events => 1 },
+          room_opts => { room_version => "1" },
       ),
       federation_user_id_fixture(),
    ],
@@ -375,7 +380,7 @@ test "Inbound federation correctly handles soft failed events as extremities",
       # local server to soft fail SF1 and SF2 when they are received.
       #
       # M1 and PL1 will therefore become forward-extremities of the room. However, M2 will
-      # be accepted, and replace M1 and PL1 as the extremities of the room. M2 should 
+      # be accepted, and replace M1 and PL1 as the extremities of the room. M2 should
       # therefore be the sole prev_event of M3.
       #
       # (The effect of #5269 was that M1 was incorrectly included as a


### PR DESCRIPTION
We're changing default room version to v4, which sytest doesn't support.

c.f. https://github.com/matrix-org/synapse/pull/5379