### PR TITLE
Fix perl 5.28 incompatibility

### DIFF
--- a/lib/SyTest/HTTPClient.pm
+++ b/lib/SyTest/HTTPClient.pm
@@ -17,7 +17,7 @@ my $json = JSON->new->convert_blessed(1)->utf8(1);
 use Future 0.33; # ->catch
 use List::Util qw( any );
 use Net::SSLeay 1.59; # TLSv1.2
-use Scalar::Util qw( blessed );
+use Scalar::Util qw( blessed looks_like_number );
 
 use SyTest::JSONSensible;
 
@@ -147,13 +147,10 @@ sub do_request_json
    $self->do_request( %params );
 }
 
-# A terrible internals hack that relies on the dualvar nature of the ^ operator
-sub SvPOK { ( $_[0] ^ $_[0] ) ne "0" }
-
 sub wrap_numbers
 {
    my ( $d ) = @_;
-   if( defined $d and !ref $d and !SvPOK $d ) {
+   if( defined $d and !ref $d and looks_like_number( $d )) {
       return JSON::number( $d );
    }
    elsif( ref $d eq "ARRAY" ) {

--- a/lib/SyTest/HTTPClient.pm
+++ b/lib/SyTest/HTTPClient.pm
@@ -17,7 +17,7 @@ my $json = JSON->new->convert_blessed(1)->utf8(1);
 use Future 0.33; # ->catch
 use List::Util qw( any );
 use Net::SSLeay 1.59; # TLSv1.2
-use Scalar::Util qw( blessed looks_like_number );
+use Scalar::Util qw( blessed );
 
 use SyTest::JSONSensible;
 

--- a/lib/SyTest/HTTPClient.pm
+++ b/lib/SyTest/HTTPClient.pm
@@ -157,7 +157,7 @@ sub SvPOK {
 sub wrap_numbers
 {
    my ( $d ) = @_;
-   if( defined $d and !ref $d and !SvPOK( $d )) {
+   if( defined $d and !ref $d and !SvPOK $d ) {
       return JSON::number( $d );
    }
    elsif( ref $d eq "ARRAY" ) {

--- a/lib/SyTest/HTTPClient.pm
+++ b/lib/SyTest/HTTPClient.pm
@@ -147,10 +147,17 @@ sub do_request_json
    $self->do_request( %params );
 }
 
+# A terrible internals hack that relies on the dualvar nature of the ^ operator.
+# Returns true if perl thinks the argument is a string.
+sub SvPOK {
+   my ( $s ) = @_;
+   return utf8::is_utf8( $s ) || ( $s ^ $s ) ne "0";
+}
+
 sub wrap_numbers
 {
    my ( $d ) = @_;
-   if( defined $d and !ref $d and looks_like_number( $d )) {
+   if( defined $d and !ref $d and !SvPOK( $d )) {
       return JSON::number( $d );
    }
    elsif( ref $d eq "ARRAY" ) {


### PR DESCRIPTION
The SvPOK hack emits an error on perl 5.28 (`Use of strings with code points over 0xFF as arguments to bitwise xor (^) operator is not allowed`). Let's try a call to `is_utf8`.