### PR TITLE
Reduce the amount of magic in the test suite

### DIFF
--- a/tests/10apidoc/33room-members.pl
+++ b/tests/10apidoc/33room-members.pl
@@ -601,21 +601,9 @@ sub local_user_and_room_fixtures
 }
 
 push @EXPORT, qw(
-   magic_local_user_and_room_fixtures matrix_join_room_synced
+   matrix_join_room_synced
    matrix_leave_room_synced matrix_invite_user_to_room_synced
 );
-
-sub magic_local_user_and_room_fixtures
-{
-   my %args = @_;
-
-   my $user_fixture = local_user_fixture();
-
-   return (
-      $user_fixture,
-      magic_room_fixture( requires_users => [ $user_fixture ], %args ),
-   );
-}
 
 sub matrix_join_room_synced
 {

--- a/tests/10apidoc/33room-members.pl
+++ b/tests/10apidoc/33room-members.pl
@@ -540,6 +540,38 @@ sub room_fixture
    );
 }
 
+=head2 magic_room_fixture
+
+   $fixture = magic_room_fixture(
+       requires_users => [ $creator_fixture, $other_user_fixture ],
+       %opts
+   );
+
+Returns a Fixture, which when provisioned will create a new room on the user's
+server and return the room id (and optionally the room alias).
+
+The following may be passed as named parameters:
+
+=over
+
+=item requires_users => LIST
+
+This should contain a list of user fixtures giving members of the new room. The
+first user is the creator of the room; the others are joined to the room after creation.
+
+=item with_alias => SCALAR
+
+This is passed into C<matrix_create_and_join_room>, and will make the result include
+the room alias as well as the room id.
+
+=item (everything else)
+
+Other parameters are passed into C<matrix_create_and_join_room>.
+
+=back
+
+=cut
+
 push @EXPORT, qw( magic_room_fixture );
 
 sub magic_room_fixture

--- a/tests/30rooms/04messages.pl
+++ b/tests/30rooms/04messages.pl
@@ -203,7 +203,7 @@ test "Remote room members can get room messages",
    };
 
 test "Message history can be paginated",
-   requires => [ magic_local_user_and_room_fixtures() ],
+   requires => [ local_user_and_room_fixtures() ],
 
    proves => [qw( can_paginate_room )],
 

--- a/tests/30rooms/06invite.pl
+++ b/tests/30rooms/06invite.pl
@@ -236,7 +236,7 @@ test "Invited user can reject local invite after originator leaves",
    };
 
 test "Invited user can see room metadata",
-   requires => [ magic_local_user_and_room_fixtures(), local_user_fixture() ],
+   requires => [ local_user_and_room_fixtures(), local_user_fixture() ],
 
    do => sub {
       my ( $creator, $room_id, $invitee ) = @_;
@@ -280,7 +280,7 @@ test "Invited user can see room metadata",
 
          $state_by_type{$_} or die "Did not receive $_ state"
             for qw( m.room.join_rules m.room.name
-                    m.room.canonical_alias m.room.avatar );
+                    m.room.avatar );
 
          my @futures = ();
 
@@ -306,7 +306,7 @@ test "Invited user can see room metadata",
    };
 
 test "Remote invited user can see room metadata",
-   requires => [ magic_local_user_and_room_fixtures(), remote_user_fixture() ],
+   requires => [ local_user_and_room_fixtures(), remote_user_fixture() ],
 
    do => sub {
       my ( $creator, $room_id, $invitee ) = @_;
@@ -348,7 +348,7 @@ test "Remote invited user can see room metadata",
 
          $state_by_type{$_} or die "Did not receive $_ state"
             for qw( m.room.join_rules m.room.name
-                    m.room.canonical_alias m.room.avatar );
+                    m.room.avatar );
 
          my @futures = ();
 

--- a/tests/30rooms/30history-visibility.pl
+++ b/tests/30rooms/30history-visibility.pl
@@ -535,13 +535,19 @@ test "Only see history_visibility changes on boundaries",
    };
 
 test "Backfill works correctly with history visibility set to joined",
-   requires => [ magic_local_user_and_room_fixtures( with_alias => 1), local_user_fixture(), remote_user_fixture() ],
+   requires => [ room_alias_name_fixture(), local_user_fixture(), local_user_fixture(), remote_user_fixture() ],
 
    do => sub {
-      my ( $user, $room_id, $room_alias, $another_user, $remote_user, $room_alias_name ) = @_;
+      my ( $room_alias_name, $user, $another_user, $remote_user ) = @_;
+      my ( $room_id, $room_alias );
 
-      matrix_set_room_history_visibility_synced( $user, $room_id, "joined" )
-      ->then( sub {
+      matrix_create_room(
+         $user,
+         room_alias_name => $room_alias_name,
+      )->then( sub {
+         ( $room_id, $room_alias ) = @_;
+         matrix_set_room_history_visibility_synced( $user, $room_id, "joined" );
+      })->then( sub {
          # Send some m.room.message that the remote server will not be able to see
          repeat( sub {
             my $msgnum = $_[0];


### PR DESCRIPTION
Get rid of magic_local_user_and_room_fixtures, and document magic_room_fixture.