### PR TITLE
Use Sytest develop for Dendrite's master branch

### DIFF
--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -13,6 +13,11 @@ else
     else
         # Otherwise, try and find out what the branch that the Synapse/Dendrite checkout is using. Fall back to develop if it's not a branch.
         branch_name="$(git --git-dir=/src/.git symbolic-ref HEAD 2>/dev/null)" || branch_name="develop"
+
+        if [ "$1" == "dendrite" ] && [ branch_name == "master" ]; then
+            # Dendrite uses master as its main branch. If the branch is master, we probably want sytest develop
+            branch_name="develop"
+        fi
     fi
 
     # Try and fetch the branch


### PR DESCRIPTION
When using Dendrite's master branch (the dev branch), we want to be running against Sytest develop.

Add an if condition that checks for this situation and forces the use of Sytest's develop branch (instead of master, which would be the same-named branch).