### PR TITLE
Add v2 lookup support to sytest identity server

### DIFF
--- a/lib/SyTest/Identity/Server.pm
+++ b/lib/SyTest/Identity/Server.pm
@@ -143,7 +143,7 @@ sub on_request
          $req->respond_json( \%resp );
       }
       elsif ( "sha256" eq $algorithm ) {
-         # If using sha256, check and return hashes
+         # If using sha256, check parameters are correct and return mappings
          my @medium_address_pepper = split ' ', $address;
 
          # Check the medium, address and pepper are in the right format
@@ -179,7 +179,7 @@ sub on_request
             my $hash = sha256( "${lookup_address} email ${lookup_pepper}" );
             $hash = encode_base64url( $hash );
 
-            # Return the hash of "testuser@example.org email matrixrocks"
+            # Return the hash of "testuser@example.org email $lookup_pepper"
             $resp{mappings} = ( { $hash => '@testuser:example.org' } );
          }
 

--- a/lib/SyTest/Identity/Server.pm
+++ b/lib/SyTest/Identity/Server.pm
@@ -98,7 +98,7 @@ sub on_request
    }
    elsif( $path eq "/_matrix/identity/v2/hash_details" ) {
       $resp{lookup_pepper} = $self->{lookup_pepper};
-      @resp{algorithms} = [ "none" ];
+      @resp{algorithms} = [ "none", "sha256" ];
       $req->respond_json( \%resp );
    }
    elsif( $path eq "/_matrix/identity/v2/lookup" ) {
@@ -132,8 +132,8 @@ sub on_request
             my $user_medium = $address_medium[1];
 
             # Extract the MXID for this address/medium combo from the bindings hash
-            # We need to swap around medium and address here as it's stored "$medium $address"
-            # locally, not "$address $medium"
+            # We need to swap around medium and address here as it's stored $medium, $address
+            # locally, not $address, $medium
             my $mxid = $self->{bindings}{ join "\0", $user_medium, $user_address };
 
             $resp{mappings}{$address} = $mxid;


### PR DESCRIPTION
Adds the `/v2/hash_details` and `/v2/lookup` endpoints to the built-in sytest identity server.

Synapse PR: https://github.com/matrix-org/synapse/pull/5897