### PR TITLE
Better error when /send fails

### DIFF
--- a/lib/SyTest/Federation/Client.pm
+++ b/lib/SyTest/Federation/Client.pm
@@ -7,6 +7,7 @@ use base qw( SyTest::Federation::_Base SyTest::HTTPClient );
 
 use List::UtilsBy qw( uniq_by );
 
+use Data::Dump 'pp';
 use MIME::Base64 qw( decode_base64 );
 use HTTP::Headers::Util qw( join_header_words );
 
@@ -167,10 +168,9 @@ sub send_event
       # event id is, but there should be one entry which maps to an empty dict
       assert_eq( length( keys %$pdus ), 1);
       my $event_id = ( keys %$pdus )[0];
-
-      assert_deeply_eq( $body,
-                        { pdus => { $event_id => {} } },
-                        "/send/ response" );
+      if( keys %{ $pdus->{ $event_id } } ) {
+         die "Unexpected response from /send: ". pp $body;
+      }
       Future->done;
    });
 }


### PR DESCRIPTION
It's annoying when you're trying to write a test and don't know *why* a
federation /send request is failing. Let's return the error.