### PR TITLE
[DINSIC] Set unlimited third party invite ratelimit

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -177,6 +177,10 @@ sub start
             per_second => 1000,
             burst_count => 1000,
         },
+        rc_third_party_invite => {
+           per_second => 1000,
+           burst_count => 1000,
+        },
         rc_login => {
             address => {
                 per_second => 1000,


### PR DESCRIPTION
Synapse DINSIC PR: https://github.com/matrix-org/synapse-dinsic/pull/11

Ups the ratelimit for third party invites.

**Superseded by https://github.com/matrix-org/sytest/pull/740**