### PR TITLE
[DINSIC] Enable account validity on tests

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -251,6 +251,11 @@ sub start
 
         require_membership_for_aliases => "false",
 
+        account_validity => {
+           enabled => "true",
+           period => "6w",
+        },
+
         $self->{recaptcha_config} ? (
            recaptcha_siteverify_api => $self->{recaptcha_config}->{siteverify_api},
            recaptcha_public_key     => $self->{recaptcha_config}->{public_key},


### PR DESCRIPTION
Enables account validity tracking in Synapse, such that we can test it.

Requires https://github.com/matrix-org/synapse/pull/6359