### PR TITLE
Expect JSON on /bind requests

### DIFF
--- a/lib/SyTest/Identity/Server.pm
+++ b/lib/SyTest/Identity/Server.pm
@@ -141,7 +141,7 @@ sub on_request
       $req->respond_json( \%resp );
    }
    elsif ( $path eq "/_matrix/identity/api/v1/3pid/bind" ) {
-      my $body = $req->body_from_form;
+      my $body = $req->body_from_json;
       my $sid = $body->{sid};
       my $mxid = $body->{mxid};
 


### PR DESCRIPTION
Because [spec says](https://matrix.org/docs/spec/identity_service/r0.2.1#post-matrix-identity-api-v1-3pid-bind) that `application/x-form-www-urlencoded` is deprecated.

Also related: https://github.com/matrix-org/synapse/pull/5658