### PR TITLE
Add loggers section to log config

### DIFF
--- a/lib/SyTest/Homeserver.pm
+++ b/lib/SyTest/Homeserver.pm
@@ -243,6 +243,12 @@ sub configure_logger
          }
       },
 
+      loggers => {
+         synapse => {
+            level => "INFO"
+         }
+      },
+
       root => {
          level => "INFO",
          handlers => ["file"]


### PR DESCRIPTION
This was causing the started servers to not print out any logs except the http stuff.