### PR TITLE
/rooms/{roomId}/event/{eventId} should return a 404 when no perms

### DIFF
--- a/tests/30rooms/51event.pl
+++ b/tests/30rooms/51event.pl
@@ -63,7 +63,7 @@ test "/event/ on non world readable room does not work",
             method  => "GET",
             uri     => "/r0/rooms/$room_id/event/${ \uri_escape( $event_id ) }",
          );
-      })->main::expect_http_403;
+      })->main::expect_http_404;
    };
 
 test "/event/ does not allow access to events before the user joined",
@@ -103,7 +103,7 @@ test "/event/ does not allow access to events before the user joined",
             method  => "GET",
             uri     => "/r0/rooms/$room_id/event/${ \uri_escape( $event_id_1 ) }",
          );
-      })->main::expect_http_403->then( sub {
+      })->main::expect_http_404->then( sub {
          # we should be able to get the event after we joined.
          do_request_json_for( $other_user,
             method  => "GET",


### PR DESCRIPTION
Part of fixing https://github.com/matrix-org/sytest/issues/652

Synapse PR: https://github.com/matrix-org/synapse/pull/5798