### PR TITLE
Supply testfile path to show-expected-fail-tests.sh for dendrite

### DIFF
--- a/docker/dendrite_sytest.sh
+++ b/docker/dendrite_sytest.sh
@@ -55,7 +55,7 @@ TEST_STATUS=0
 ./run-tests.pl -I Dendrite::Monolith -d /src/bin -W /src/testfile -O tap --all "$@" > results.tap || TEST_STATUS=$?
 
 # Check for new tests to be added to testfile
-/src/show-expected-fail-tests.sh results.tap || TEST_STATUS=$?
+/src/show-expected-fail-tests.sh results.tap /src/testfile || TEST_STATUS=$?
 
 # Copy out the logs
 mkdir -p /logs


### PR DESCRIPTION
https://github.com/matrix-org/dendrite/pull/719 updates the parameters required by the script `show-expected-fail-tests.sh` for dendrite. This PR updates `docker/dendrite_sytest.sh` to keep up with it.

Signed-off-by: Alex Chen <minecnly@gmail.com>