### PR TITLE
Fix a flaky cross-signing test

### DIFF
--- a/tests/41end-to-end-keys/08-cross-signing.pl
+++ b/tests/41end-to-end-keys/08-cross-signing.pl
@@ -525,10 +525,11 @@ test "uploading self-signing key notifies over federation",
          matrix_create_room( $user1 );
       })->then( sub {
          ( $room_id ) = @_;
-
+         matrix_sync( $user1 );
+      })->then( sub {
          matrix_invite_user_to_room( $user1, $user2, $room_id )
       })->then( sub {
-         matrix_sync( $user1 );
+         sync_until_user_in_device_list( $user1, $user2 );
       })->then( sub {
          matrix_join_room( $user2, $room_id );
       })->then( sub {


### PR DESCRIPTION
The basic problem in this test is that there are three things that can cause a
"devices/changed" sync update:
 * inviting the user
 * the user joining
 * the user doing his cross-signing

... and it's hard to be sure that we're getting the right update. If we make
sure that we wait for each update, it fixes the race condition.