### PR TITLE
Make 3PID binding tests use /account/3pid/bind ala MSC2290

### DIFF
--- a/tests/12login/01threepid-and-password.pl
+++ b/tests/12login/01threepid-and-password.pl
@@ -84,23 +84,10 @@ sub await_id_validation {
 Add the given email address to the homeserver account, including the
 verfication steps.
 
-C<%params> may include:
-
-=over
-
-=item bind => SCALAR
-
-If truthy, we will ask the server to ask the IS to bind the email
-address. False by default.
-
-=back
-
 =cut
 
 sub add_email_for_user {
    my ( $user, $address, $id_server, %params ) = @_;
-
-   my $bind = $params{bind} // 0;
 
    my $id_access_token = $id_server->get_access_token();
 
@@ -121,7 +108,6 @@ sub add_email_for_user {
                sid             => $sid,
                client_secret   => $client_secret,
             },
-            bind => $bind ? JSON::true : JSON::false,
          },
       );
    });

--- a/tests/12login/01threepid-and-password.pl
+++ b/tests/12login/01threepid-and-password.pl
@@ -18,12 +18,15 @@ test "Can login with 3pid and password using m.login.password",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/unstable/account/3pid/bind",
+         uri    => "/r0/account/3pid",
          content => {
-            id_server       => $id_server->name,
-            id_access_token => $id_access_token,
-            sid             => $sid,
-            client_secret   => $client_secret,
+            three_pid_creds => {
+               id_server       => $id_server->name,
+               id_access_token => $id_access_token,
+               sid             => $sid,
+               client_secret   => $client_secret,
+            },
+            bind => JSON::false,
          },
       )->then( sub {
          $http->do_request_json(

--- a/tests/12login/01threepid-and-password.pl
+++ b/tests/12login/01threepid-and-password.pl
@@ -18,15 +18,12 @@ test "Can login with 3pid and password using m.login.password",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/r0/account/3pid",
+         uri    => "/unstable/account/3pid/bind",
          content => {
-            three_pid_creds => {
-               id_server       => $id_server->name,
-               id_access_token => $id_access_token,
-               sid             => $sid,
-               client_secret   => $client_secret,
-            },
-            bind => JSON::false,
+            id_server       => $id_server->name,
+            id_access_token => $id_access_token,
+            sid             => $sid,
+            client_secret   => $client_secret,
          },
       )->then( sub {
          $http->do_request_json(

--- a/tests/54identity.pl
+++ b/tests/54identity.pl
@@ -13,15 +13,12 @@ test "Can bind 3PID via home server",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/r0/account/3pid",
+         uri    => "/unstable/account/3pid/bind",
          content => {
-            three_pid_creds => {
-               id_server       => $id_server->name,
-               id_access_token => $id_access_token,
-               sid             => $sid,
-               client_secret   => $client_secret,
-            },
-            bind => JSON::true,
+            id_server       => $id_server->name,
+            id_access_token => $id_access_token,
+            sid             => $sid,
+            client_secret   => $client_secret,
          },
       )->then( sub {
          my $res = $id_server->lookup_identity( $medium, $address );
@@ -48,15 +45,12 @@ test "Can bind and unbind 3PID via homeserver",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/r0/account/3pid",
+         uri    => "/unstable/account/3pid/bind",
          content => {
-            three_pid_creds => {
-               id_server       => $id_server->name,
-               id_access_token => $id_access_token,
-               sid             => $sid,
-               client_secret   => $client_secret,
-            },
-            bind => JSON::true,
+            id_server       => $id_server->name,
+            id_access_token => $id_access_token,
+            sid             => $sid,
+            client_secret   => $client_secret,
          },
       )->then( sub {
          my $res = $id_server->lookup_identity( $medium, $address );
@@ -125,15 +119,12 @@ test "3PIDs are unbound after account deactivation",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/r0/account/3pid",
+         uri    => "/unstable/account/3pid/bind",
          content => {
-            three_pid_creds => {
-               id_server       => $id_server->name,
-               id_access_token => $id_access_token,
-               sid             => $sid,
-               client_secret   => $client_secret,
-            },
-            bind => JSON::true,
+            id_server       => $id_server->name,
+            id_access_token => $id_access_token,
+            sid             => $sid,
+            client_secret   => $client_secret,
          },
       )->then( sub {
          my $res = $id_server->lookup_identity( $medium, $address );
@@ -158,19 +149,18 @@ test "Can bind and unbind 3PID via /unbind by specifying the identity server",
       my $medium = "email";
       my $address = 'bobby@example.com';
       my $client_secret = "53kr3t";
+      my $id_access_token = $id_server->get_access_token();
 
       my $sid = $id_server->validate_identity( $medium, $address, $client_secret );
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/r0/account/3pid",
+         uri    => "/unstable/account/3pid/bind",
          content => {
-            three_pid_creds => {
-               id_server     => $id_server->name,
-               sid           => $sid,
-               client_secret => $client_secret,
-            },
-            bind => JSON::true,
+            id_server       => $id_server->name,
+            id_access_token => $id_access_token,
+            sid             => $sid,
+            client_secret   => $client_secret,
          },
       )->then( sub {
          my $res = $id_server->lookup_identity( $medium, $address );
@@ -203,19 +193,18 @@ test "Can bind and unbind 3PID via /unbind without specifying the identity serve
       my $medium = "email";
       my $address = 'bobby@example.com';
       my $client_secret = "53kr3t";
+      my $id_access_token = $id_server->get_access_token();
 
       my $sid = $id_server->validate_identity( $medium, $address, $client_secret );
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/r0/account/3pid",
+         uri    => "/unstable/account/3pid/bind",
          content => {
-            three_pid_creds => {
-               id_server     => $id_server->name,
-               sid           => $sid,
-               client_secret => $client_secret,
-            },
-            bind => JSON::true,
+            id_server       => $id_server->name,
+            id_access_token => $id_access_token,
+            sid             => $sid,
+            client_secret   => $client_secret,
          },
       )->then( sub {
          my $res = $id_server->lookup_identity( $medium, $address );


### PR DESCRIPTION
Synapse PR: https://github.com/matrix-org/synapse/pull/6043

Changes the 3PID binding tests to use the new unstable `/account/3pid/bind` API endpoint, defined in [MSC2290](https://github.com/matrix-org/matrix-doc/pull/2290).