### PR TITLE
Tests for room tags and push rules after upgrading a remote room

### DIFF
--- a/tests/30rooms/60version_upgrade.pl
+++ b/tests/30rooms/60version_upgrade.pl
@@ -455,108 +455,74 @@ test "/upgrade copies ban events to the new room",
       });
    };
 
-test "/upgrade copies push rules to the new room",
-   requires => [
-      local_user_and_room_fixtures(),
-      qw( can_upgrade_room_version ),
-   ],
+# These tests are run against a local and remote room
+foreach my $user_type ( qw ( local remote ) ) {
+   test "$user_type user has push rules copied to upgraded room",
+      requires => [
+         local_user_and_room_fixtures(),
+         ( $user_type eq "local" ? local_user_fixture() : remote_user_fixture() ),
+      ],
 
-   do => sub {
-      my ( $creator, $room_id ) = @_;
-      my ( $new_room_id );
+      do => sub {
+         my ( $creator, $room_id, $joiner ) = @_;
+         my ( $new_room_id );
 
-      matrix_add_push_rule( $creator, "global", "room", $room_id, {
-         actions => [ "notify" ]
-      })->then( sub {
-         matrix_sync( $creator );
-      })->then( sub {
-         upgrade_room_synced(
-            $creator, $room_id,
-            new_version => $TEST_NEW_VERSION,
-         );
-      })->then( sub {
-         ( $new_room_id, ) = @_;
+         matrix_invite_user_to_room_synced(
+            $creator, $joiner, $room_id,
+         )->then( sub {
+            matrix_join_room_synced(
+               $joiner, $room_id, ( server_name => $creator->server_name, ),
+            );
+         })->then( sub {
+            matrix_sync( $joiner );
+         })->then( sub {
+            matrix_add_push_rule(
+               $joiner, "global", "room", $room_id,
+               { actions => [ "notify" ] },
+            );
+         })->then(sub {
+            matrix_sync( $joiner );
+         })->then(sub {
+            upgrade_room_synced(
+               $creator, $room_id,
+               new_version => $TEST_NEW_VERSION,
+            );
+         })->then(sub {
+            ( $new_room_id, ) = @_;
 
-         matrix_get_push_rules( $creator )->then( sub {
-            my ( $body ) = @_;
+            matrix_join_room_synced(
+               $joiner, $new_room_id, ( server_name => $creator->server_name, )
+            );
+         })->then(sub {
+            matrix_get_push_rules( $joiner )->then( sub {
+               my ( $body ) = @_;
 
-            my @to_check;
+               my @to_check;
 
-            foreach my $kind ( keys %{ $body->{global} } ) {
-               foreach my $rule ( @{ $body->{global}{$kind} } ) {
-                  push @to_check, [ $kind, $rule->{rule_id} ];
+               foreach my $kind ( keys %{ $body->{global} }) {
+                  foreach my $rule ( @{ $body->{global}{$kind} } ) {
+                     push @to_check, [ $kind, $rule->{rule_id} ];
+                  }
                }
-            }
 
-            my $found = 0;
-            try_repeat {
-               my $to_check = shift;
+               my $found = 0;
+               try_repeat {
+                  my $to_check = shift;
 
-               my ( $kind, $rule_id ) = @$to_check;
+                  my ( $kind, $rule_id ) = @$to_check;
 
-               log_if_fail("testing $rule_id against $new_room_id");
+                  log_if_fail( "testing $rule_id against $new_room_id" );
 
-               if ( $rule_id eq $new_room_id ) {
-                  $found = 1;
-               }
-            } foreach => \@to_check;
+                  if ( $rule_id eq $new_room_id ) {
+                     $found = 1;
+                  }
+               } foreach => \@to_check;
 
-            Future->done( $found );
-         })
-      });
-   };
-
-test "/upgrade on a remote room copies push rules to the new room",
-   requires => [
-      local_user_and_room_fixtures(),
-      remote_user_fixture(),
-      qw( can_upgrade_room_version ),
-   ],
-
-   do => sub {
-      my ( $local_user, $room_id, $remote_user ) = @_;
-      my ( $new_room_id );
-
-      matrix_add_push_rule( $remote_user, "global", "room", $room_id, {
-         actions => [ "notify" ]
-      })->then( sub {
-         matrix_sync( $remote_user );
-      })->then( sub {
-         upgrade_room_synced(
-            $local_user, $room_id,
-            new_version => $TEST_NEW_VERSION,
-         );
-      })->then( sub {
-         ( $new_room_id, ) = @_;
-
-         matrix_get_push_rules( $remote_user )->then( sub {
-            my ( $body ) = @_;
-
-            my @to_check;
-
-            foreach my $kind ( keys %{ $body->{global} } ) {
-               foreach my $rule ( @{ $body->{global}{$kind} } ) {
-                  push @to_check, [ $kind, $rule->{rule_id} ];
-               }
-            }
-
-            my $found = 0;
-            try_repeat {
-               my $to_check = shift;
-
-               my ( $kind, $rule_id ) = @$to_check;
-
-               log_if_fail("testing $rule_id against $new_room_id");
-
-               if ( $rule_id eq $new_room_id ) {
-                  $found = 1;
-               }
-            } foreach => \@to_check;
-
-            Future->done( $found );
-         })
-      });
-   };
+               Future->done( $found );
+            })
+         });
+      };
+}
 
 test "/upgrade moves aliases to the new room",
    requires => [

--- a/tests/30rooms/60version_upgrade.pl
+++ b/tests/30rooms/60version_upgrade.pl
@@ -428,8 +428,6 @@ test "/upgrade copies ban events to the new room",
          type => "m.room.member",
          content => $content,
          state_key => '@bob:matrix.org',
-      )->then( sub {
-         matrix_sync( $creator );
       })->then( sub {
          upgrade_room_synced(
             $creator, $room_id,
@@ -474,14 +472,10 @@ foreach my $user_type ( qw ( local remote ) ) {
                $joiner, $room_id, ( server_name => $creator->server_name, ),
             );
          })->then( sub {
-            matrix_sync( $joiner );
-         })->then( sub {
             matrix_add_push_rule(
                $joiner, "global", "room", $room_id,
                { actions => [ "notify" ] },
             );
-         })->then(sub {
-            matrix_sync( $joiner );
          })->then(sub {
             upgrade_room_synced(
                $creator, $room_id,

--- a/tests/30rooms/60version_upgrade.pl
+++ b/tests/30rooms/60version_upgrade.pl
@@ -501,9 +501,59 @@ test "/upgrade copies push rules to the new room",
                }
             } foreach => \@to_check;
 
-            if ( $found == 1 ) {
-               Future->done(1);
+            Future->done( $found );
+         })
+      });
+   };
+
+test "/upgrade on a remote room copies push rules to the new room",
+   requires => [
+      local_user_and_room_fixtures(),
+      remote_user_fixture(),
+      qw( can_upgrade_room_version ),
+   ],
+
+   do => sub {
+      my ( $local_user, $room_id, $remote_user ) = @_;
+      my ( $new_room_id );
+
+      matrix_add_push_rule( $remote_user, "global", "room", $room_id, {
+         actions => [ "notify" ]
+      })->then( sub {
+         matrix_sync( $remote_user );
+      })->then( sub {
+         upgrade_room_synced(
+            $local_user, $room_id,
+            new_version => $TEST_NEW_VERSION,
+         );
+      })->then( sub {
+         ( $new_room_id, ) = @_;
+
+         matrix_get_push_rules( $remote_user )->then( sub {
+            my ( $body ) = @_;
+
+            my @to_check;
+
+            foreach my $kind ( keys %{ $body->{global} } ) {
+               foreach my $rule ( @{ $body->{global}{$kind} } ) {
+                  push @to_check, [ $kind, $rule->{rule_id} ];
+               }
             }
+
+            my $found = 0;
+            try_repeat {
+               my $to_check = shift;
+
+               my ( $kind, $rule_id ) = @$to_check;
+
+               log_if_fail("testing $rule_id against $new_room_id");
+
+               if ( $rule_id eq $new_room_id ) {
+                  $found = 1;
+               }
+            } foreach => \@to_check;
+
+            Future->done( $found );
          })
       });
    };
