### PR TITLE
Remove trailing slashes from some requests

### DIFF
--- a/lib/SyTest/Federation/Client.pm
+++ b/lib/SyTest/Federation/Client.pm
@@ -123,7 +123,7 @@ sub send_transaction
    $self->do_request_json(
       method   => "PUT",
       hostname => $params{destination},
-      uri      => "/v1/send/$ts/",
+      uri      => "/v1/send/$ts",
 
       content => \%transaction,
    );

--- a/tests/10apidoc/46push.pl
+++ b/tests/10apidoc/46push.pl
@@ -129,6 +129,7 @@ sub matrix_get_push_rules
 {
    my ( $user ) = @_;
 
+   # Trailing slash indicates retrieving ALL push rules for this user
    do_request_json_for( $user,
       method  => "GET",
       uri     => "/r0/pushrules/",

--- a/tests/50federation/32room-getevent.pl
+++ b/tests/50federation/32room-getevent.pl
@@ -24,7 +24,7 @@ test "Inbound federation can return events",
          $outbound_client->do_request_json(
             method   => "GET",
             hostname => $first_home_server,
-            uri      => "/v1/event/$member_event->{event_id}/",
+            uri      => "/v1/event/$member_event->{event_id}",
          );
       })->then( sub {
          my ( $body ) = @_;
@@ -73,7 +73,7 @@ test "Inbound federation redacts events from erased users",
          $outbound_client->do_request_json(
             method   => "GET",
             hostname => $first_home_server,
-            uri      => "/v1/event/$message_id/",
+            uri      => "/v1/event/$message_id",
          );
       })->then( sub {
          my ( $body ) = @_;
@@ -97,7 +97,7 @@ test "Inbound federation redacts events from erased users",
             $outbound_client->do_request_json(
                method   => "GET",
                hostname => $first_home_server,
-               uri      => "/v1/event/$message_id/",
+               uri      => "/v1/event/$message_id",
             )->then( sub {
                my ( $body ) = @_;
                log_if_fail "Fetched event after erasure", $body;

--- a/tests/50federation/34room-backfill.pl
+++ b/tests/50federation/34room-backfill.pl
@@ -162,7 +162,7 @@ test "Inbound federation can backfill events",
          $outbound_client->do_request_json(
             method   => "GET",
             hostname => $first_home_server,
-            uri      => "/v1/backfill/$room_id/",
+            uri      => "/v1/backfill/$room_id",
 
             params => {
                v     => $join_event->{prev_events}[0][0],
@@ -224,7 +224,7 @@ test "Backfill checks the events requested belong to the room",
          $outbound_client->do_request_json(
             method   => "GET",
             hostname => $first_home_server,
-            uri      => "/v1/backfill/$pub_room_id/",
+            uri      => "/v1/backfill/$pub_room_id",
 
             params => {
                v     => $priv_event_id,

--- a/tests/50federation/36-state.pl
+++ b/tests/50federation/36-state.pl
@@ -4,7 +4,7 @@ sub get_state_ids_from_server {
    return $outbound_client->do_request_json(
       method   => "GET",
       hostname => $server,
-      uri      => "/v1/state_ids/$room_id/",
+      uri      => "/v1/state_ids/$room_id",
       params   => { event_id => $event_id },
    );
 }
@@ -32,7 +32,7 @@ test "Inbound federation can get state for a room",
          $outbound_client->do_request_json(
             method   => "GET",
             hostname => $first_home_server,
-            uri      => "/v1/state/$room_id/",
+            uri      => "/v1/state/$room_id",
             params   => {
                event_id => $room->{prev_events}[-1]->{event_id},
             }
@@ -73,7 +73,7 @@ test "Inbound federation of state requires event_id as a mandatory paramater",
       $outbound_client->do_request_json(
          method   => "GET",
          hostname => $first_home_server,
-         uri      => "/v1/state/notaroombutitdoesntmatter/",
+         uri      => "/v1/state/notaroombutitdoesntmatter",
       )->main::expect_http_400();
    };
 
@@ -137,7 +137,7 @@ test "Inbound federation of state_ids requires event_id as a mandatory paramater
       $outbound_client->do_request_json(
          method   => "GET",
          hostname => $first_home_server,
-         uri      => "/v1/state_ids/notaroombutitdoesntmatter/",
+         uri      => "/v1/state_ids/notaroombutitdoesntmatter",
       )->main::expect_http_400();
    };
 
@@ -682,7 +682,7 @@ test "Getting state checks the events requested belong to the room",
          $outbound_client->do_request_json(
             method   => "GET",
             hostname => $first_home_server,
-            uri      => "/v1/state/$pub_room_id/",
+            uri      => "/v1/state/$pub_room_id",
 
             params => {
                event_id => $priv_event_id,
@@ -724,7 +724,7 @@ test "Getting state IDs checks the events requested belong to the room",
          $outbound_client->do_request_json(
             method   => "GET",
             hostname => $first_home_server,
-            uri      => "/v1/state_ids/$pub_room_id/",
+            uri      => "/v1/state_ids/$pub_room_id",
 
             params => {
                event_id => $priv_event_id,

--- a/tests/61push/02add_rules.pl
+++ b/tests/61push/02add_rules.pl
@@ -33,12 +33,12 @@ sub check_add_push_rule
    })->then( sub {
       do_request_json_for( $user,
          method  => "GET",
-         uri     => "/r0/pushrules/$scope/$kind/",
+         uri     => "/r0/pushrules/$scope/$kind",
       )->on_done( $check_rule_list );
    })->then( sub {
        do_request_json_for( $user,
          method  => "GET",
-         uri     => "/r0/pushrules/$scope/",
+         uri     => "/r0/pushrules/$scope",
       )->on_done( sub {
          my ( $body ) = @_;
 

--- a/tests/61push/02add_rules.pl
+++ b/tests/61push/02add_rules.pl
@@ -31,14 +31,16 @@ sub check_add_push_rule
       matrix_get_push_rule( $user, $scope, $kind, $rule_id )
       ->on_done( $check_rule );
    })->then( sub {
+      # Trailing slash indicates retrieving ALL push rules for this scope/kind
       do_request_json_for( $user,
          method  => "GET",
-         uri     => "/r0/pushrules/$scope/$kind",
+         uri     => "/r0/pushrules/$scope/$kind/",
       )->on_done( $check_rule_list );
    })->then( sub {
+      # Trailing slash indicates retrieving ALL push rules for this scope
        do_request_json_for( $user,
          method  => "GET",
-         uri     => "/r0/pushrules/$scope",
+         uri     => "/r0/pushrules/$scope/",
       )->on_done( sub {
          my ( $body ) = @_;
 

--- a/tests/80torture/03events.pl
+++ b/tests/80torture/03events.pl
@@ -73,7 +73,7 @@ test "Event size limits",
 
          do_request_json_for( $user,
             method  => "PUT",
-            uri     => "/r0/rooms/$room_id/state/oooooooh/",
+            uri     => "/r0/rooms/$room_id/state/oooooooh",
             content => {
                key => "O" x 70000,
             }


### PR DESCRIPTION
Dendrite is currently quite strict in that it doesn't allow trailing slashes anywhere that the spec does not supply them (this is expected to become more lax in the future but doing so elegantly is currently a bit tricky with our HTTP library). 

In the meantime, we should update SyTest to follow the spec with regards to trailing slashes anyways.

Synapse is still happy: https://buildkite.com/matrix-dot-org/synapse/builds/2870