### PR TITLE
Add support for recent room versions to the federation client

### DIFF
--- a/lib/SyTest/Federation/Client.pm
+++ b/lib/SyTest/Federation/Client.pm
@@ -159,8 +159,17 @@ sub send_event
       pdus => [ $event ],
    )->then( sub {
       my ( $body ) = @_;
+
+      assert_json_keys( $body, 'pdus' );
+      my $pdus = $body->{pdus};
+
+      # 'pdus' is a map from event id to error details. We don't know what our
+      # event id is, but there should be one entry which maps to an empty dict
+      assert_eq( length( keys %$pdus ), 1);
+      my $event_id = ( keys %$pdus )[0];
+
       assert_deeply_eq( $body,
-                        { pdus => { $event->{event_id} => {} } },
+                        { pdus => { $event_id => {} } },
                         "/send/ response" );
       Future->done;
    });
@@ -176,34 +185,36 @@ sub join_room
    my $user_id     = $args{user_id};
 
    my $store = $self->{datastore};
+   my $room_version;
 
    $self->do_request_json(
       method   => "GET",
       hostname => $server_name,
-      uri      => "/v1/make_join/$room_id/$user_id"
+      uri      => "/v1/make_join/$room_id/$user_id",
+      params   => { "ver" => [1, 5] },
    )->then( sub {
       my ( $body ) = @_;
 
+      $room_version = $body->{room_version} // 1;
+
       my $protoevent = $body->{event};
 
-      my %member_event = (
+      my ( $member_event, $event_id ) = $store->create_event(
+         room_version    => $room_version,
+
          ( map { $_ => $protoevent->{$_} } qw(
             auth_events content depth prev_events room_id sender
             state_key type ) ),
 
-         event_id         => $store->next_event_id,
          origin           => $store->server_name,
          origin_server_ts => $self->time_ms,
       );
 
-      $store->sign_event( \%member_event );
-
       $self->do_request_json(
          method   => "PUT",
          hostname => $server_name,
-         uri      => "/v1/send_join/$room_id/$member_event{event_id}",
-
-         content => \%member_event,
+         uri      => "/v1/send_join/$room_id/$event_id",
+         content  => $member_event,
       )->then( sub {
          my ( $join_body ) = @_;
          # SYN-490 workaround
@@ -212,12 +223,13 @@ sub join_room
          my $room = SyTest::Federation::Room->new(
             datastore => $store,
             room_id   => $room_id,
+            room_version => $room_version,
          );
 
-         my @events = uniq_by { $_->{event_id} } (
+         my @events = uniq_by { $room->id_for_event( $_ ) } (
             @{ $join_body->{auth_chain} },
             @{ $join_body->{state} },
-            \%member_event,
+            $member_event,
          );
 
          $room->insert_event( $_ ) for @events;

--- a/lib/SyTest/Federation/Protocol.pm
+++ b/lib/SyTest/Federation/Protocol.pm
@@ -1,0 +1,86 @@
+# Copyright 2019 The Matrix.org Foundation C.I.C
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package SyTest::Federation::Protocol;
+
+use strict;
+use warnings;
+
+use Digest::SHA qw( sha256 );
+use MIME::Base64 qw( encode_base64url );
+
+use Protocol::Matrix qw(
+   redacted_event
+   encode_json_for_signing
+   encode_base64_unpadded
+);
+
+
+use Exporter 'import';
+our @EXPORT_OK = qw(
+   hash_event
+   id_for_event
+);
+
+=head2 hash_event
+
+    $hash = hash_event( $event );
+
+Calculates the reference hash of an event.
+
+=cut
+
+sub hash_event
+{
+   my ( $event ) = @_;
+   my $redacted = redacted_event( $event );
+   delete $redacted->{signatures};
+   delete $redacted->{age_ts};
+   delete $redacted->{unsigned};
+
+   my $bytes_to_hash = encode_json_for_signing( $redacted );
+   return sha256( $bytes_to_hash );
+}
+
+
+=head2 id_for_event
+
+    $event_id = id_for_event( $event, $room_version );
+
+Fetches or calculates the event_id for the given event
+
+=cut
+
+sub id_for_event
+{
+   my ( $event, $room_version ) = @_;
+
+   $room_version //= 1;
+
+   if( $room_version eq '1' || $room_version eq '2' ) {
+      my $event_id = $event->{event_id};
+      die "event with no event_id" if not $event_id;
+      return $event_id;
+   }
+
+   my $event_hash = hash_event( $event );
+
+   # room v3 uses the unpadded-base64-encoded hash
+   if( $room_version eq '3' ) {
+      return '$' . encode_base64_unpadded( $event_hash );
+   }
+
+   # other rooms use the url-safe unpadded-base64-encoded hash
+   return '$' . encode_base64url( $event_hash );
+}

--- a/lib/SyTest/Federation/Room.pm
+++ b/lib/SyTest/Federation/Room.pm
@@ -8,16 +8,11 @@ use Carp;
 use List::Util qw( max );
 use List::UtilsBy qw( extract_by );
 
+use SyTest::Federation::Protocol;
+
 =head1 NAME
 
 C<SyTest::Federation::Room> - represent a single Room instance
-
-=cut
-
-sub make_event_refs
-{
-   [ map { [ $_->{event_id}, $_->{hashes} ] } @_ ];
-}
 
 =head1 CONSTRUCTOR
 
@@ -25,7 +20,11 @@ sub make_event_refs
 
 =head2 new
 
-   $room = SyTest::Federation::Room->new( room_id => $room_id, datastore => $store )
+   $room = SyTest::Federation::Room->new(
+      room_id => $room_id,
+      datastore => $store,
+      [ room_version => $room_version, ]
+   )
 
 Constructs a new Room instance, initially blank containing no state or events.
 
@@ -43,10 +42,12 @@ sub new
       croak "Require a 'datastore'";
 
    my $room_id = $args{room_id} // $datastore->next_room_id;
+   my $room_version = $args{room_version} // 1;
 
    return bless {
       room_id   => $room_id,
       datastore => $datastore,
+      room_version => $room_version,
 
       current_state => {},
       prev_events => [],
@@ -56,6 +57,34 @@ sub new
 =head1 METHODS
 
 =cut
+
+sub make_event_refs
+{
+   my $self = shift;
+   my @events = @_;
+
+   if ( $self->room_version eq "1" || $self->room_version eq "2" ) {
+      # room versions 1 and 2 use [ event_id, hash ] pairs.
+      return [ map { [ $_->{event_id}, $_->{hashes} ] } @_ ];
+   } else {
+      # other room versions just use event ids.
+      return [ map { $self->id_for_event( $_ ) } @_ ];
+   }
+}
+
+sub event_ids_from_refs
+{
+   my $self = shift;
+   my ( $event_refs ) = @_;
+
+   my @event_ids;
+   if ( $self->room_version eq "1" || $self->room_version eq "2" ) {
+      @event_ids = map { $_->[0] } @$event_refs;
+      return \@event_ids;
+   }
+
+   return $event_refs;
+}
 
 =head2 room_id
 
@@ -69,6 +98,21 @@ sub room_id
 {
    return $_[0]->{room_id};
 }
+
+
+=head2 room_version
+
+    $room_version = $room->room_version;
+
+Accessor to return the room version.
+
+=cut
+
+sub room_version
+{
+   return $_[0]->{room_version};
+}
+
 
 =head2 next_depth
 
@@ -111,7 +155,9 @@ sub create_initial_events
    my $creator = $args{creator} or
       croak "Require a 'creator'";
 
-   my $room_version = $args{room_version};
+   my $room_version = $args{room_version} // (
+      $self->room_version == 1 ? undef : $self->room_version
+   );
 
    $self->create_and_insert_event(
       type => "m.room.create",
@@ -164,13 +210,14 @@ sub create_event
       $self->get_current_state_event( "m.room.power_levels" ),
       $self->get_current_state_event( "m.room.member", $fields{sender} ),
    );
-   $fields{auth_events} //= make_event_refs( @auth_events ),
+   $fields{auth_events} //= $self->make_event_refs( @auth_events ),
 
    $fields{depth} //= JSON::number($self->next_depth);
 
-   $fields{prev_events} //= make_event_refs( @{ $self->{prev_events} } );
+   $fields{prev_events} //= $self->make_event_refs( @{ $self->{prev_events} } );
 
    return $self->{datastore}->create_event(
+      room_version => $self->room_version,
       room_id => $self->room_id,
       %fields,
    );
@@ -211,14 +258,17 @@ sub insert_event
 
    # Remove from $self->{prev_events} any event IDs that are now recursively
    # implied by this new event.
-   my %to_remove = map { $_->[0] => 1 } @{ $event->{prev_events} };
-   extract_by { $to_remove{ $_->{event_id} } } @$prev_events;
+   my @event_ids_to_remove = @{ $self->event_ids_from_refs( $event->{prev_events} ) };
+   my %to_remove = map { $_ => 1 } @event_ids_to_remove;
+   extract_by { $to_remove{ $self->id_for_event($_) } } @$prev_events;
 }
 
 sub _insert_event
 {
    my $self = shift;
    my ( $event ) = @_;
+
+   croak "Event not ref" unless ref $event;
 
    if( defined $event->{state_key} ) {
       $self->{current_state}{ join "\0", $event->{type}, $event->{state_key} }
@@ -288,14 +338,36 @@ sub make_join_protoevent
    return {
       type => "m.room.member",
 
-      auth_events      => make_event_refs( @auth_events ),
+      auth_events      => $self->make_event_refs( @auth_events ),
       content          => { membership => "join" },
       depth            => JSON::number($self->next_depth),
-      prev_events      => make_event_refs( @{ $self->{prev_events} } ),
+      prev_events      => $self->make_event_refs( @{ $self->{prev_events} } ),
       room_id          => $self->room_id,
       sender           => $user_id,
       state_key        => $user_id,
    };
+}
+
+=head2 id_for_event
+
+    $event_id = $room->id_for_event( $event );
+
+Gets a the event_id for the given event. For room version 1 and 2, the event_id
+is pulled out of the event structure. For other room versions, it is calculated
+from the hash of the event.
+
+Fetches or calculates the event_id for the given event
+
+=cut
+
+sub id_for_event
+{
+   my $self = shift;
+   my ( $event ) = @_;
+
+   return SyTest::Federation::Protocol::id_for_event(
+      $event, $self->room_version,
+   );
 }
 
 1;


### PR DESCRIPTION
This is all about the updated event format, which omits event_ids from the event sent over federation, in favour of implicit IDs from the hashes.