### PR TITLE
Fix typo in postgres fsync option in Dockerfiles

### DIFF
--- a/docker/Dockerfile-dendrite
+++ b/docker/Dockerfile-dendrite
@@ -15,7 +15,7 @@ ENV PGUSER=postgres
 
 # Turn off all the fsync stuff for postgres
 RUN mkdir -p /etc/postgresql/9.6/main/conf.d/
-RUN echo "fync=off" > /etc/postgresql/9.6/main/conf.d/fsync.conf
+RUN echo "fsync=off" > /etc/postgresql/9.6/main/conf.d/fsync.conf
 RUN echo "full_page_writes=off" >> /etc/postgresql/9.6/main/conf.d/fsync.conf
 
 # Initialise the database files

--- a/docker/Dockerfile-synapsepy2
+++ b/docker/Dockerfile-synapsepy2
@@ -10,7 +10,7 @@ RUN su -c '/usr/lib/postgresql/9.6/bin/initdb -E "UTF-8" --lc-collate="en_US.UTF
 
 # Turn off all the fsync stuff for postgres
 RUN mkdir -p /etc/postgresql/9.6/main/conf.d/
-RUN echo "fync=off" > /etc/postgresql/9.6/main/conf.d/fsync.conf
+RUN echo "fsync=off" > /etc/postgresql/9.6/main/conf.d/fsync.conf
 RUN echo "full_page_writes=off" >> /etc/postgresql/9.6/main/conf.d/fsync.conf
 
 # /src is where we expect Synapse to be

--- a/docker/Dockerfile-synapsepy3
+++ b/docker/Dockerfile-synapsepy3
@@ -10,7 +10,7 @@ RUN su -c '/usr/lib/postgresql/9.6/bin/initdb -E "UTF-8" --lc-collate="en_US.UTF
 
 # Turn off all the fsync stuff for postgres
 RUN mkdir -p /etc/postgresql/9.6/main/conf.d/
-RUN echo "fync=off" > /etc/postgresql/9.6/main/conf.d/fsync.conf
+RUN echo "fsync=off" > /etc/postgresql/9.6/main/conf.d/fsync.conf
 RUN echo "full_page_writes=off" >> /etc/postgresql/9.6/main/conf.d/fsync.conf
 
 # /src is where we expect Synapse to be


### PR DESCRIPTION
The option `fync=off` should be `fsync=off`.

Signed-off-by: Alex Chen <minecnly@gmail.com>