### PR TITLE
Have the room member tests retry a few times

### DIFF
--- a/tests/10apidoc/33room-members.pl
+++ b/tests/10apidoc/33room-members.pl
@@ -35,23 +35,21 @@ test "POST /rooms/:room_id/join can join a room",
          $body->{room_id} eq $room_id or
             die "Expected 'room_id' to be $room_id";
 
-         Future->done(1);
-      });
-   },
+         # Retry getting the state a few times, for it may take some time to
+         # propagate in a multi-process homeserver
+         retry_until_success {
+            matrix_get_room_state( $user, $room_id,
+               type      => "m.room.member",
+               state_key => $user->user_id,
+            )->then( sub {
+               my ( $body ) = @_;
 
-   check => sub {
-      my ( $user, $room_id, undef ) = @_;
+               $body->{membership} eq "join" or
+                  die "Expected membership to be 'join'";
 
-      matrix_get_room_state( $user, $room_id,
-         type      => "m.room.member",
-         state_key => $user->user_id,
-      )->then( sub {
-         my ( $body ) = @_;
-
-         $body->{membership} eq "join" or
-            die "Expected membership to be 'join'";
-
-         Future->done(1);
+               Future->done(1);
+            })
+         }
       });
    };
 
@@ -101,23 +99,21 @@ test "POST /join/:room_alias can join a room",
          $body->{room_id} eq $room_id or
             die "Expected 'room_id' to be $room_id";
 
-         Future->done(1);
-      });
-   },
+         # Retry getting the state a few times, for it may take some time to
+         # propagate in a multi-process homeserver
+         retry_until_success {
+            matrix_get_room_state( $user, $room_id,
+               type      => "m.room.member",
+               state_key => $user->user_id,
+            )->then( sub {
+               my ( $body ) = @_;
 
-   check => sub {
-      my ( $user, $room_id, undef ) = @_;
+               $body->{membership} eq "join" or
+                  die "Expected membership to be 'join'";
 
-      matrix_get_room_state( $user, $room_id,
-         type      => "m.room.member",
-         state_key => $user->user_id,
-      )->then( sub {
-         my ( $body ) = @_;
-
-         $body->{membership} eq "join" or
-            die "Expected membership to be 'join'";
-
-         Future->done(1);
+               Future->done(1);
+            })
+         }
       });
    };
 
@@ -140,23 +136,21 @@ test "POST /join/:room_id can join a room",
          $body->{room_id} eq $room_id or
             die "Expected 'room_id' to be $room_id";
 
-         Future->done(1);
-      });
-   },
+         # Retry getting the state a few times, for it may take some time to
+         # propagate in a multi-process homeserver
+         retry_until_success {
+            matrix_get_room_state( $user, $room_id,
+               type      => "m.room.member",
+               state_key => $user->user_id,
+            )->then( sub {
+               my ( $body ) = @_;
 
-   check => sub {
-      my ( $user, $room_id, undef ) = @_;
+               $body->{membership} eq "join" or
+                  die "Expected membership to be 'join'";
 
-      matrix_get_room_state( $user, $room_id,
-         type      => "m.room.member",
-         state_key => $user->user_id,
-      )->then( sub {
-         my ( $body ) = @_;
-
-         $body->{membership} eq "join" or
-            die "Expected membership to be 'join'";
-
-         Future->done(1);
+               Future->done(1);
+            })
+         }
       });
    };
 
@@ -178,10 +172,14 @@ test "POST /join/:room_id can join a room with custom content",
          assert_json_keys( $body, qw( room_id ) );
          assert_eq( $body->{room_id}, $room_id );
 
