### PR TITLE
Increase synapse's federation ratelimit

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -191,6 +191,13 @@ sub start
                 burst_count => 1000,
             }
         },
+
+        rc_federation => {
+           # allow 100 requests per sec instead of 10
+           sleep_limit => 100,
+           window_size => 1000,
+        },
+
         enable_registration => "true",
         database => \%synapse_db_config,
         macaroon_secret_key => $macaroon_secret_key,


### PR DESCRIPTION
We hit 10 requests per second pretty quickly and then our requests start
getting tarpitted and the tests time out. Let's increase the limit.

(This will need https://github.com/matrix-org/synapse/pull/5621 to land before it actually does anything, but it will be harmless without)