### PR TITLE
Remove check for obsolete json key prev_state

### DIFF
--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -39,14 +39,11 @@ sub assert_is_valid_pdu {
    # for event types which are known to be state events, check that they
    # have the relevant keys
    if ( $STATE_EVENT_TYPES{ $event->{type} }) {
-      # XXX richvdh: I'm unconvinced prev_state is required here - I think
-      # it's deprecated. It's certainly not mentioned in the spec.
       assert_json_keys( $event, qw(
-         state_key prev_state
+         state_key
       ));
 
       assert_json_string( $event->{state_key} );
-      assert_json_list( $event->{prev_state} );
    }
 
    # TODO: Check signatures and hashes
@@ -233,7 +230,7 @@ test "Inbound federation can receive room-join requests",
          my $protoevent = $body->{event};
 
          assert_json_keys( $protoevent, qw(
-            auth_events content depth prev_state room_id sender state_key type
+            auth_events content depth room_id sender state_key type
          ));
 
          assert_json_nonempty_list( my $auth_events = $protoevent->{auth_events} );
@@ -265,7 +262,7 @@ test "Inbound federation can receive room-join requests",
 
          my %event = (
             ( map { $_ => $protoevent->{$_} } qw(
-               auth_events content depth prev_events prev_state room_id sender
+               auth_events content depth prev_events room_id sender
                state_key type ) ),
 
             event_id         => $datastore->next_event_id,

--- a/tests/50federation/35room-invite.pl
+++ b/tests/50federation/35room-invite.pl
@@ -27,7 +27,7 @@ test "Outbound federation can send invites",
             assert_eq( $body->{sender}, $user->user_id,
                'event sender' );
 
-            assert_json_keys( $body, qw( content state_key prev_state ));
+            assert_json_keys( $body, qw( content state_key ));
 
             assert_eq( $body->{content}{membership}, "invite",
                'event content membership' );


### PR DESCRIPTION
The `prev_state` key isn't mentioned at all in the spec.

If merged, this PR should obsolete https://github.com/matrix-org/gomatrixserverlib/pull/95 and https://github.com/matrix-org/dendrite/pull/526.

Signed-off-by: Alex Chen <minecnly@gmail.com>