### PR TITLE
Create new SSL certs for each test run

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -20,7 +20,7 @@ use POSIX qw( strftime WIFEXITED WEXITSTATUS );
 
 use YAML ();
 
-use SyTest::SSL qw( ensure_ssl_cert );
+use SyTest::SSL qw( ensure_ssl_key create_ssl_cert );
 
 sub _init
 {
@@ -150,7 +150,8 @@ sub start
    $self->{paths}{cert_file} = "$hs_dir/tls.crt";
    $self->{paths}{key_file} = "$hs_dir/tls.key";
 
-   ensure_ssl_cert( $self->{paths}{cert_file}, $self->{paths}{key_file}, $bind_host );
+   ensure_ssl_key( $self->{paths}{key_file} );
+   create_ssl_cert( $self->{paths}{cert_file}, $self->{paths}{key_file}, $bind_host );
 
    my $config_path = $self->{paths}{config} = $self->write_yaml_file( "config.yaml" => {
         server_name => $self->server_name,

--- a/tests/01http-server.pl
+++ b/tests/01http-server.pl
@@ -6,7 +6,7 @@ use IO::Async::SSL;
 
 use SyTest::HTTPClient;
 use SyTest::HTTPServer::Request;
-use SyTest::SSL qw( ensure_ssl_cert );
+use SyTest::SSL qw( ensure_ssl_key create_ssl_cert );
 
 my $DIR = dirname( __FILE__ );
 
@@ -35,7 +35,8 @@ sub start_test_server_ssl {
 
    my $ssl_cert = "$test_server_dir/server.crt";
    my $ssl_key = "$test_server_dir/server.key";
-   ensure_ssl_cert( $ssl_cert, $ssl_key, $BIND_HOST );
+   ensure_ssl_key( $ssl_key );
+   create_ssl_cert( $ssl_cert, $ssl_key, $BIND_HOST );
 
    return $server->listen(
       host          => $BIND_HOST,


### PR DESCRIPTION
Fixes a problem where the sytests would suddenly start failing because they
were still using the certs taht we generated a month ago.