### PR TITLE
Allow specification of a room version on the commandline

### DIFF
--- a/run-tests.pl
+++ b/run-tests.pl
@@ -61,6 +61,11 @@ my $SERVER_IMPL = undef;
 my $WHITELIST_FILE;
 my $BLACKLIST_FILE;
 
+# the room version that we use for the majority of our tests (those which do
+# not requires a specific room version). 'undef' means 'use the default from
+# the server under test'.
+our $TEST_ROOM_VERSION;
+
 Getopt::Long::Configure('pass_through');
 GetOptions(
    'I|server-implementation=s' => \$SERVER_IMPL,
@@ -81,6 +86,8 @@ GetOptions(
    'v|verbose+' => \(my $VERBOSE = 0),
 
    'n|no-tls' => sub { $WANT_TLS = 0 },
+
+   'room-version=s' => \$TEST_ROOM_VERSION,
 
    # these two are superceded by -I, but kept for backwards compatibility
    'dendron=s' => sub {
@@ -171,6 +178,8 @@ Options:
 
    -p, --port-range START:MAX   - pool of TCP ports to allocate from
 
+   --room-version VERSION       - use the given room version for the majority of
+                                  tests
 .
    write STDERR;
 

--- a/tests/10apidoc/30room-create.pl
+++ b/tests/10apidoc/30room-create.pl
@@ -272,6 +272,9 @@ The following options have defaults:
    visibility => 'private'
    preset => 'public_chat'
 
+'room_version' will also be set if an explicit room version was given on the
+commandline.
+
 The resultant future completes with two values: the room_id from the
 /createRoom response; the room_alias from the /createRoom response (which is
 non-standard and its use is deprecated).
@@ -287,6 +290,10 @@ sub matrix_create_room
 
    $opts{visibility} //= "private";
    $opts{preset} //= "public_chat";
+
+   if( defined $TEST_ROOM_VERSION ) {
+      $opts{room_version} //= $TEST_ROOM_VERSION;
+   }
 
    do_request_json_for( $user,
       method => "POST",


### PR DESCRIPTION
Where tests do not specify an explicit room version, allow one to be chosen on
the commandline.