-         matrix_get_room_state( $user, $room_id,
-            type      => "m.room.member",
-            state_key => $user->user_id,
-         )
+         # Retry getting the state a few times, for it may take some time to
+         # propagate in a multi-process homeserver
+         retry_until_success {
+            matrix_get_room_state( $user, $room_id,
+               type      => "m.room.member",
+               state_key => $user->user_id,
+            )
+         }
       })->then( sub {
          my ( $body ) = @_;
 
@@ -213,10 +211,14 @@ test "POST /join/:room_alias can join a room with custom content",
          assert_json_keys( $body, qw( room_id ) );
          assert_eq( $body->{room_id}, $room_id );
 
-         matrix_get_room_state( $user, $room_id,
-            type      => "m.room.member",
-            state_key => $user->user_id,
-         )
+         # Retry getting the state a few times, for it may take some time to
+         # propagate in a multi-process homeserver
+         retry_until_success {
+            matrix_get_room_state( $user, $room_id,
+               type      => "m.room.member",
+               state_key => $user->user_id,
+            )
+         }
       })->then( sub {
          my ( $body ) = @_;
 
@@ -244,12 +246,16 @@ test "POST /rooms/:room_id/leave can leave a room",
             uri    => "/r0/rooms/$room_id/leave",
 
             content => {},
-         );
-      })->then( sub {
-         matrix_get_room_state( $joiner_to_leave, $room_id,
-            type      => "m.room.member",
-            state_key => $joiner_to_leave->user_id,
          )
+      })->then( sub {
+         # Retry getting the state a few times, for it may take some time to
+         # propagate in a multi-process homeserver
+         retry_until_success {
+            matrix_get_room_state( $joiner_to_leave, $room_id,
+               type      => "m.room.member",
+               state_key => $joiner_to_leave->user_id,
+            )
+         }
       })->then(
          sub { # then
             my ( $body ) = @_;
@@ -299,22 +305,22 @@ test "POST /rooms/:room_id/invite can send an invite",
          uri    => "/r0/rooms/$room_id/invite",
 
          content => { user_id => $invited_user->user_id },
-      );
-   },
-
-   check => sub {
-      my ( $creator, $invited_user, $room_id, undef ) = @_;
-
-      matrix_get_room_state( $creator, $room_id,
-         type      => "m.room.member",
-         state_key => $invited_user->user_id,
       )->then( sub {
-         my ( $body ) = @_;
+         # Retry getting the state a few times, for it may take some time to
+         # propagate in a multi-process homeserver
+         retry_until_success {
+            matrix_get_room_state( $creator, $room_id,
+               type      => "m.room.member",
+               state_key => $invited_user->user_id,
+            )->then( sub {
+               my ( $body ) = @_;
 
-         $body->{membership} eq "invite" or
-            die "Expected membership to be 'invite'";
+               $body->{membership} eq "invite" or
+                  die "Expected membership to be 'invite'";
 
-         Future->done(1);
+               Future->done(1);
+            });
+         }
       });
    };
 
@@ -366,22 +372,22 @@ test "POST /rooms/:room_id/ban can ban a user",
             user_id => $banned_user->user_id,
             reason  => "Just testing",
          },
-      );
-   },
-
-   check => sub {
-      my ( $creator, $banned_user, $room_id, undef ) = @_;
-
-      matrix_get_room_state( $creator, $room_id,
-         type      => "m.room.member",
-         state_key => $banned_user->user_id,
       )->then( sub {
-         my ( $body ) = @_;
+         # Retry getting the state a few times, for it may take some time to
+         # propagate in a multi-process homeserver
+         retry_until_success {
+            matrix_get_room_state( $creator, $room_id,
+               type      => "m.room.member",
+               state_key => $banned_user->user_id,
+            )->then( sub {
+               my ( $body ) = @_;
 
-         $body->{membership} eq "ban" or
-            die "Expecting membership to be 'ban'";
+               $body->{membership} eq "ban" or
+                  die "Expecting membership to be 'ban'";
 
-         Future->done(1);
+               Future->done(1);
+            })
+         }
       });
    };
 

--- a/tests/10apidoc/33room-members.pl
+++ b/tests/10apidoc/33room-members.pl
@@ -35,7 +35,7 @@ test "POST /rooms/:room_id/join can join a room",
          $body->{room_id} eq $room_id or
             die "Expected 'room_id' to be $room_id";
 
