### PR TITLE
Bind the mocked federation server to $BIND_HOST

### DIFF
--- a/tests/50federation/00prepare.pl
+++ b/tests/50federation/00prepare.pl
@@ -22,7 +22,11 @@ sub create_federation_server
       my ( $server ) = @_;
       my $sock = $server->read_handle;
 
-      my $server_name = sprintf "%s:%d", $sock->sockhostname, $sock->sockport;
+      # Use $BIND_HOST here instead of $sock->sockhostname because both don't
+      # always hold the same value, the federation certificate is generated for
+      # $BIND_HOST, and we need the server's hostname to match the certificate's
+      # common name.
+      my $server_name = sprintf "%s:%d", $BIND_HOST, $sock->sockport;
 
       my ( $pkey, $skey ) = Crypt::NaCl::Sodium->sign->keypair;
 


### PR DESCRIPTION
`$BIND_HOST` and `$sock->sockhostname` don't always hold the same value (i.e. if the system has different hostnames for the localhost). Since we need the mocked federation server's hostname to match its certificate's common name, and the certificate is generated for `$BIND_HOST`, this changes the server's init so that it uses `$BIND_HOST` as its hostname as well.