### PR TITLE
Replace HOMESERVER_INFO incantations

### DIFF
--- a/tests/10apidoc/00prepare.pl
+++ b/tests/10apidoc/00prepare.pl
@@ -1,7 +1,7 @@
 our @EXPORT = qw( User is_User do_request_json_for new_User );
 
 my @KEYS = qw(
-   http user_id device_id password access_token eventstream_token
+   http user_id server_name device_id password access_token eventstream_token
    sync_next_batch saved_events pending_get_events device_message_next_batch
 );
 
@@ -33,6 +33,7 @@ sub do_request_json_for
 sub new_User
 {
    my ( %params ) = @_;
+   $params{server_name} //= $params{http}->server_name;
 
    my $user = User( delete @params{ @KEYS } );
 

--- a/tests/50federation/10query-profile.pl
+++ b/tests/50federation/10query-profile.pl
@@ -40,11 +40,11 @@ test "Outbound federation can query profile data",
 my $dname = "Displayname Set For Federation Test";
 
 test "Inbound federation can query profile data",
-   requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0], local_user_fixture(),
+   requires => [ $main::OUTBOUND_CLIENT, local_user_fixture(),
                  qw( can_set_displayname )],
 
    do => sub {
-      my ( $outbound_client, $info, $user ) = @_;
+      my ( $outbound_client, $user ) = @_;
 
       do_request_json_for( $user,
          method => "PUT",
@@ -56,7 +56,7 @@ test "Inbound federation can query profile data",
       )->then( sub {
          $outbound_client->do_request_json(
             method   => "GET",
-            hostname => $info->server_name,
+            hostname => $user->server_name,
             uri      => "/v1/query/profile",
 
             params => {

--- a/tests/50federation/11query-directory.pl
+++ b/tests/50federation/11query-directory.pl
@@ -44,13 +44,13 @@ test "Inbound federation can query room alias directory",
    # TODO(paul): technically this doesn't need local_user_fixture(), if we had
    #   some user we could assert can perform media/directory/etc... operations
    #   but doesn't mutate any of its own state, or join rooms, etc...
-   requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
+   requires => [ $main::OUTBOUND_CLIENT,
                  local_user_fixture(), room_alias_fixture(),
                  qw( can_create_room_alias )],
 
    do => sub {
-      my ( $outbound_client, $info, $user, $room_alias ) = @_;
-      my $first_home_server = $info->server_name;
+      my ( $outbound_client, $user, $room_alias ) = @_;
+      my $first_home_server = $user->server_name;
 
       my $room_id;
 

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -204,13 +204,12 @@ test "Outbound federation passes make_join failures through to the client",
 
 test "Inbound federation can receive v1 room-join requests",
    requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
-                 $main::HOMESERVER_INFO[0],
                  local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                  federation_user_id_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $inbound_server, $info, undef, $room_id, $user_id ) = @_;
-      my $first_home_server = $info->server_name;
+      my ( $outbound_client, $inbound_server, $creator, $room_id, $user_id ) = @_;
+      my $first_home_server = $creator->server_name;
 
       my $local_server_name = $outbound_client->server_name;
       my $datastore         = $inbound_server->datastore;
@@ -338,14 +337,13 @@ test "Inbound federation can receive v1 room-join requests",
 
 test "Inbound federation rejects remote attempts to join local users to rooms",
    requires => [ $main::OUTBOUND_CLIENT,
-                 $main::HOMESERVER_INFO[0],
                  local_user_fixture(),
                  local_user_fixture(),
                ],
 
    do => sub {
-      my ( $outbound_client, $info, $creator_user, $user ) = @_;
-      my $first_home_server = $info->server_name;
+      my ( $outbound_client, $creator_user, $user ) = @_;
+      my $first_home_server = $creator_user->server_name;
 
       my $user_id = $user->user_id;
 
@@ -373,13 +371,12 @@ test "Inbound federation rejects remote attempts to join local users to rooms",
 
 test "Inbound federation rejects remote attempts to kick local users to rooms",
    requires => [ $main::OUTBOUND_CLIENT,
-                 $main::HOMESERVER_INFO[0],
                  local_user_fixture(),
                ],
 
    do => sub {
-      my ( $outbound_client, $info, $creator_user ) = @_;
-      my $first_home_server = $info->server_name;
+      my ( $outbound_client, $creator_user ) = @_;
+      my $first_home_server = $creator_user->server_name;
 
       my $user_id = $creator_user->user_id;
 
@@ -406,14 +403,13 @@ test "Inbound federation rejects remote attempts to kick local users to rooms",
 
 test "Inbound federation rejects attempts to join v1 rooms from servers without v1 support",
    requires => [ $main::OUTBOUND_CLIENT,
-                 $main::HOMESERVER_INFO[0],
                  local_user_fixture(),
                  federation_user_id_fixture(),
                ],
 
    do => sub {
-      my ( $outbound_client, $info, $creator_user, $user_id ) = @_;
-      my $first_home_server = $info->server_name;
+      my ( $outbound_client, $creator_user, $user_id ) = @_;
+      my $first_home_server = $creator_user->server_name;
 
       matrix_create_room(
          $creator_user,
@@ -443,14 +439,13 @@ test "Inbound federation rejects attempts to join v1 rooms from servers without 
 
 test "Inbound federation rejects attempts to join v2 rooms from servers lacking version support",
    requires => [ $main::OUTBOUND_CLIENT,
-                 $main::HOMESERVER_INFO[0],
                  local_user_fixture(),
                  federation_user_id_fixture(),
                  qw( can_create_versioned_room ) ],
 
    do => sub {
-      my ( $outbound_client, $info, $creator_user, $user_id ) = @_;
-      my $first_home_server = $info->server_name;
+      my ( $outbound_client, $creator_user, $user_id ) = @_;
+      my $first_home_server = $creator_user->server_name;
 
       matrix_create_room(
          $creator_user,
@@ -477,14 +472,13 @@ test "Inbound federation rejects attempts to join v2 rooms from servers lacking 
 
 test "Inbound federation rejects attempts to join v2 rooms from servers only supporting v1",
    requires => [ $main::OUTBOUND_CLIENT,
-                 $main::HOMESERVER_INFO[0],
                  local_user_fixture(),
                  federation_user_id_fixture(),
                  qw( can_create_versioned_room ) ],
 
    do => sub {
-      my ( $outbound_client, $info, $creator_user, $user_id ) = @_;
-      my $first_home_server = $info->server_name;
+      my ( $outbound_client, $creator_user, $user_id ) = @_;
+      my $first_home_server = $creator_user->server_name;
 
       matrix_create_room(
          $creator_user,
@@ -514,14 +508,13 @@ test "Inbound federation rejects attempts to join v2 rooms from servers only sup
 
 test "Inbound federation accepts attempts to join v2 rooms from servers with support",
    requires => [ $main::OUTBOUND_CLIENT,
-                 $main::HOMESERVER_INFO[0],
                  local_user_fixture(),
                  federation_user_id_fixture(),
                  qw( can_create_versioned_room ) ],
 
    do => sub {
-      my ( $outbound_client, $info, $creator_user, $user_id ) = @_;
-      my $first_home_server = $info->server_name;
+      my ( $outbound_client, $creator_user, $user_id ) = @_;
+      my $first_home_server = $creator_user->server_name;
 
       matrix_create_room(
          $creator_user,

--- a/tests/50federation/31room-send.pl
+++ b/tests/50federation/31room-send.pl
@@ -46,15 +46,15 @@ test "Outbound federation can send events",
    };
 
 test "Inbound federation can receive events",
-   requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
+   requires => [ $main::OUTBOUND_CLIENT,
                  local_user_and_room_fixtures(
                    user_opts => { with_events => 1 },
                  ),
                  federation_user_id_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $info, $creator, $room_id, $user_id ) = @_;
-      my $first_home_server = $info->server_name;
+      my ( $outbound_client, $creator, $room_id, $user_id ) = @_;
+      my $first_home_server = $creator->server_name;
 
       my $local_server_name = $outbound_client->server_name;
 
@@ -95,15 +95,15 @@ test "Inbound federation can receive events",
    };
 
 test "Inbound federation can receive redacted events",
-   requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
+   requires => [ $main::OUTBOUND_CLIENT,
                  local_user_and_room_fixtures(
                    user_opts => { with_events => 1 },
                  ),
                  federation_user_id_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $info, $creator, $room_id, $user_id ) = @_;
-      my $first_home_server = $info->server_name;
+      my ( $outbound_client, $creator, $room_id, $user_id ) = @_;
+      my $first_home_server = $creator->server_name;
 
       my $local_server_name = $outbound_client->server_name;
 

--- a/tests/50federation/31room-send.pl
+++ b/tests/50federation/31room-send.pl
@@ -1,5 +1,6 @@
 use Protocol::Matrix qw( redact_event );
 
+
 test "Outbound federation can send events",
    requires => [ local_user_fixture(), $main::INBOUND_SERVER, federation_user_id_fixture() ],
 

--- a/tests/50federation/32room-getevent.pl
+++ b/tests/50federation/32room-getevent.pl
@@ -1,11 +1,11 @@
 test "Inbound federation can return events",
-   requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
+   requires => [ $main::OUTBOUND_CLIENT,
                  local_user_and_room_fixtures(),
                  federation_user_id_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $info, undef, $room_id, $user_id ) = @_;
-      my $first_home_server = $info->server_name;
+      my ( $outbound_client, $creator, $room_id, $user_id ) = @_;
+      my $first_home_server = $creator->server_name;
 
       my $local_server_name = $outbound_client->server_name;
 
@@ -53,13 +53,13 @@ test "Inbound federation can return events",
 
 
 test "Inbound federation redacts events from erased users",
-   requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
+   requires => [ $main::OUTBOUND_CLIENT,
                  local_user_and_room_fixtures(),
                  federation_user_id_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $info, $creator, $room_id, $user_id ) = @_;
-      my $first_home_server = $info->server_name;
+      my ( $outbound_client, $creator, $room_id, $user_id ) = @_;
+      my $first_home_server = $creator->server_name;
 
       my $message_id;
 

--- a/tests/50federation/33room-get-missing-events.pl
+++ b/tests/50federation/33room-get-missing-events.pl
@@ -1,5 +1,5 @@
 test "Outbound federation can request missing events",
-   requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO[0],
+   requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
                  local_user_and_room_fixtures(
                     user_opts => { with_events => 1 },
                     room_opts => { room_version => "1" },
@@ -7,8 +7,8 @@ test "Outbound federation can request missing events",
                  federation_user_id_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $inbound_server, $info, $creator, $room_id, $user_id ) = @_;
-      my $first_home_server = $info->server_name;
+      my ( $outbound_client, $inbound_server, $creator, $room_id, $user_id ) = @_;
+      my $first_home_server = $creator->server_name;
 
       my $local_server_name = $inbound_server->server_name;
       my $datastore         = $inbound_server->datastore;
@@ -104,13 +104,13 @@ test "Outbound federation can request missing events",
 
 foreach my $vis (qw( world_readable shared invite joined )) {
    test "Inbound federation can return missing events for $vis visibility",
-      requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
+      requires => [ $main::OUTBOUND_CLIENT,
                     local_user_and_room_fixtures(),
                     federation_user_id_fixture() ],
 
       do => sub {
-         my ( $outbound_client, $info, $creator, $room_id, $user_id ) = @_;
-         my $first_home_server = $info->server_name;
+         my ( $outbound_client, $creator, $room_id, $user_id ) = @_;
+         my $first_home_server = $creator->server_name;
 
          # start by making the room sekret
          matrix_set_room_history_visibility(

--- a/tests/50federation/34room-backfill.pl
+++ b/tests/50federation/34room-backfill.pl
@@ -130,13 +130,13 @@ test "Outbound federation can backfill events",
    };
 
 test "Inbound federation can backfill events",
-   requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
+   requires => [ $main::OUTBOUND_CLIENT,
                  local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                  federation_user_id_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $info, $creator, $room_id, $user_id ) = @_;
-      my $first_home_server = $info->server_name;
+      my ( $outbound_client, $creator, $room_id, $user_id ) = @_;
+      my $first_home_server = $creator->server_name;
 
       my $local_server_name = $outbound_client->server_name;
 
@@ -193,14 +193,14 @@ test "Inbound federation can backfill events",
    };
 
 test "Backfill checks the events requested belong to the room",
-   requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
+   requires => [ $main::OUTBOUND_CLIENT,
                  local_user_and_room_fixtures(),
                  local_user_and_room_fixtures(),
                  federation_user_id_fixture() ],
    do => sub {
-      my ( $outbound_client, $info, $priv_creator, $priv_room_id,
+      my ( $outbound_client, $priv_creator, $priv_room_id,
            $pub_creator, $pub_room_id, $fed_user_id ) = @_;
-      my $first_home_server = $info->server_name;
+      my $first_home_server = $priv_creator->server_name;
 
       my $local_server_name = $outbound_client->server_name;
 

--- a/tests/50federation/36-state.pl
+++ b/tests/50federation/36-state.pl
@@ -10,15 +10,13 @@ sub get_state_ids_from_server {
 }
 
 test "Inbound federation can get state for a room",
-   requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
+   requires => [ $main::OUTBOUND_CLIENT,
                  local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                  federation_user_id_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $info, undef, $room_id, $user_id ) = @_;
-      my $first_home_server = $info->server_name;
-
-      my $local_server_name = $outbound_client->server_name;
+      my ( $outbound_client, $creator, $room_id, $user_id ) = @_;
+      my $first_home_server = $creator->server_name;
 
       my $room;
 
@@ -60,15 +58,13 @@ test "Inbound federation can get state for a room",
 
 
 test "Inbound federation of state requires event_id as a mandatory paramater",
-   requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
+   requires => [ $main::OUTBOUND_CLIENT,
                  local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                  federation_user_id_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $info, undef, $room_id, $user_id ) = @_;
-      my $first_home_server = $info->server_name;
-
-      my $local_server_name = $outbound_client->server_name;
+      my ( $outbound_client, $creator, $room_id, $user_id ) = @_;
+      my $first_home_server = $creator->server_name;
 
       $outbound_client->do_request_json(
          method   => "GET",
@@ -79,15 +75,13 @@ test "Inbound federation of state requires event_id as a mandatory paramater",
 
 
 test "Inbound federation can get state_ids for a room",
-   requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
+   requires => [ $main::OUTBOUND_CLIENT,
                  local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                  federation_user_id_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $info, undef, $room_id, $user_id ) = @_;
-      my $first_home_server = $info->server_name;
-
-      my $local_server_name = $outbound_client->server_name;
+      my ( $outbound_client, $info, $creator, $room_id, $user_id ) = @_;
+      my $first_home_server = $creator->server_name;
 
       my $room;
 
@@ -124,15 +118,13 @@ test "Inbound federation can get state_ids for a room",
    };
 
 test "Inbound federation of state_ids requires event_id as a mandatory paramater",
-   requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
+   requires => [ $main::OUTBOUND_CLIENT,
                  local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                  federation_user_id_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $info, undef, $room_id, $user_id ) = @_;
-      my $first_home_server = $info->server_name;
-
-      my $local_server_name = $outbound_client->server_name;
+      my ( $outbound_client, $creator, $room_id, $user_id ) = @_;
+      my $first_home_server = $creator->server_name;
 
       $outbound_client->do_request_json(
          method   => "GET",
@@ -142,7 +134,7 @@ test "Inbound federation of state_ids requires event_id as a mandatory paramater
    };
 
 test "Federation rejects inbound events where the prev_events cannot be found",
-   requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO[0],
+   requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
                  local_user_and_room_fixtures(
                     user_opts => { with_events => 1 },
                     room_opts => { room_version => "1" },
@@ -150,10 +142,8 @@ test "Federation rejects inbound events where the prev_events cannot be found",
                  federation_user_id_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $inbound_server, $info, $creator, $room_id, $user_id ) = @_;
-      my $first_home_server = $info->server_name;
-
-      my $local_server_name = $outbound_client->server_name;
+      my ( $outbound_client, $inbound_server, $creator, $room_id, $user_id ) = @_;
+      my $first_home_server = $creator->server_name;
 
       my $room;
       my $sent_event;
@@ -226,7 +216,7 @@ test "Federation rejects inbound events where the prev_events cannot be found",
 
 
 test "Outbound federation requests missing prev_events and then asks for /state_ids and resolves the state",
-   requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO[0],
+   requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
                  local_user_and_room_fixtures(
                     user_opts => { with_events => 1 },
                     room_opts => { room_version => "1" },
@@ -234,8 +224,8 @@ test "Outbound federation requests missing prev_events and then asks for /state_
                  federation_user_id_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $inbound_server, $info, $creator, $room_id, $user_id ) = @_;
-      my $first_home_server = $info->server_name;
+      my ( $outbound_client, $inbound_server, $creator, $room_id, $user_id ) = @_;
+      my $first_home_server = $creator->server_name;
 
       # in this test, we're going to create a DAG like this:
       #
@@ -494,7 +484,7 @@ test "Outbound federation requests missing prev_events and then asks for /state_
 
 
 test "Federation handles empty auth_events in state_ids sanely",
-   requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO[0],
+   requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
                  local_user_and_room_fixtures(
                     user_opts => { with_events => 1 },
                     room_opts => { room_version => "1" },
@@ -502,8 +492,8 @@ test "Federation handles empty auth_events in state_ids sanely",
                  federation_user_id_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $inbound_server, $info, $creator, $room_id, $user_id ) = @_;
-      my $first_home_server = $info->server_name;
+      my ( $outbound_client, $inbound_server, $creator, $room_id, $user_id ) = @_;
+      my $first_home_server = $creator->server_name;
 
       # in this test, we're going to create a DAG like this:
       #
@@ -651,16 +641,14 @@ test "Federation handles empty auth_events in state_ids sanely",
 
 
 test "Getting state checks the events requested belong to the room",
-   requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
+   requires => [ $main::OUTBOUND_CLIENT,
                  local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                  local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                  federation_user_id_fixture() ],
    do => sub {
-      my ( $outbound_client, $info, $priv_creator, $priv_room_id,
+      my ( $outbound_client, $priv_creator, $priv_room_id,
            $pub_creator, $pub_room_id, $fed_user_id ) = @_;
-      my $first_home_server = $info->server_name;
-
-      my $local_server_name = $outbound_client->server_name;
+      my $first_home_server = $pub_creator->server_name;
 
       my $priv_join_event;
 
@@ -693,16 +681,14 @@ test "Getting state checks the events requested belong to the room",
 
 
 test "Getting state IDs checks the events requested belong to the room",
-   requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
+   requires => [ $main::OUTBOUND_CLIENT,
                  local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                  local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                  federation_user_id_fixture() ],
    do => sub {
-      my ( $outbound_client, $info, $priv_creator, $priv_room_id,
+      my ( $outbound_client, $priv_creator, $priv_room_id,
            $pub_creator, $pub_room_id, $fed_user_id ) = @_;
-      my $first_home_server = $info->server_name;
-
-      my $local_server_name = $outbound_client->server_name;
+      my $first_home_server = $pub_creator->server_name;
 
       my $priv_join_event;
 
@@ -764,7 +750,7 @@ test "Should not be able to take over the room by pretending there is no PL even
    # unaffected.
 
    requires => [
-      $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO[0],
+      $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
       # Create user and a publicly joinable room on the synapse.
       local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
       # Pick a user_id for our evil federation user.
@@ -772,9 +758,8 @@ test "Should not be able to take over the room by pretending there is no PL even
    ],
 
    do => sub {
-      my ( $outbound_client, $inbound_server, $info, $creator, $room_id, $evil_user_id ) = @_;
-      my $first_home_server = $info->server_name;
-      my $local_server_name = $outbound_client->server_name;
+      my ( $outbound_client, $inbound_server, $creator, $room_id, $evil_user_id ) = @_;
+      my $first_home_server = $creator->server_name;
 
       # Join our evil user to the room.
       $outbound_client->join_room(

--- a/tests/50federation/36-state.pl
+++ b/tests/50federation/36-state.pl
@@ -80,7 +80,7 @@ test "Inbound federation can get state_ids for a room",
                  federation_user_id_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $info, $creator, $room_id, $user_id ) = @_;
+      my ( $outbound_client, $creator, $room_id, $user_id ) = @_;
       my $first_home_server = $creator->server_name;
 
       my $room;

--- a/tests/50federation/37public-rooms.pl
+++ b/tests/50federation/37public-rooms.pl
@@ -1,11 +1,11 @@
 test "Inbound federation can get public room list",
-   requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
+   requires => [ $main::OUTBOUND_CLIENT,
                  local_user_and_room_fixtures(),
                  federation_user_id_fixture() ],
 
    do => sub {
-     my ( $outbound_client, $info, $creator, $room_id, $user_id ) = @_;
-     my $first_home_server = $info->server_name;
+     my ( $outbound_client, $creator, $room_id, $user_id ) = @_;
+     my $first_home_server = $creator->server_name;
 
      my $local_server_name = $outbound_client->server_name;
 

--- a/tests/50federation/38receipts.pl
+++ b/tests/50federation/38receipts.pl
@@ -3,16 +3,15 @@ test "Outbound federation sends receipts",
                  federation_user_id_fixture(),
                  $main::OUTBOUND_CLIENT,
                  $main::INBOUND_SERVER,
-                 $main::HOMESERVER_INFO[0],
                  qw( can_post_room_receipts ),
                ],
    do => sub {
-      my ( $creator_user, $room_id, $federated_user_id, $outbound_client, $inbound_server, $server_0 ) = @_;
+      my ( $creator_user, $room_id, $federated_user_id, $outbound_client, $inbound_server ) = @_;
 
       my $event_id;
 
       $outbound_client->join_room(
-         server_name => $server_0->server_name,
+         server_name => $creator_user->server_name,
          room_id     => $room_id,
          user_id     => $federated_user_id,
       )->then( sub {
@@ -32,7 +31,7 @@ test "Outbound federation sends receipts",
 
          $outbound_client->send_event(
             event => $event,
-            destination => $server_0->server_name,
+            destination => $creator_user->server_name,
          );
       })->then( sub {
          await_sync_timeline_contains( $creator_user, $room_id, check => sub {
@@ -72,14 +71,14 @@ test "Outbound federation sends receipts",
 
 
 test "Inbound federation rejects receipts from wrong remote",
-   requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO[0],
+   requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
                  local_user_and_room_fixtures(),
                  federation_user_id_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $inbound_server, $info, $creator, $room_id, $user_id ) = @_;
+      my ( $outbound_client, $inbound_server, $creator, $room_id, $user_id ) = @_;
 
-      my $local_server_name = $info->server_name;
+      my $local_server_name = $creator->server_name;
       my $remote_server_name = $inbound_server->server_name;
 
       my ( $event_id, );

--- a/tests/50federation/39redactions.pl
+++ b/tests/50federation/39redactions.pl
@@ -18,7 +18,6 @@ test "Inbound federation ignores redactions from invalid servers room > v3",
    requires => [
       $main::OUTBOUND_CLIENT,
       $main::INBOUND_SERVER,
-      $main::HOMESERVER_INFO[0],
       local_user_and_room_fixtures(
          room_opts => { room_version => "5" },
       ),
@@ -26,8 +25,8 @@ test "Inbound federation ignores redactions from invalid servers room > v3",
    ],
 
    do => sub {
-      my ( $outbound_client, $inbound_server, $info, $creator, $room_id, $user_id ) = @_;
-      my $first_home_server = $info->server_name;
+      my ( $outbound_client, $inbound_server, $creator, $room_id, $user_id ) = @_;
+      my $first_home_server = $creator->server_name;
 
       my ( $msg_event_id, $redaction_event_id, $room );
 
@@ -135,7 +134,6 @@ test "An event which redacts an event in a different room should be ignored",
    requires => [
       $main::OUTBOUND_CLIENT,
       $main::INBOUND_SERVER,
-      $main::HOMESERVER_INFO[0],
       $creator_fixture,
       room_fixture( $creator_fixture ),
       room_fixture( $creator_fixture ),
@@ -143,8 +141,8 @@ test "An event which redacts an event in a different room should be ignored",
    ],
 
    do => sub {
-      my ( $outbound_client, $inbound_server, $info, $creator, $room_id_1, $room_id_2, $user_id ) = @_;
-      my $first_home_server = $info->server_name;
+      my ( $outbound_client, $inbound_server, $creator, $room_id_1, $room_id_2, $user_id ) = @_;
+      my $first_home_server = $creator->server_name;
 
       my ( $room_1, $room_2 );
       my ( $msg_event_id, $redaction_event_id );
@@ -253,14 +251,13 @@ test "An event which redacts itself should be ignored",
    requires => [
       $main::OUTBOUND_CLIENT,
       $main::INBOUND_SERVER,
-      $main::HOMESERVER_INFO[0],
       local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
       federation_user_id_fixture(),
    ],
 
    do => sub {
-      my ( $outbound_client, $inbound_server, $info, $creator, $room_id, $user_id ) = @_;
-      my $first_home_server = $info->server_name;
+      my ( $outbound_client, $inbound_server, $creator, $room_id, $user_id ) = @_;
+      my $first_home_server = $creator->server_name;
 
       my ( $room );
 
@@ -302,14 +299,13 @@ test "A pair of events which redact each other should be ignored",
    requires => [
       $main::OUTBOUND_CLIENT,
       $main::INBOUND_SERVER,
-      $main::HOMESERVER_INFO[0],
       local_user_and_room_fixtures( room_opts => { room_version => "1" }),
       federation_user_id_fixture(),
    ],
 
    do => sub {
-      my ( $outbound_client, $inbound_server, $info, $creator, $room_id, $user_id ) = @_;
-      my $first_home_server = $info->server_name;
+      my ( $outbound_client, $inbound_server, $creator, $room_id, $user_id ) = @_;
+      my $first_home_server = $creator->server_name;
 
       my ( $room );
 

--- a/tests/50federation/40devicelists.pl
+++ b/tests/50federation/40devicelists.pl
@@ -64,15 +64,15 @@ test "Local device key changes get to remote servers",
 test "Server correctly handles incoming m.device_list_update",
    requires => [ local_user_fixture(),
                  $main::INBOUND_SERVER, $main::OUTBOUND_CLIENT,
-                 $main::HOMESERVER_INFO[0],  federation_user_id_fixture(),
+                 federation_user_id_fixture(),
                  room_alias_name_fixture() ],
 
    check => sub {
-      my ( $user, $inbound_server, $outbound_client, $info, $creator_id, $room_alias_name ) = @_;
+      my ( $user, $inbound_server, $outbound_client, $creator_id, $room_alias_name ) = @_;
 
       my ( $room_id );
 
-      my $local_server_name = $info->server_name;
+      my $local_server_name = $user->server_name;
 
       my $remote_server_name = $inbound_server->server_name;
       my $datastore          = $inbound_server->datastore;
@@ -290,7 +290,6 @@ test "Device list doesn't change if remote server is down",
    requires => [
       $main::OUTBOUND_CLIENT,
       $main::INBOUND_SERVER,
-      $main::HOMESERVER_INFO[0],
       local_user_fixture,
       federation_user_id_fixture(),
       qw( can_upload_e2e_keys )
@@ -300,7 +299,6 @@ test "Device list doesn't change if remote server is down",
       my (
          $outbound_client,
          $inbound_server,
-         $local_server_info,
          $local_user,
          $outbound_client_user
       ) = @_;
@@ -372,7 +370,7 @@ test "Device list doesn't change if remote server is down",
       )->then( sub {
          my ( $room_id ) = @_;
          $outbound_client->join_room(
-            server_name => $local_server_info->server_name,
+            server_name => $local_user->server_name,
             room_id     => $room_id,
             user_id     => $outbound_client_user,
          )

--- a/tests/50federation/41power-levels.pl
+++ b/tests/50federation/41power-levels.pl
@@ -61,17 +61,16 @@ test "Remote servers should reject attempts by non-creators to set the power lev
 
    requires => [ $main::OUTBOUND_CLIENT,
                  $main::INBOUND_SERVER,
-                 $main::HOMESERVER_INFO[0],
                  local_user_fixture(),
                  federation_user_id_fixture(),
                  federation_user_id_fixture(),
                 ],
 
    do => sub {
-      my ( $outbound_server, $inbound_server, $hs_info,
+      my ( $outbound_server, $inbound_server,
            $synapse_user, $sytest_user_id_a, $sytest_user_id_b ) = @_;
 
-      my $synapse_server_name = $synapse_user->http->server_name;
+      my $synapse_server_name = $synapse_user->server_name;
       my $outbound_client     = $inbound_server->client;
       my $sytest_server_name  = $inbound_server->server_name;
       my $datastore           = $inbound_server->datastore;
@@ -118,7 +117,7 @@ test "Remote servers should reject attempts by non-creators to set the power lev
 
          $outbound_client->send_event(
             event => $pl,
-            destination => $hs_info->server_name,
+            destination => $synapse_server_name,
          );
       })->then( sub {
          # check that synapse still doesn't have a PL event. Annoyingly we need

--- a/tests/50federation/42query-auth.pl
+++ b/tests/50federation/42query-auth.pl
@@ -1,14 +1,14 @@
 use Future::Utils qw( repeat );
 
 test "Querying auth checks the events requested belong to the room",
-   requires => [ $main::OUTBOUND_CLIENT, $main::HOMESERVER_INFO[0],
+   requires => [ $main::OUTBOUND_CLIENT,
                  local_user_and_room_fixtures(),
                  local_user_and_room_fixtures(),
                  federation_user_id_fixture() ],
    do => sub {
-      my ( $outbound_client, $info, $priv_creator, $priv_room_id,
+      my ( $outbound_client, $priv_creator, $priv_room_id,
            $pub_creator, $pub_room_id, $fed_user_id ) = @_;
-      my $first_home_server = $info->server_name;
+      my $first_home_server = $pub_creator->server_name;
 
       my $local_server_name = $outbound_client->server_name;
 

--- a/tests/50federation/43typing.pl
+++ b/tests/50federation/43typing.pl
@@ -3,15 +3,14 @@
 test "Inbound federation rejects typing notifications from wrong remote",
    requires => [
       $main::OUTBOUND_CLIENT,
-      $main::HOMESERVER_INFO[0],
       local_user_and_room_fixtures(),
       federation_user_id_fixture(),
    ],
 
    do => sub {
-      my ( $outbound_client, $info, $creator, $room_id, $user_id ) = @_;
+      my ( $outbound_client, $creator, $room_id, $user_id ) = @_;
 
-      my $local_server_name = $info->server_name;
+      my $local_server_name = $creator->server_name;
 
       $outbound_client->join_room(
          server_name => $local_server_name,

--- a/tests/50federation/50no-deextrem-outliers.pl
+++ b/tests/50federation/50no-deextrem-outliers.pl
@@ -1,5 +1,5 @@
 test "Forward extremities remain so even after the next events are populated as outliers",
-      requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO[0],
+      requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
                  local_user_and_room_fixtures(
                     user_opts => { with_events => 1 },
                     room_opts => { room_version => "1" },
@@ -7,8 +7,8 @@ test "Forward extremities remain so even after the next events are populated as 
                  federation_user_id_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $inbound_server, $info, $creator, $room_id, $user_id ) = @_;
-      my $first_home_server = $info->server_name;
+      my ( $outbound_client, $inbound_server, $creator, $room_id, $user_id ) = @_;
+      my $first_home_server = $creator->server_name;
 
       # Here we create a straightforward dag like this:
       #

--- a/tests/50federation/51transactions.pl
+++ b/tests/50federation/51transactions.pl
@@ -1,19 +1,17 @@
 test "Server correctly handles transactions that break edu limits",
-   requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO[0],
+   requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
                  local_user_and_room_fixtures(),
                  federation_user_id_fixture(), room_alias_name_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $inbound_server, $info, $creator, $room_id, $user_id, $room_alias_name ) = @_;
-
-      my $local_server_name = $info->server_name;
+      my ( $outbound_client, $inbound_server, $creator, $room_id, $user_id, $room_alias_name ) = @_;
 
       my $remote_server_name = $inbound_server->server_name;
 
       my $room_alias = "#$room_alias_name:$remote_server_name";
 
       $outbound_client->join_room(
-         server_name => $local_server_name,
+         server_name => $creator->server_name,
          room_id     => $room_id,
          user_id     => $user_id,
       )->then( sub {
@@ -37,13 +35,13 @@ test "Server correctly handles transactions that break edu limits",
             # Send the transaction to the client and expect a fail
             $outbound_client->send_transaction(
                 pdus => \@bad_pdus,
-                destination => $local_server_name,
+                destination => $creator->server_name,
             )->main::expect_http_400(),
 
             # Send the transaction to the client and expect a succeed
             $outbound_client->send_transaction(
                 pdus => \@good_pdus,
-                destination => $local_server_name,
+                destination => $creator->server_name,
             )->then( sub {
                 my ( $response ) = @_;
 

--- a/tests/50federation/52soft-fail.pl
+++ b/tests/50federation/52soft-fail.pl
@@ -1,5 +1,5 @@
 test "Inbound federation correctly soft fails events",
-   requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO[0],
+   requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
                  local_user_and_room_fixtures(
                     user_opts => { with_events => 1 },
                     room_opts => { room_version => "1" },
@@ -7,10 +7,8 @@ test "Inbound federation correctly soft fails events",
                  federation_user_id_fixture() ],
 
    do => sub {
-      my ( $outbound_client, $inbound_server, $info, $creator, $room_id, $user_id ) = @_;
-      my $first_home_server = $info->server_name;
-
-      my $local_server_name = $outbound_client->server_name;
+      my ( $outbound_client, $inbound_server, $creator, $room_id, $user_id ) = @_;
+      my $first_home_server = $creator->server_name;
 
       my $room;
 
@@ -146,7 +144,7 @@ test "Inbound federation correctly soft fails events",
 test "Inbound federation accepts a second soft-failed event",
    # this is mostly a regression test for https://github.com/matrix-org/synapse/issues/5090.
    requires => [
-      $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO[0],
+      $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
       local_user_and_room_fixtures(
          user_opts => { with_events => 1 },
          room_opts => { room_version => "1" }
@@ -156,12 +154,10 @@ test "Inbound federation accepts a second soft-failed event",
 
    do => sub {
       my (
-         $outbound_client, $inbound_server, $info, $creator, $room_id,
+         $outbound_client, $inbound_server, $creator, $room_id,
          $remote_user_id,
       ) = @_;
-      my $first_home_server = $info->server_name;
-
-      my $local_server_name = $outbound_client->server_name;
+      my $first_home_server = $creator->server_name;
 
       my $room;
 
@@ -332,7 +328,7 @@ test "Inbound federation accepts a second soft-failed event",
 test "Inbound federation correctly handles soft failed events as extremities",
    # this is mostly a regression test for https://github.com/matrix-org/synapse/issues/5269.
    requires => [
-      $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER, $main::HOMESERVER_INFO[0],
+      $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
       local_user_and_room_fixtures(
          user_opts => { with_events => 1 },
           room_opts => { room_version => "1" },
@@ -342,12 +338,10 @@ test "Inbound federation correctly handles soft failed events as extremities",
 
    do => sub {
       my (
-         $outbound_client, $inbound_server, $info, $creator, $room_id,
+         $outbound_client, $inbound_server, $creator, $room_id,
          $remote_user_id,
       ) = @_;
-      my $first_home_server = $info->server_name;
-
-      my $local_server_name = $outbound_client->server_name;
+      my $first_home_server = $creator->server_name;
 
       my $room;
 


### PR DESCRIPTION
I've always found these HOMESERVER_INFO[0] incantations awkward and
confusing. In general, we want to be sending events/requests/etc to the server
associated with a given user, so let's store it in the User object, rather
than going back to the HOMESERVER_INFO.