### PR TITLE
Fix flakiness due to create_room_synced

### DIFF
--- a/tests/32room-versions.pl
+++ b/tests/32room-versions.pl
@@ -8,11 +8,17 @@ foreach my $version ( qw ( 1 2 3 4 5 ) )  {
       check => sub {
          my ( $user ) = @_;
 
+         my $room_id;
+
          matrix_create_room_synced(
             $user,
             room_version => $version,
          )->then( sub {
-            my ( $room_id, undef, $sync_body ) = @_;
+            ( $room_id ) = @_;
+
+            matrix_sync( $user );
+         })->then( sub {
+            my ( $sync_body ) = @_;
 
             log_if_fail "sync body", $sync_body;
 
@@ -42,14 +48,16 @@ foreach my $version ( qw ( 1 2 3 4 5 ) )  {
          check => sub {
             my ( $user, $joiner, $room_alias_name ) = @_;
 
-            my ( $room_id, $room_alias, $event_id );
+            my ( $room_id, $event_id );
+
+            my $room_alias = sprintf( '#%s:%s', $room_alias_name, $user->server_name );
 
             matrix_create_room_synced(
                $user,
                room_version    => $version,
                room_alias_name => $room_alias_name,
             )->then( sub {
-               ( $room_id, $room_alias ) = @_;
+               ( $room_id ) = @_;
 
                matrix_join_room_synced( $joiner, $room_alias );
             })->then( sub {


### PR DESCRIPTION
When we create a room, it's possible for a subsequent /sync to receive subset of
the intial events in that room. This was making some tests [1] flaky when
running in worker mode.

AFAICT there's nothing in the spec which forbids this behaviour. By way of a
workaround, we send a test message in the new room and wait for it to turn up
over /sync.

However, a corollary is that we can't rely on the /sync to contain all the
events in the room. Solution to that is to sync again in tests that actually
care about the sync body.

[1]: notably 'A message sent after an initial sync appears in the timeline of
an incremental sync.'