### PR TITLE
Have the in-built identity server support v2

### DIFF
--- a/lib/SyTest/Identity/Server.pm
+++ b/lib/SyTest/Identity/Server.pm
@@ -80,7 +80,7 @@ sub on_request
       pubkey( $self, $req, $key_name );
    }
    elsif( $path eq "/_matrix/identity/api/v1/lookup" ) {
-      v1_lookup( $req );
+      v1_lookup( $self, $req );
    }
    elsif( $path eq "/_matrix/identity/v2/lookup" ) {
       check_v2( $req );

--- a/lib/SyTest/Identity/Server.pm
+++ b/lib/SyTest/Identity/Server.pm
@@ -72,10 +72,10 @@ sub on_request
    ) {
       is_valid( $self, $req );
    }
-   elsif( $key_name = $path =~ m#^/_matrix/identity/api/v1/pubkey/([^/]*)$# ) {
+   elsif( ( $key_name ) = $path =~ m#^/_matrix/identity/api/v1/pubkey/([^/]*)$# ) {
       pubkey( $self, $req, $key_name );
    }
-   elsif( $key_name = $path =~ m#^/_matrix/identity/v2/pubkey/([^/]*)$# ) {
+   elsif( ( $key_name ) = $path =~ m#^/_matrix/identity/v2/pubkey/([^/]*)$# ) {
       check_v2( $req );
       pubkey( $self, $req, $key_name );
    }

--- a/lib/SyTest/Identity/Server.pm
+++ b/lib/SyTest/Identity/Server.pm
@@ -193,7 +193,7 @@ sub pubkey
    my ( $req, $key_name ) = @_;
    my %resp;
 
-   if( defined $self->{keys}->{$key_name} ) {
+   if( defined $self->{keys}{$key_name} ) {
       $resp{public_key} = $self->{keys}{$key_name};
    }
    $req->respond_json( \%resp );

--- a/tests/12login/01threepid-and-password.pl
+++ b/tests/12login/01threepid-and-password.pl
@@ -12,6 +12,7 @@ test "Can login with 3pid and password using m.login.password",
       my $medium = "email";
       my $address = 'bob@example.com';
       my $client_secret = "a client secret";
+      my $id_access_token = "testing";
 
       my $sid = $id_server->validate_identity( $medium, $address, $client_secret );
 
@@ -20,9 +21,10 @@ test "Can login with 3pid and password using m.login.password",
          uri    => "/r0/account/3pid",
          content => {
             three_pid_creds => {
-               id_server     => $id_server->name,
-               sid           => $sid,
-               client_secret => $client_secret,
+               id_server       => $id_server->name,
+               id_access_token => $id_access_token,
+               sid             => $sid,
+               client_secret   => $client_secret,
             },
             bind => JSON::false,
          },

--- a/tests/30rooms/12thirdpartyinvite.pl
+++ b/tests/30rooms/12thirdpartyinvite.pl
@@ -11,6 +11,7 @@ test "Can invite existing 3pid",
       my $invitee_mxid = $invitee->user_id;
 
       my $room_id;
+      my $id_access_token = "testing";
 
       $id_server->bind_identity( undef, "email", $invitee_email, $invitee )
       ->then( sub {
@@ -23,9 +24,10 @@ test "Can invite existing 3pid",
             uri    => "/r0/rooms/$room_id/invite",
 
             content => {
-               id_server    => $id_server->name,
-               medium       => "email",
-               address      => $invitee_email,
+               id_server       => $id_server->name,
+               id_access_token => $id_access_token,
+               medium          => "email",
+               address         => $invitee_email,
             },
          );
       })->then( sub {
@@ -51,6 +53,7 @@ test "Can invite existing 3pid with no ops",
       my $invitee_mxid = $invitee->user_id;
 
       my $room_id;
+      my $id_access_token = "testing";
 
       $id_server->bind_identity( undef, "email", $invitee_email, $invitee )
       ->then( sub {
@@ -63,9 +66,10 @@ test "Can invite existing 3pid with no ops",
             uri    => "/r0/rooms/$room_id/invite",
 
             content => {
-               id_server    => $id_server->name,
-               medium       => "email",
-               address      => $invitee_email,
+               id_server       => $id_server->name,
+               id_access_token => $id_access_token,
+               medium          => "email",
+               address         => $invitee_email,
             },
          );
       })->then( sub {
@@ -91,6 +95,7 @@ test "Can invite existing 3pid in createRoom",
       my $invitee_mxid = $invitee->user_id;
 
       my $room_id;
+      my $id_access_token = "testing";
 
       $id_server->bind_identity( undef, "email", $invitee_email, $invitee )
       ->then( sub {
@@ -98,6 +103,7 @@ test "Can invite existing 3pid in createRoom",
             medium    => "email",
             address   => $invitee_email,
             id_server => $id_server->name,
+            id_access_token => $id_access_token,
          };
          matrix_create_room( $inviter, invite_3pid => [ $invite_info ] );
       })->then( sub {
@@ -255,7 +261,7 @@ test "Can invite unbound 3pid over federation with users from both servers",
             return unless $event->{type} eq "m.room.member";
             return unless $event->{state_key} eq $invitee->user_id;
 
-            assert_eq( $event->{content}{membership},  "invite" );
+            assert_eq( $event->{content}{membership}, "invite" );
 
             return 1;
          })
@@ -464,13 +470,16 @@ sub assert_membership {
 sub do_3pid_invite {
    my ( $inviter, $room_id, $id_server, $invitee_email ) = @_;
 
+   my $id_access_token = "testing";
+
    do_request_json_for( $inviter,
       method  => "POST",
       uri     => "/r0/rooms/$room_id/invite",
       content => {
-         id_server    => $id_server,
-         medium       => "email",
-         address      => $invitee_email,
+         id_server       => $id_server,
+         id_access_token => $id_access_token,
+         medium          => "email",
+         address         => $invitee_email,
       }
    )->then( sub {
       my ( $result ) = @_;

--- a/tests/54identity.pl
+++ b/tests/54identity.pl
@@ -7,6 +7,7 @@ test "Can bind 3PID via home server",
       my $medium = "email";
       my $address = 'bob@example.com';
       my $client_secret = "a client secret";
+      my $id_access_token = "testing";
 
       my $sid = $id_server->validate_identity( $medium, $address, $client_secret );
 
@@ -15,9 +16,10 @@ test "Can bind 3PID via home server",
          uri    => "/r0/account/3pid",
          content => {
             three_pid_creds => {
-               id_server     => $id_server->name,
-               sid           => $sid,
-               client_secret => $client_secret,
+               id_server       => $id_server->name,
+               id_access_token => $id_access_token,
+               sid             => $sid,
+               client_secret   => $client_secret,
             },
             bind => JSON::true,
          },
@@ -40,6 +42,7 @@ test "Can bind and unbind 3PID via homeserver",
       my $medium = "email";
       my $address = 'bob@example.com';
       my $client_secret = "a client secret";
+      my $id_access_token = "testing";
 
       my $sid = $id_server->validate_identity( $medium, $address, $client_secret );
 
@@ -48,9 +51,10 @@ test "Can bind and unbind 3PID via homeserver",
          uri    => "/r0/account/3pid",
          content => {
             three_pid_creds => {
-               id_server     => $id_server->name,
-               sid           => $sid,
-               client_secret => $client_secret,
+               id_server       => $id_server->name,
+               id_access_token => $id_access_token,
+               sid             => $sid,
+               client_secret   => $client_secret,
             },
             bind => JSON::true,
          },
@@ -115,6 +119,7 @@ test "3PIDs are unbound after account deactivation",
       my $medium = "email";
       my $address = 'bob@example.com';
       my $client_secret = "a client secret";
+      my $id_access_token = "testing";
 
       my $sid = $id_server->validate_identity( $medium, $address, $client_secret );
 
@@ -123,9 +128,10 @@ test "3PIDs are unbound after account deactivation",
          uri    => "/r0/account/3pid",
          content => {
             three_pid_creds => {
-               id_server     => $id_server->name,
-               sid           => $sid,
-               client_secret => $client_secret,
+               id_server       => $id_server->name,
+               id_access_token => $id_access_token,
+               sid             => $sid,
+               client_secret   => $client_secret,
             },
             bind => JSON::true,
          },


### PR DESCRIPTION
Add all of the v2 identity server endpoints to Sytest's built-in identity server. This is independent of any of the Synapse changes currently in-flight.

Additionally, change the identity server tests to use these v2 endpoints.

This essentially just involves switching the endpoints to `v2` and including an `id_access_token` parameter at the top-level of the JSON, or in a query parameter.

I tried to reuse functions wherever possible.