### PR TITLE
Ability to join a room using a given server_name

### DIFF
--- a/tests/10apidoc/33room-members.pl
+++ b/tests/10apidoc/33room-members.pl
@@ -62,10 +62,8 @@ sub matrix_join_room
 
    my %content;
    my %params;
-   if ( defined $opts{server_name} ) {
-      $params{server_name} = $opts{server_name};
-   }
 
+   defined $opts{server_name} and $params{server_name} = $opts{server_name};
    defined $opts{third_party_signed} and $content{third_party_signed} = $opts{third_party_signed};
 
    do_request_json_for( $user,

--- a/tests/10apidoc/33room-members.pl
+++ b/tests/10apidoc/33room-members.pl
@@ -61,12 +61,17 @@ sub matrix_join_room
    is_User( $user ) or croak "Expected a User; got $user";
 
    my %content;
+   my %params;
+   if ( defined $opts{server_name} ) {
+      $params{server_name} = $opts{server_name};
+   }
 
    defined $opts{third_party_signed} and $content{third_party_signed} = $opts{third_party_signed};
 
    do_request_json_for( $user,
       method => "POST",
       uri    => "/r0/join/$room",
+      params => \%params,
 
       content => \%content,
    )->then( sub {


### PR DESCRIPTION
When working on https://github.com/matrix-org/sytest/pull/721/, I found it difficult to upgrade a room (which gives me a room ID), then have a remote user join the room via that room ID. Synapse would complain as it needs to know what server to join the room via.

We can tell Synapse using the `server_name` query parameter as defined by https://matrix.org/docs/spec/client_server/unstable#post-matrix-client-r0-join-roomidoralias

This adds the ability for the `server_name` argument to be given to the `matrix_join_room` and `matrix_join_room_synced` methods to join with a given server_name.