### PR TITLE
remove SYN-490 comments

### DIFF
--- a/lib/SyTest/Federation/Client.pm
+++ b/lib/SyTest/Federation/Client.pm
@@ -219,8 +219,9 @@ sub join_room
          content  => $member_event,
       )->then( sub {
          my ( $join_body ) = @_;
-         # SYN-490 workaround
-         $join_body = $join_body->[1] if ref $join_body eq "ARRAY";
+
+         # /v1/send_join has an extraneous [ 200, ... ] wrapper (see MSC1802)
+         $join_body = $join_body->[1];
 
          my $room = SyTest::Federation::Room->new(
             datastore => $store,

--- a/lib/SyTest/Federation/Server.pm
+++ b/lib/SyTest/Federation/Server.pm
@@ -305,7 +305,7 @@ sub on_request_federation_v1_send_join
 
    $room->insert_event( $event );
 
-   # SYN-490
+   # /v1/send_join has an extraneous [ 200, ... ] wrapper (see MSC1802)
    Future->done( json => [ 200, {
       auth_chain => \@auth_chain,
       state      => \@state_events,

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -110,7 +110,7 @@ test "Outbound federation can send room-join requests",
             );
 
             $req->respond_json(
-               # TODO(paul): This workaround is for SYN-490
+               # /v1/send_join has an extraneous [200, ...] wrapper (see MSC1802)
                my $response = [ 200, {
                   auth_chain => \@auth_chain,
                   state      => [ $room->current_state_events ],
@@ -222,10 +222,6 @@ test "Inbound federation can receive v1 room-join requests",
          my ( $body ) = @_;
          log_if_fail "make_join body", $body;
 
-         # TODO(paul): This is all entirely cargoculted guesswork based on
-         #   observing what Synapse actually does, because the entire make_join
-         #   API is entirely undocumented. See SPEC-241
-
          assert_json_keys( $body, qw( event ));
 
          my $protoevent = $body->{event};
@@ -283,15 +279,11 @@ test "Inbound federation can receive v1 room-join requests",
       })->then( sub {
          my ( $response ) = @_;
 
-         # $response seems to arrive with an extraneous layer of wrapping as
-         # the result of a synapse implementation bug (SYN-490).
-         if( ref $response eq "ARRAY" ) {
-            $response->[0] == 200 or
-               die "Expected first response element to be 200";
+         # /v1/send_join has an extraneous [200, ...] wrapper (see MSC1802)
+         $response->[0] == 200 or
+            die "Expected first response element to be 200";
 
-            warn "SYN-490 detected; deploying workaround\n";
-            $response = $response->[1];
-         }
+         $response = $response->[1];
 
          assert_json_keys( $response, qw( auth_chain state ));
 
@@ -664,7 +656,7 @@ test "Outbound federation rejects send_join responses with no m.room.create even
             @auth_chain = grep { $_->{type} ne 'm.room.create' } @auth_chain;
 
             $req->respond_json(
-               # TODO(paul): This workaround is for SYN-490
+               # /v1/send_join has an extraneous [200, ...] wrapper (see MSC1802)
                my $response = [ 200, {
                   auth_chain => \@auth_chain,
                   state      => [ $room->current_state_events ],
@@ -752,7 +744,7 @@ test "Outbound federation rejects m.room.create events with an unknown room vers
             );
 
             $req->respond_json(
-               # TODO(paul): This workaround is for SYN-490
+               # /v1/send_join has an extraneous [200, ...] wrapper (see MSC1802)
                my $response = [ 200, {
                   auth_chain => \@auth_chain,
                   state      => [ $room->current_state_events ],

--- a/tests/50federation/35room-invite.pl
+++ b/tests/50federation/35room-invite.pl
@@ -37,7 +37,7 @@ test "Outbound federation can send invites",
             $inbound_server->datastore->sign_event( $body );
 
             $req->respond_json(
-               # SYN-490
+               # /v1/invite has an extraneous [ 200, ... ] wrapper (fixed in /v2)
                [ 200, { event => $body } ]
             );
 


### PR DESCRIPTION
SYN-490 has been resolved in favour of MSC1802 (for /send_join) and MSC1794 (for /invite).
The behavior is now specced rather than a bug.