### PR TITLE
Don't require unsigned for /rooms/{roomId}/event/{eventId}

### DIFF
--- a/tests/30rooms/51event.pl
+++ b/tests/30rooms/51event.pl
@@ -38,7 +38,7 @@ test "/event/ on joined room works",
          )->then( sub {
             my ( $body ) = @_;
 
-            assert_json_keys( $body, qw( content type room_id sender event_id unsigned ) );
+            assert_json_keys( $body, qw( content type room_id sender event_id ) );
             assert_eq( $body->{event_id}, $event_id, "event id" );
             assert_eq( $body->{room_id}, $room_id, "room id" );
             assert_eq( $body->{content}->{body}, "hello, world", "body" );
@@ -112,7 +112,7 @@ test "/event/ does not allow access to events before the user joined",
       })->then( sub {
          my ( $body ) = @_;
 
-         assert_json_keys( $body, qw( content type room_id sender event_id unsigned ) );
+         assert_json_keys( $body, qw( content type room_id sender event_id ) );
          assert_eq( $body->{event_id}, $event_id_2, "event id" );
          assert_eq( $body->{content}->{body}, "after join", "body" );
 


### PR DESCRIPTION
Fixes https://github.com/matrix-org/sytest/issues/653

The spec [doesn't mention](https://matrix.org/docs/spec/client_server/unstable#get-matrix-client-r0-rooms-roomid-event-eventid) `unsigned`, so we shouldn't require it here.