-         # Retry getting the state a few times, for it may take some time to
+         # Retry getting the state a few times, as it may take some time to
          # propagate in a multi-process homeserver
          retry_until_success {
             matrix_get_room_state( $user, $room_id,
@@ -99,7 +99,7 @@ test "POST /join/:room_alias can join a room",
          $body->{room_id} eq $room_id or
             die "Expected 'room_id' to be $room_id";
 
-         # Retry getting the state a few times, for it may take some time to
+         # Retry getting the state a few times, as it may take some time to
          # propagate in a multi-process homeserver
          retry_until_success {
             matrix_get_room_state( $user, $room_id,
@@ -136,7 +136,7 @@ test "POST /join/:room_id can join a room",
          $body->{room_id} eq $room_id or
             die "Expected 'room_id' to be $room_id";
 
-         # Retry getting the state a few times, for it may take some time to
+         # Retry getting the state a few times, as it may take some time to
          # propagate in a multi-process homeserver
          retry_until_success {
             matrix_get_room_state( $user, $room_id,
@@ -172,7 +172,7 @@ test "POST /join/:room_id can join a room with custom content",
          assert_json_keys( $body, qw( room_id ) );
          assert_eq( $body->{room_id}, $room_id );
 
-         # Retry getting the state a few times, for it may take some time to
+         # Retry getting the state a few times, as it may take some time to
          # propagate in a multi-process homeserver
          retry_until_success {
             matrix_get_room_state( $user, $room_id,
@@ -211,7 +211,7 @@ test "POST /join/:room_alias can join a room with custom content",
          assert_json_keys( $body, qw( room_id ) );
          assert_eq( $body->{room_id}, $room_id );
 
-         # Retry getting the state a few times, for it may take some time to
+         # Retry getting the state a few times, as it may take some time to
          # propagate in a multi-process homeserver
          retry_until_success {
             matrix_get_room_state( $user, $room_id,
@@ -248,7 +248,7 @@ test "POST /rooms/:room_id/leave can leave a room",
             content => {},
          )
       })->then( sub {
-         # Retry getting the state a few times, for it may take some time to
+         # Retry getting the state a few times, as it may take some time to
          # propagate in a multi-process homeserver
          retry_until_success {
             matrix_get_room_state( $joiner_to_leave, $room_id,
@@ -304,7 +304,7 @@ test "POST /rooms/:room_id/invite can send an invite",
 
          content => { user_id => $invited_user->user_id },
       )->then( sub {
-         # Retry getting the state a few times, for it may take some time to
+         # Retry getting the state a few times, as it may take some time to
          # propagate in a multi-process homeserver
          retry_until_success {
             matrix_get_room_state( $creator, $room_id,
@@ -371,7 +371,7 @@ test "POST /rooms/:room_id/ban can ban a user",
             reason  => "Just testing",
          },
       )->then( sub {
-         # Retry getting the state a few times, for it may take some time to
+         # Retry getting the state a few times, as it may take some time to
          # propagate in a multi-process homeserver
          retry_until_success {
             matrix_get_room_state( $creator, $room_id,

--- a/tests/10apidoc/36room-levels.pl
+++ b/tests/10apidoc/36room-levels.pl
@@ -56,7 +56,9 @@ test "PUT /rooms/:room_id/state/m.room.power_levels can set levels",
             content => $levels,
          )
       })->then( sub {
-         matrix_get_room_state( $user, $room_id, type => "m.room.power_levels" )
+         retry_until_success {
+            matrix_get_room_state( $user, $room_id, type => "m.room.power_levels" )
+         }
       })->then( sub {
          my ( $levels ) = @_;
 

--- a/tests/10apidoc/36room-levels.pl
+++ b/tests/10apidoc/36room-levels.pl
@@ -57,15 +57,17 @@ test "PUT /rooms/:room_id/state/m.room.power_levels can set levels",
          )
       })->then( sub {
          retry_until_success {
-            matrix_get_room_state( $user, $room_id, type => "m.room.power_levels" )
+            matrix_get_room_state(
+               $user, $room_id, type => "m.room.power_levels"
+            )->then( sub {
+               my ( $levels ) = @_;
+
+               $levels->{users}{'@random-other-user:their.home'} == 20 or
+                  die "Expected to have set other user's level to 20";
+
+               Future->done(1);
+            })
          }
-      })->then( sub {
-         my ( $levels ) = @_;
-
-         $levels->{users}{'@random-other-user:their.home'} == 20 or
-            die "Expected to have set other user's level to 20";
-
-         Future->done(1);
       });
    };
 

--- a/tests/30rooms/14override-per-room.pl
+++ b/tests/30rooms/14override-per-room.pl
@@ -43,18 +43,20 @@ test "Room members can join a room with an overridden displayname",
             displayname => "Overridden",
          },
       )->then( sub {
-         matrix_get_room_state( $creator, $room_id,
-            type      => "m.room.member",
-            state_key => $joiner->user_id,
-         );
-      })->then( sub {
-         my ( $state ) = @_;
+         retry_until_success {
+            matrix_get_room_state( $creator, $room_id,
+               type      => "m.room.member",
+               state_key => $joiner->user_id,
+            )->then( sub {
+               my ( $state ) = @_;
 
-         log_if_fail "State", $state;
+               log_if_fail "State", $state;
 
-         assert_eq( $state->{displayname}, "Overridden",
-            'displayname in my m.room.member event at join time' );
+               assert_eq( $state->{displayname}, "Overridden",
+                  'displayname in my m.room.member event at join time' );
 
-         Future->done(1);
+               Future->done(1);
+            })
+         }
       });
    };


### PR DESCRIPTION
These tests were pretty flaky in a multi-process homeserver (like Dendrite). The events took a few moments to persist, and thus a race condition was produced where SyTest would request the status right afterwards (before the events finished persisting).

We now retry a few times before calling it failed.

(Should `retry_until_success` be moved inside of `matrix_get_room_state`?)