### PR TITLE
Increase the timeouts on some tests which go slowly

### DIFF
--- a/tests/31sync/06state.pl
+++ b/tests/31sync/06state.pl
@@ -773,6 +773,9 @@ test "Current state appears in timeline in private history with many messages be
    requires => [ local_user_fixtures( 3, with_events => 0 ),
                  qw( can_sync ) ],
 
+   # sending 50 messages can take a while
+   timeout => 20000,
+
    check => sub {
       my ( $creator, $syncer, $invitee ) = @_;
 
@@ -795,7 +798,9 @@ test "Current state appears in timeline in private history with many messages be
 
             matrix_send_room_text_message( $creator, $room_id,
                body => "Message $msgnum",
-            )
+            )->on_done( sub {
+               log_if_fail "Sent msg $msgnum / 50";
+            });
          }, foreach => [ 1 .. 50 ])
       })->then( sub {
          matrix_leave_room( $syncer, $room_id )
@@ -828,6 +833,9 @@ test "Current state appears in timeline in private history with many messages af
    requires => [ local_user_fixtures( 3, with_events => 0 ),
                  qw( can_sync ) ],
 
+   # sending 50 messages can take a while
+   timeout => 20000,
+
    check => sub {
       my ( $creator, $syncer, $invitee ) = @_;
 
@@ -854,7 +862,9 @@ test "Current state appears in timeline in private history with many messages af
 
             matrix_send_room_text_message( $creator, $room_id,
                body => "Message $msgnum",
-            )
+            )->on_done( sub {
+               log_if_fail "Sent msg $msgnum / 50";
+            });
          }, foreach => [ 1 .. 50 ])
       })->then( sub {
          matrix_join_room_synced( $syncer, $room_id )

--- a/tests/52user-directory/01public.pl
+++ b/tests/52user-directory/01public.pl
@@ -151,6 +151,9 @@ foreach my $type (qw( join_rules history_visibility )) {
    multi_test "Users appear/disappear from directory when $type are changed",
       requires => [ local_user_fixtures( 2 ) ],
 
+      # matrix_get_user_dir_synced creates two new users and a room, which is kinda slow.
+      timeout => 20000,
+
       check => sub {
          my ( $creator, $user ) = @_;
 
@@ -245,6 +248,9 @@ foreach my $type (qw( join_rules history_visibility )) {
 
 multi_test "Users stay in directory when join_rules are changed but history_visibility is world_readable",
    requires => [ local_user_fixtures( 2 ) ],
+
+   # matrix_get_user_dir_synced creates two new users and a room, which is kinda slow.
+   timeout => 20000,
 
    check => sub {
       my ( $creator, $user ) = @_;
@@ -476,11 +482,16 @@ sub matrix_get_user_dir_synced
    }) -> then( sub {
       ( $searching_user ) = @_;
 
+      log_if_fail "Created test users for user directory search: " .
+         $new_user->user_id . ", " . $searching_user->user_id;
+
       matrix_create_room( $new_user,
          preset => "public_chat",
       );
    })->then( sub {
       ( $room_id ) = @_;
+
+      log_if_fail "Created test room for user directory search: " . $room_id;
 
       matrix_join_room( $searching_user, $room_id );
    })->then( sub {


### PR DESCRIPTION
These guys were timing out when I ran them against synapse with a real sqlite.