### PR TITLE
Don't add outliers to forward extremities.

### DIFF
--- a/lib/SyTest/Federation/Client.pm
+++ b/lib/SyTest/Federation/Client.pm
@@ -262,10 +262,11 @@ sub join_room
          my @events = uniq_by { $room->id_for_event( $_ ) } (
             @{ $join_body->{auth_chain} },
             @{ $join_body->{state} },
-            $member_event,
          );
 
-         $room->insert_event( $_ ) for @events;
+         $room->insert_outlier_event( $_ ) for @events;
+
+         $room->insert_event( $member_event );
 
          Future->done( $room );
       });

--- a/lib/SyTest/Federation/Room.pm
+++ b/lib/SyTest/Federation/Room.pm
@@ -280,7 +280,7 @@ sub create_and_insert_event
 
    $room->insert_event( $event );
 
-Inserts a new event into the database, updating the rooms view of the forward
+Inserts a new event into the database, updating the room's view of the forward
 extremities (i.e. event IDs to use as the prev events of the the next
 generated event).
 
@@ -308,7 +308,7 @@ sub insert_event
 
    $room->insert_outlier_event( $event );
 
-Inserts a new event into the database, without updating the rooms forward
+Inserts a new event into the database, *without* updating the room's forward
 extremities (i.e. event IDs to use as the prev events of the the next
 generated event).
 

--- a/lib/SyTest/Federation/Room.pm
+++ b/lib/SyTest/Federation/Room.pm
@@ -278,9 +278,11 @@ sub create_and_insert_event
 
 =head2 insert_event
 
-   $event = $room->insert_event( $event );
+   $room->insert_event( $event );
 
-Inserts a new event into the database, updating prev_events.
+Inserts a new event into the database, updating the rooms view of the forward
+extremities (i.e. event IDs to use as the prev events of the the next
+generated event).
 
 =cut
 
@@ -304,9 +306,11 @@ sub insert_event
 
 =head2 insert_outlier_event
 
-   $event = $room->insert_outlier_event( $event );
+   $room->insert_outlier_event( $event );
 
-Inserts a new event into the database, without updating prev_events.
+Inserts a new event into the database, without updating the rooms forward
+extremities (i.e. event IDs to use as the prev events of the the next
+generated event).
 
 =cut
 

--- a/lib/SyTest/Federation/Room.pm
+++ b/lib/SyTest/Federation/Room.pm
@@ -268,7 +268,7 @@ sub create_and_insert_event
 
    my ( $event, $event_id ) = $self->create_event( %fields );
 
-   $self->_insert_event( $event );
+   $self->insert_outlier_event( $event );
 
    $self->{prev_events} = [ $event ];
 
@@ -276,12 +276,20 @@ sub create_and_insert_event
    return ( $event, $event_id );
 }
 
+=head2 insert_event
+
+   $event = $room->insert_event( $event );
+
+Inserts a new event into the database, updating prev_events.
+
+=cut
+
 sub insert_event
 {
    my $self = shift;
    my ( $event ) = @_;
 
-   $self->_insert_event( $event );
+   $self->insert_outlier_event( $event );
 
    my $prev_events = $self->{prev_events};
    push @$prev_events, $event;
@@ -293,7 +301,16 @@ sub insert_event
    extract_by { $to_remove{ $self->id_for_event($_) } } @$prev_events;
 }
 
-sub _insert_event
+
+=head2 insert_outlier_event
+
+   $event = $room->insert_outlier_event( $event );
+
+Inserts a new event into the database, without updating prev_events.
+
+=cut
+
+sub insert_outlier_event
 {
    my $self = shift;
    my ( $event ) = @_;


### PR DESCRIPTION
The inbuilt federation library blindly added all events as foreward
extremities. Normally this would be fine as adding all state events in
the correct order removed all superfluous extremities, however if not
done in the right order, or there was a gap, then new events would get
sent out with a random assortment of prev events. This led to some
events being rejected due to the resolved state being not what was
expected.