### PR TITLE
Add sytest blacklist for DINUM synapse

### DIFF
--- a/docker/synapse_sytest.sh
+++ b/docker/synapse_sytest.sh
@@ -82,7 +82,7 @@ fi
 >&2 echo "+++ Running tests"
 
 RUN_TESTS=(
-    perl -I "$SYTEST_LIB" ./run-tests.pl --python=/venv/bin/python --synapse-directory=/src --coverage -O tap --all
+    perl -I "$SYTEST_LIB" ./run-tests.pl --python=/venv/bin/python --synapse-directory=/src -B /src/sytest-blacklist --coverage -O tap --all
 )
 
 TEST_STATUS=0


### PR DESCRIPTION
Have DINUM sytest make use of a sytest blacklist file for synapse builds.

synapse-dinsic PR that adds the blacklist file: https://github.com/matrix-org/synapse-dinsic/pull/17