### PR TITLE
Add tests for preserving device_id on /login, /register

### DIFF
--- a/tests/10apidoc/01register.pl
+++ b/tests/10apidoc/01register.pl
@@ -106,6 +106,37 @@ test "POST /register downcases capitals in usernames",
       });
    };
 
+test "POST /register returns the same device_id as that in the request",
+   requires => [ $main::API_CLIENTS[0],
+                 qw( can_register_dummy_flow ) ],
+
+   do => sub {
+      my ( $http ) = @_;
+
+      my $device_id = "my_device_id";
+
+      $http->do_request_json(
+         method => "POST",
+         uri    => "/r0/register",
+
+         content => {
+            auth => {
+               type => "m.login.dummy",
+            },
+            username => "mycooluser",
+            password => "sUp3rs3kr1t",
+            device_id => $device_id,
+         },
+      )->then( sub {
+         my ( $body ) = @_;
+
+         assert_json_keys( $body, qw( device_id ));
+         assert_eq( $body->{device_id}, $device_id, 'device_id' );
+
+         Future->done( 1 );
+      });
+   };
+
 
 foreach my $chr (split '', '!":?\@[]{|}£é' . "\n'" ) {
    my $q = $chr; $q =~ s/\n/\\n/;

--- a/tests/10apidoc/02login.pl
+++ b/tests/10apidoc/02login.pl
@@ -96,6 +96,38 @@ test "POST /login can log in as a user",
       });
    };
 
+test "POST /login returns the same device_id as that in the request",
+   requires => [ $main::API_CLIENTS[0], $registered_user_fixture,
+                 qw( can_login_password_flow )],
+
+   proves => [qw( can_login )],
+
+   do => sub {
+      my ( $http, $user_id ) = @_;
+
+      my $device_id = "my_super_id";
+
+      $http->do_request_json(
+         method => "POST",
+         uri    => "/r0/login",
+
+         content => {
+            type     => "m.login.password",
+            user     => $user_id,
+            password => $password,
+            device_id => $device_id,
+         },
+      )->then( sub {
+         my ( $body ) = @_;
+
+         assert_json_keys( $body, qw( device_id ));
+
+         assert_eq( $body->{device_id}, $device_id, 'device_id' );
+
+         Future->done(1);
+      });
+   };
+
 test "POST /login can log in as a user with just the local part of the id",
    requires => [ $main::API_CLIENTS[0], $registered_user_fixture,
                  qw( can_login_password_flow )],


### PR DESCRIPTION
Dendrite PR: https://github.com/matrix-org/dendrite/pull/753

The spec mandates that providing a `device_id` in the request to `/register` and `/login` should, on success, create a device with that `device_id`. Dendrite didn't do this, and it wasn't failing any tests because of it.

So, add some tests that check this.

Spec bits:

https://matrix.org/docs/spec/client_server/unstable#post-matrix-client-r0-register
https://matrix.org/docs/spec/client_server/unstable#post-matrix-client-r0-login