### PR TITLE
Fix some incorrect assumptions about event formats

### DIFF
--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -17,13 +17,12 @@ sub assert_is_valid_pdu {
    my ( $event ) = @_;
 
    assert_json_keys( $event, qw(
-      auth_events content depth event_id hashes origin origin_server_ts
+      auth_events content depth hashes origin origin_server_ts
       prev_events room_id sender signatures type
    ));
 
    assert_json_list( $event->{auth_events} );
    assert_json_number( $event->{depth} );
-   assert_json_string( $event->{event_id} );
    assert_json_object( $event->{hashes} );
 
    assert_json_string( $event->{origin} );
@@ -47,6 +46,9 @@ sub assert_is_valid_pdu {
    }
 
    # TODO: Check signatures and hashes
+
+   # TODO: check the event id is valid in room v1, v2, and check it is absent
+   # in room v3 and later
 }
 push our @EXPORT, qw( assert_is_valid_pdu );
 

--- a/tests/50federation/32room-getevent.pl
+++ b/tests/50federation/32room-getevent.pl
@@ -9,22 +9,24 @@ test "Inbound federation can return events",
 
       my $local_server_name = $outbound_client->server_name;
 
-      my $member_event;
+      my ( $member_event, $room );
 
       $outbound_client->join_room(
          server_name => $first_home_server,
          room_id     => $room_id,
          user_id     => $user_id,
       )->then( sub {
-         my ( $room ) = @_;
+         ( $room ) = @_;
 
          $member_event = $room->get_current_state_event( "m.room.member", $user_id );
          log_if_fail "Member event", $member_event;
 
+         my $event_id = $room->id_for_event( $member_event );
+
          $outbound_client->do_request_json(
             method   => "GET",
             hostname => $first_home_server,
-            uri      => "/v1/event/$member_event->{event_id}",
+            uri      => "/v1/event/$event_id",
          );
       })->then( sub {
          my ( $body ) = @_;
@@ -39,7 +41,11 @@ test "Inbound federation can return events",
 
          # Check that the string fields seem right
          assert_eq( $event->{$_}, $member_event->{$_},
-            "event $_" ) for qw( depth event_id origin room_id sender state_key type );
+            "event $_" ) for qw( depth origin room_id sender state_key type );
+
+         if ( $room->room_version eq "1" || $room->room_version eq "2" ) {
+            assert_eq( $event->{event_id}, $member_event->{event_id}, "event_id" );
+         }
 
          Future->done(1);
       });

--- a/tests/50federation/33room-get-missing-events.pl
+++ b/tests/50federation/33room-get-missing-events.pl
@@ -142,8 +142,8 @@ foreach my $vis (qw( world_readable shared invite joined )) {
                uri      => "/v1/get_missing_events/" . $room->room_id,
 
                content => {
-                  earliest_events => [ $creation_event->{event_id} ],
-                  latest_events   => [ $member_event->{event_id} ],
+                  earliest_events => [ $room->id_for_event( $creation_event )],
+                  latest_events   => [ $room->id_for_event( $member_event )],
                   limit           => 10,
 
                   # XXX: min_depth requests the remote server to filter by depth

--- a/tests/50federation/38receipts.pl
+++ b/tests/50federation/38receipts.pl
@@ -28,7 +28,7 @@ test "Outbound federation sends receipts",
             },
          );
 
-         $event_id = $event->{event_id};
+         $event_id = $room->id_for_event( $event );
 
          $outbound_client->send_event(
             event => $event,

--- a/tests/50federation/39redactions.pl
+++ b/tests/50federation/39redactions.pl
@@ -202,7 +202,7 @@ test "An event which redacts an event in a different room should be ignored",
             },
          );
 
-         $msg_event_id = $event->{event_id};
+         $msg_event_id = $room_1->id_for_event( $event );
 
          Future->needs_all(
             $outbound_client->send_event(
@@ -224,7 +224,7 @@ test "An event which redacts an event in a different room should be ignored",
             redacts  => $msg_event_id,
          );
 
-         $redaction_event_id = $event->{event_id};
+         $redaction_event_id = $room_2->id_for_event( $event );
 
          log_if_fail "Sending redaction", $event;
 
@@ -244,7 +244,7 @@ test "An event which redacts an event in a different room should be ignored",
             },
          );
 
-         my $event_id = $event->{event_id};
+         my $event_id = $room_2->id_for_event( $event );
 
          Future->needs_all(
             $outbound_client->send_event(


### PR DESCRIPTION
Fixes some assumptions in the tests which do not necessarily hold in non-v1
rooms; in general these are just about whether events have 'event_id' fields.

(Doesn't actually change the tests to run on non-v1 rooms: that will be a
future change)