@@ -829,4 +879,3 @@ test "Cannot send tombstone event that points to the same room",
    };
 
 # upgrade with other local users
-# upgrade with remote users

--- a/tests/30rooms/60version_upgrade.pl
+++ b/tests/30rooms/60version_upgrade.pl
@@ -428,7 +428,7 @@ test "/upgrade copies ban events to the new room",
          type => "m.room.member",
          content => $content,
          state_key => '@bob:matrix.org',
-      })->then( sub {
+      )->then( sub {
          upgrade_room_synced(
             $creator, $room_id,
             new_version => $TEST_NEW_VERSION,

--- a/tests/42tags.pl
+++ b/tests/42tags.pl
@@ -436,11 +436,55 @@ test "/upgrade copies user tags to the new room",
 
          log_if_fail "sync body", $sync_body;
 
-         my $room = $sync_body->{rooms}{join}{$new_room_id};
-
          matrix_list_tags( $user, $new_room_id );
       })->then( sub {
          my ( $tags ) = @_;
+
+         keys %{ $tags } == 1 or die "Expected one tag in the upgraded room";
+         defined $tags->{test_tag} or die "Unexpected tag";
+
+         Future->done(1);
+      });
+   };
+
+test "/upgrade on a remote room copies user tags to the new room",
+   requires => [
+      local_user_and_room_fixtures(),
+      remote_user_fixture(),
+      qw( can_upgrade_room_version can_add_tag ),
+   ],
+
+   do => sub {
+      my ( $local_user, $room_id, $remote_user ) = @_;
+      my ( $new_room_id );
+
+      matrix_add_tag(
+         $remote_user, $room_id, "test_tag", {}
+      )->then( sub {
+         matrix_sync( $remote_user );
+      })->then( sub {
+         upgrade_room_synced(
+            $local_user, $room_id,
+            new_version => $main::TEST_NEW_VERSION,
+         );
+      })->then( sub {
+         ($new_room_id,) = @_;
+
+         matrix_sync_again($remote_user);
+      })->then( sub {
+         matrix_invite_user_to_room_synced( $local_user, $remote_user, $new_room_id );
+      })->then( sub {
+         matrix_join_room_synced( $remote_user, $new_room_id );
+      })->then( sub {
+         my ( $sync_body ) = @_;
+
+         log_if_fail "sync body", $sync_body;
+
+         matrix_list_tags( $remote_user, $new_room_id );
+      })->then( sub {
+         my ( $tags ) = @_;
+
+         log_if_fail "upgraded room tags", $tags;
 
          keys %{ $tags } == 1 or die "Expected one tag in the upgraded room";
          defined $tags->{test_tag} or die "Unexpected tag";


### PR DESCRIPTION
Synapse PR: https://github.com/matrix-org/synapse/pull/6155

Requires: https://github.com/matrix-org/sytest/pull/726

New versions of the existing `/upgrade copies push rules to the new room` and `/upgrade on a remote room copies user tags to the new room` tests, but testing with a user who is on a different server than the one that upgraded the room.