### PR TITLE
Support more room versions when joining over federation

### DIFF
--- a/lib/SyTest/Federation/Client.pm
+++ b/lib/SyTest/Federation/Client.pm
@@ -191,7 +191,7 @@ sub join_room
       method   => "GET",
       hostname => $server_name,
       uri      => "/v1/make_join/$room_id/$user_id",
-      params   => { "ver" => [1, 5] },
+      params   => { "ver" => [1, 2, 3, 4, 5] },
    )->then( sub {
       my ( $body ) = @_;
 


### PR DESCRIPTION
We already have everything we need for room versions 2-4, so let's allow
joining them:

 * v4 is the same as v5 except signing key validity periods, which is basically
   redundant for us

 * v3 is the same as v4 except for the hash format for event ids, which we
   already implement.

 * v2 is the same as v3 except again for the event id format (v2 uses chosen
   event IDs instead of hashes).