### PR TITLE
Set unlimited third party invite ratelimit

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -205,7 +205,6 @@ sub start
         use_frozen_events => "true",
 
         allow_guest_access => "True",
-        invite_3pid_guest => "true",
 
         # Metrics are always useful
         enable_metrics => 1,

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -205,6 +205,7 @@ sub start
         use_frozen_events => "true",
 
         allow_guest_access => "True",
+        invite_3pid_guest => "true",
 
         # Metrics are always useful
         enable_metrics => 1,

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -177,6 +177,10 @@ sub start
             per_second => 1000,
             burst_count => 1000,
         },
+        rc_third_party_invite => {
+           per_second => 1000,
+           burst_count => 1000,
+        },
         rc_login => {
             address => {
                 per_second => 1000,


### PR DESCRIPTION
Synapse PR: https://github.com/matrix-org/synapse-dinsic/pull/11

CI is going to fail on this PR as it tests mainline Synapse instead of dinsic's.