### PR TITLE
Test v2 endpoint for /send_join

### DIFF
--- a/lib/SyTest/Federation/Server.pm
+++ b/lib/SyTest/Federation/Server.pm
@@ -402,22 +402,20 @@ sub mk_await_request_pair
       }
    };
 
-   # Don't specify the version prefix in the function name if the version is v1 so we
-   # don't break existing function calls.
-   my ( $await_request_function_name, $on_request_function_name );
+   # Don't specify the version prefix in the await function name if the version is v1 so
+   # we don't break existing function calls.
+   my ( $await_request_function_name );
    if( $versionprefix eq "v1" ) {
       $await_request_function_name = "await_request_$shortname";
-      $on_request_function_name = "on_request_federation_$shortname"
    }
    else {
       $await_request_function_name = "await_request_$versionprefix\_$shortname";
-      $on_request_function_name = "on_request_federation_$versionprefix\_$shortname";
    }
 
    no strict 'refs';
    no warnings 'redefine';
    *{"${class}::$await_request_function_name"} = $awaitfunc;
-   *{"${class}::$on_request_function_name"} = $on_requestfunc;
+   *{"${class}::on_request_federation_$versionprefix\_$shortname"} = $on_requestfunc;
 }
 
 __PACKAGE__->mk_await_request_pair(

--- a/lib/SyTest/Federation/Server.pm
+++ b/lib/SyTest/Federation/Server.pm
@@ -402,10 +402,22 @@ sub mk_await_request_pair
       }
    };
 
+   # Don't specify the version prefix in the function name if the version is v1 so we
+   # don't break existing function calls.
+   my ( $await_request_function_name, $on_request_function_name );
+   if( $versionprefix eq "v1" ) {
+      $await_request_function_name = "await_request_$shortname";
+      $on_request_function_name = "on_request_federation_$shortname"
+   }
+   else {
+      $await_request_function_name = "await_request_$versionprefix\_$shortname";
+      $on_request_function_name = "on_request_federation_$versionprefix\_$shortname";
+   }
+
    no strict 'refs';
    no warnings 'redefine';
-   *{"${class}::await_request_$shortname"} = $awaitfunc;
-   *{"${class}::on_request_federation_v1_$shortname"} = $on_requestfunc;
+   *{"${class}::$await_request_function_name"} = $awaitfunc;
+   *{"${class}::$on_request_function_name"} = $on_requestfunc;
 }
 
 __PACKAGE__->mk_await_request_pair(

--- a/lib/SyTest/Federation/Server.pm
+++ b/lib/SyTest/Federation/Server.pm
@@ -315,10 +315,10 @@ sub on_request_federation_v1_send_join
 sub mk_await_request_pair
 {
    my $class = shift;
-   my ( $shortname, $paramnames ) = @_;
+   my ( $shortname, $versionprefix, $paramnames ) = @_;
    my @paramnames = @$paramnames;
 
-   my $okey = "awaiting_$shortname";
+   my $okey = "awaiting_$versionprefix\_$shortname";
 
    my $awaitfunc = sub {
       my $self = shift;
@@ -336,7 +336,9 @@ sub mk_await_request_pair
          });
    };
 
-   my $was_on_requestfunc = $class->can( "on_request_federation_v1_$shortname" );
+   my $was_on_requestfunc = $class->can(
+      "on_request_federation_$versionprefix\_$shortname"
+   );
    my $on_requestfunc = sub {
       my $self = shift;
       my ( $req, @pathvalues ) = @_;
@@ -380,59 +382,59 @@ sub mk_await_request_pair
 }
 
 __PACKAGE__->mk_await_request_pair(
-   query_directory => [qw( ?room_alias )],
+   query_directory => "v1", [qw( ?room_alias )],
 );
 
 __PACKAGE__->mk_await_request_pair(
-   query_profile => [qw( ?user_id )],
+   query_profile => "v1", [qw( ?user_id )],
 );
 
 __PACKAGE__->mk_await_request_pair(
-   make_join => [qw( :room_id :user_id )],
+   make_join => "v1", [qw( :room_id :user_id )],
 );
 
 __PACKAGE__->mk_await_request_pair(
-   make_leave => [qw( :room_id :user_id )],
+   make_leave => "v1", [qw( :room_id :user_id )],
 );
 
 __PACKAGE__->mk_await_request_pair(
-   send_join => [qw( :room_id )],
+   send_join => "v1", [qw( :room_id )],
 );
 
 __PACKAGE__->mk_await_request_pair(
-   state_ids => [qw( :room_id ?event_id )],
+   state_ids => "v1", [qw( :room_id ?event_id )],
 );
 
 __PACKAGE__->mk_await_request_pair(
-   state => [qw( :room_id )],
+   state => "v1", [qw( :room_id )],
 );
 
 __PACKAGE__->mk_await_request_pair(
-   get_missing_events => [qw( :room_id )],
+   get_missing_events => "v1", [qw( :room_id )],
 );
 
 __PACKAGE__->mk_await_request_pair(
-   event_auth => [qw( :room_id :event_id )],
+   event_auth => "v1", [qw( :room_id :event_id )],
 );
 
 __PACKAGE__->mk_await_request_pair(
-   backfill => [qw( :room_id )],
+   backfill => "v1", [qw( :room_id )],
 );
 
 __PACKAGE__->mk_await_request_pair(
-   invite => [qw( :room_id )],
+   invite => "v1", [qw( :room_id )],
 );
 
 __PACKAGE__->mk_await_request_pair(
-   event => [qw( :event_id )],
+   event => "v1", [qw( :event_id )],
 );
 
 __PACKAGE__->mk_await_request_pair(
-   user_devices => [qw( :user_id )],
+   user_devices => "v1", [qw( :user_id )],
 );
 
 __PACKAGE__->mk_await_request_pair(
-   user_keys_query => [qw( )],
+   user_keys_query => "v1", [qw( )],
 );
 
 sub on_request_federation_v1_send

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -53,7 +53,7 @@ sub assert_is_valid_pdu {
 push our @EXPORT, qw( assert_is_valid_pdu );
 
 foreach my $versionprefix ( qw( v1 v2 ) ) {
-   test "Inbound federation supports $versionprefix /send_join",
+   test "Outbound federation can query $versionprefix /send_join",
       requires => [ local_user_fixture(), $main::INBOUND_SERVER,
                     federation_user_id_fixture() ],
 
@@ -217,7 +217,7 @@ test "Outbound federation passes make_join failures through to the client",
 
 
 foreach my $versionprefix ( qw ( v1 v2 ) ) {
-   test "Inbound federation supports $versionprefix /send_join",
+   test "Outbound federation can receive $versionprefix /send_join",
       requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
                     local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                     federation_user_id_fixture() ],

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -52,102 +52,118 @@ sub assert_is_valid_pdu {
 }
 push our @EXPORT, qw( assert_is_valid_pdu );
 
-test "Outbound federation can send room-join requests",
-   requires => [ local_user_fixture(), $main::INBOUND_SERVER,
-                 federation_user_id_fixture() ],
+foreach my $versionprefix ( qw( v1 v2 ) ) {
+   test "Inbound federation supports $versionprefix /send_join",
+      requires => [ local_user_fixture(), $main::INBOUND_SERVER,
+                    federation_user_id_fixture() ],
 
-   do => sub {
-      my ( $user, $inbound_server, $creator_id ) = @_;
+      do => sub {
+         my ( $user, $inbound_server, $creator_id ) = @_;
 
-      my $local_server_name = $inbound_server->server_name;
-      my $datastore         = $inbound_server->datastore;
+         my $local_server_name = $inbound_server->server_name;
+         my $datastore         = $inbound_server->datastore;
 
-      my $room = SyTest::Federation::Room->new(
-         datastore => $datastore,
-      );
+         my $room = SyTest::Federation::Room->new(
+            datastore => $datastore,
+         );
 
-      $room->create_initial_events(
-         server  => $inbound_server,
-         creator => $creator_id,
-      );
+         $room->create_initial_events(
+            server  => $inbound_server,
+            creator => $creator_id,
+         );
 
-      my $room_id = $room->room_id;
+         my $room_id = $room->room_id;
 
-      my $room_alias = "#50fed-room-alias:$local_server_name";
-      $datastore->{room_aliases}{$room_alias} = $room_id;
+         my $room_alias = "#50fed-room-alias:$local_server_name";
+         $datastore->{room_aliases}{$room_alias} = $room_id;
 
-      Future->needs_all(
-         # Await PDU?
+         my $await_request_send_join;
 
-         $inbound_server->await_request_make_join( $room_id, $user->user_id )->then( sub {
-            my ( $req, $room_id, $user_id ) = @_;
+         if( $versionprefix eq "v1" ) {
+            $await_request_send_join = $inbound_server->await_request_v1_send_join( $room_id );
+         }
+         elsif( $versionprefix eq "v2" ) {
+            $await_request_send_join = $inbound_server->await_request_v2_send_join( $room_id );
+         }
 
-            my $proto = $room->make_join_protoevent(
-               user_id => $user_id,
-            );
+         Future->needs_all(
+            # Await PDU?
 
-            $proto->{origin}           = $inbound_server->server_name;
-            $proto->{origin_server_ts} = $inbound_server->time_ms;
+            $inbound_server->await_request_make_join( $room_id, $user->user_id )->then( sub {
+               my ( $req, $room_id, $user_id ) = @_;
 
-            $req->respond_json( {
-               event => $proto,
-            } );
+               my $proto = $room->make_join_protoevent(
+                  user_id => $user_id,
+               );
 
-            Future->done;
-         }),
+               $proto->{origin}           = $inbound_server->server_name;
+               $proto->{origin_server_ts} = $inbound_server->time_ms;
 
-         $inbound_server->await_request_v2_send_join( $room_id )->then( sub {
-            my ( $req, $room_id, $event_id ) = @_;
+               $req->respond_json( {
+                  event => $proto,
+               } );
 
-            $req->method eq "PUT" or
-               die "Expected send_join method to be PUT";
+               Future->done;
+            }),
 
-            my $event = $req->body_from_json;
-            log_if_fail "send_join event", $event;
+            $await_request_send_join->then( sub {
+               my ( $req, $room_id, $event_id ) = @_;
 
-            my @auth_chain = $datastore->get_auth_chain_events(
-               map { $_->[0] } @{ $event->{auth_events} }
-            );
+               $req->method eq "PUT" or
+                  die "Expected send_join method to be PUT";
 
-            $req->respond_json(
+               my $event = $req->body_from_json;
+               log_if_fail "send_join event", $event;
+
+               my @auth_chain = $datastore->get_auth_chain_events(
+                  map { $_->[0] } @{ $event->{auth_events} }
+               );
+
                my $response = {
                   auth_chain => \@auth_chain,
                   state      => [ $room->current_state_events ],
+               };
+
+               if( $versionprefix eq "v1" ) {
+                  # /v1/send_join has an extraneous [200, ...] wrapper (see MSC1802)
+                  $response = [ 200, $response ];
                }
-            );
 
-            log_if_fail "send_join response", $response;
+               $req->respond_json($response);
 
-            Future->done;
-         }),
+               log_if_fail "send_join response", $response;
 
-         do_request_json_for( $user,
-            method => "POST",
-            uri    => "/r0/join/$room_alias",
+               Future->done;
+            }),
 
-            content => {},
-         )->then( sub {
-            my ( $body ) = @_;
-            log_if_fail "Join response", $body;
+            do_request_json_for( $user,
+               method => "POST",
+               uri    => "/r0/join/$room_alias",
 
-            assert_json_keys( $body, qw( room_id ));
+               content => {},
+            )->then( sub {
+               my ( $body ) = @_;
+               log_if_fail "Join response", $body;
 
-            $body->{room_id} eq $room_id or
-               die "Expected room_id to be $room_id";
+               assert_json_keys( $body, qw( room_id ));
 
-            matrix_get_my_member_event( $user, $room_id )
-         })->then( sub {
-            my ( $event ) = @_;
+               $body->{room_id} eq $room_id or
+                  die "Expected room_id to be $room_id";
 
-            # The joining HS (i.e. the SUT) should have invented the event ID
-            # for my membership event.
+               matrix_get_my_member_event( $user, $room_id )
+            })->then( sub {
+               my ( $event ) = @_;
 
-            # TODO - sanity check the $event
+               # The joining HS (i.e. the SUT) should have invented the event ID
+               # for my membership event.
 
-            Future->done(1);
-         }),
-      )
-   };
+               # TODO - sanity check the $event
+
+               Future->done(1);
+            }),
+         )
+      };
+}
 
 
 test "Outbound federation passes make_join failures through to the client",
@@ -200,351 +216,133 @@ test "Outbound federation passes make_join failures through to the client",
    };
 
 
+foreach my $versionprefix ( qw ( v1 v2 ) ) {
+   test "Inbound federation supports $versionprefix /send_join",
+      requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
+                    local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
+                    federation_user_id_fixture() ],
 
-test "Inbound federation can receive v1 room-join requests",
-   requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
-                 local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
-                 federation_user_id_fixture() ],
+      do => sub {
+         my ( $outbound_client, $inbound_server, $creator, $room_id, $user_id ) = @_;
+         my $first_home_server = $creator->server_name;
 
-   do => sub {
-      my ( $outbound_client, $inbound_server, $creator, $room_id, $user_id ) = @_;
-      my $first_home_server = $creator->server_name;
-
-      my $local_server_name = $outbound_client->server_name;
-      my $datastore         = $inbound_server->datastore;
-
-      $outbound_client->do_request_json(
-         method   => "GET",
-         hostname => $first_home_server,
-         uri      => "/v1/make_join/$room_id/$user_id",
-      )->then( sub {
-         my ( $body ) = @_;
-         log_if_fail "make_join body", $body;
-
-         assert_json_keys( $body, qw( event ));
-
-         my $protoevent = $body->{event};
-
-         assert_json_keys( $protoevent, qw(
-            auth_events content depth room_id sender state_key type
-         ));
-
-         assert_json_nonempty_list( my $auth_events = $protoevent->{auth_events} );
-         foreach my $auth_event ( @$auth_events ) {
-            assert_json_list( $auth_event );
-            @$auth_event == 2 or
-               die "Expected auth_event list element to have 2 members";
-
-            assert_json_string( $auth_event->[0] );  # id
-            assert_json_object( $auth_event->[1] );  # hashes
-         }
-
-         assert_json_nonempty_list( $protoevent->{prev_events} );
-
-         assert_json_number( $protoevent->{depth} );
-
-         $protoevent->{room_id} eq $room_id or
-            die "Expected 'room_id' to be $room_id";
-         $protoevent->{sender} eq $user_id or
-            die "Expected 'sender' to be $user_id";
-         $protoevent->{state_key} eq $user_id or
-            die "Expected 'state_key' to be $user_id";
-         $protoevent->{type} eq "m.room.member" or
-            die "Expected 'type' to be 'm.room.member'";
-
-         assert_json_keys( my $content = $protoevent->{content}, qw( membership ) );
-         $content->{membership} eq "join" or
-            die "Expected 'membership' to be 'join'";
-
-         my %event = (
-            ( map { $_ => $protoevent->{$_} } qw(
-               auth_events content depth prev_events room_id sender
-               state_key type ) ),
-
-            event_id         => $datastore->next_event_id,
-            origin           => $local_server_name,
-            origin_server_ts => $inbound_server->time_ms,
-         );
-
-         $datastore->sign_event( \%event );
+         my $local_server_name = $outbound_client->server_name;
+         my $datastore         = $inbound_server->datastore;
 
          $outbound_client->do_request_json(
-            method   => "PUT",
+            method   => "GET",
             hostname => $first_home_server,
-            uri      => "/v1/send_join/$room_id/$event{event_id}",
-
-            content => \%event,
-         )
-      })->then( sub {
-         my ( $response ) = @_;
-
-         # /v1/send_join has an extraneous [200, ...] wrapper (see MSC1802)
-         $response->[0] == 200 or
-            die "Expected first response element to be 200";
-
-         $response = $response->[1];
-
-         assert_json_keys( $response, qw( auth_chain state ));
-
-         assert_json_nonempty_list( $response->{auth_chain} );
-         my @auth_chain = @{ $response->{auth_chain} };
-
-         log_if_fail "Auth chain", \@auth_chain;
-
-         foreach my $event ( @auth_chain ) {
-            assert_is_valid_pdu( $event );
-            $event->{room_id} eq $room_id or
-               die "Expected auth_event room_id to be $room_id";
-         }
-
-         # Annoyingly, the "auth chain" isn't specified to arrive in any
-         # particular order. We'll have to keep walking it incrementally.
-
-         my %accepted_authevents;
-         while( @auth_chain ) {
-            my @accepted = extract_by {
-               $inbound_server->auth_check_event( $_, \%accepted_authevents )
-            } @auth_chain;
-
-            unless( @accepted ) {
-               log_if_fail "Unacceptable auth chain", \@auth_chain;
-
-               die "Unable to find any more acceptable auth_chain events";
-            }
-
-            $accepted_authevents{$_->{event_id}} = $_ for @accepted;
-         }
-
-         assert_json_nonempty_list( $response->{state} );
-         my %state = partition_by { $_->{type} } @{ $response->{state} };
-
-         log_if_fail "State", \%state;
-
-         # TODO: lots more checking. Requires spec though
-         Future->done(1);
-      });
-   };
-
-
-
-test "Inbound federation supports v2 /send_join",
-   requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
-                 local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
-                 federation_user_id_fixture() ],
-
-   do => sub {
-      my ( $outbound_client, $inbound_server, $creator, $room_id, $user_id ) = @_;
-      my $first_home_server = $creator->server_name;
-
-      my $local_server_name = $outbound_client->server_name;
-      my $datastore         = $inbound_server->datastore;
-
-      $outbound_client->do_request_json(
-         method   => "GET",
-         hostname => $first_home_server,
-         uri      => "/v1/make_join/$room_id/$user_id",
-      )->then( sub {
-         my ( $body ) = @_;
-         log_if_fail "make_join body", $body;
-
-         assert_json_keys( $body, qw( event ));
-
-         my $protoevent = $body->{event};
-
-         assert_json_keys( $protoevent, qw(
-            auth_events content depth room_id sender state_key type
-         ));
-
-         assert_json_nonempty_list( my $auth_events = $protoevent->{auth_events} );
-         foreach my $auth_event ( @$auth_events ) {
-            assert_json_list( $auth_event );
-            @$auth_event == 2 or
-               die "Expected auth_event list element to have 2 members";
-
-            assert_json_string( $auth_event->[0] );  # id
-            assert_json_object( $auth_event->[1] );  # hashes
-         }
-
-         assert_json_nonempty_list( $protoevent->{prev_events} );
-
-         assert_json_number( $protoevent->{depth} );
-
-         $protoevent->{room_id} eq $room_id or
-            die "Expected 'room_id' to be $room_id";
-         $protoevent->{sender} eq $user_id or
-            die "Expected 'sender' to be $user_id";
-         $protoevent->{state_key} eq $user_id or
-            die "Expected 'state_key' to be $user_id";
-         $protoevent->{type} eq "m.room.member" or
-            die "Expected 'type' to be 'm.room.member'";
-
-         assert_json_keys( my $content = $protoevent->{content}, qw( membership ) );
-         $content->{membership} eq "join" or
-            die "Expected 'membership' to be 'join'";
-
-         my %event = (
-            ( map { $_ => $protoevent->{$_} } qw(
-               auth_events content depth prev_events room_id sender
-               state_key type ) ),
-
-            event_id         => $datastore->next_event_id,
-            origin           => $local_server_name,
-            origin_server_ts => $inbound_server->time_ms,
-         );
-
-         $datastore->sign_event( \%event );
-
-         $outbound_client->do_request_json(
-            method   => "PUT",
-            hostname => $first_home_server,
-            uri      => "/v2/send_join/$room_id/$event{event_id}",
-
-            content => \%event,
-         )
-      })->then( sub {
-         my ( $response ) = @_;
-
-         assert_json_keys( $response, qw( auth_chain state ));
-
-         assert_json_nonempty_list( $response->{auth_chain} );
-         my @auth_chain = @{ $response->{auth_chain} };
-
-         log_if_fail "Auth chain", \@auth_chain;
-
-         foreach my $event ( @auth_chain ) {
-            assert_is_valid_pdu( $event );
-            $event->{room_id} eq $room_id or
-               die "Expected auth_event room_id to be $room_id";
-         }
-
-         # Annoyingly, the "auth chain" isn't specified to arrive in any
-         # particular order. We'll have to keep walking it incrementally.
-
-         my %accepted_authevents;
-         while( @auth_chain ) {
-            my @accepted = extract_by {
-               $inbound_server->auth_check_event( $_, \%accepted_authevents )
-            } @auth_chain;
-
-            unless( @accepted ) {
-               log_if_fail "Unacceptable auth chain", \@auth_chain;
-
-               die "Unable to find any more acceptable auth_chain events";
-            }
-
-            $accepted_authevents{$_->{event_id}} = $_ for @accepted;
-         }
-
-         assert_json_nonempty_list( $response->{state} );
-         my %state = partition_by { $_->{type} } @{ $response->{state} };
-
-         log_if_fail "State", \%state;
-
-         # TODO: lots more checking. Requires spec though
-         Future->done(1);
-      });
-   };
-
-
-
-test "Outbound federation falls back to v1 /send_join if v2 isn't available",
-   requires => [ local_user_fixture(), $main::INBOUND_SERVER,
-                 federation_user_id_fixture() ],
-
-   do => sub {
-      my ( $user, $inbound_server, $creator_id ) = @_;
-
-      my $local_server_name = $inbound_server->server_name;
-      my $datastore         = $inbound_server->datastore;
-
-      my $room = SyTest::Federation::Room->new(
-         datastore => $datastore,
-      );
-
-      $room->create_initial_events(
-         server  => $inbound_server,
-         creator => $creator_id,
-      );
-
-      my $room_id = $room->room_id;
-
-      my $room_alias = "#50fed-room-alias:$local_server_name";
-      $datastore->{room_aliases}{$room_alias} = $room_id;
-
-      Future->needs_all(
-         # Await PDU?
-
-         $inbound_server->await_request_make_join( $room_id, $user->user_id )->then( sub {
-            my ( $req, $room_id, $user_id ) = @_;
-
-            my $proto = $room->make_join_protoevent(
-               user_id => $user_id,
-            );
-
-            $proto->{origin}           = $inbound_server->server_name;
-            $proto->{origin_server_ts} = $inbound_server->time_ms;
-
-            $req->respond_json( {
-               event => $proto,
-            } );
-
-            Future->done;
-         }),
-
-         $inbound_server->await_request_send_join( $room_id )->then( sub {
-            my ( $req, $room_id, $event_id ) = @_;
-
-            $req->method eq "PUT" or
-               die "Expected send_join method to be PUT";
-
-            my $event = $req->body_from_json;
-            log_if_fail "send_join event", $event;
-
-            my @auth_chain = $datastore->get_auth_chain_events(
-               map { $_->[0] } @{ $event->{auth_events} }
-            );
-
-            $req->respond_json(
-               # /v1/send_join has an extraneous [200, ...] wrapper (see MSC1802)
-               my $response = [ 200, {
-                  auth_chain => \@auth_chain,
-                  state      => [ $room->current_state_events ],
-               } ]
-            );
-
-            log_if_fail "send_join response", $response;
-
-            Future->done;
-         }),
-
-         do_request_json_for( $user,
-            method => "POST",
-            uri    => "/r0/join/$room_alias",
-
-            content => {},
+            uri      => "/v1/make_join/$room_id/$user_id",
          )->then( sub {
             my ( $body ) = @_;
-            log_if_fail "Join response", $body;
+            log_if_fail "make_join body", $body;
 
-            assert_json_keys( $body, qw( room_id ));
+            assert_json_keys( $body, qw( event ));
 
-            $body->{room_id} eq $room_id or
-               die "Expected room_id to be $room_id";
+            my $protoevent = $body->{event};
 
-            matrix_get_my_member_event( $user, $room_id )
+            assert_json_keys( $protoevent, qw(
+               auth_events content depth room_id sender state_key type
+            ));
+
+            assert_json_nonempty_list( my $auth_events = $protoevent->{auth_events} );
+            foreach my $auth_event ( @$auth_events ) {
+               assert_json_list( $auth_event );
+               @$auth_event == 2 or
+                  die "Expected auth_event list element to have 2 members";
+
+               assert_json_string( $auth_event->[0] );  # id
+               assert_json_object( $auth_event->[1] );  # hashes
+            }
+
+            assert_json_nonempty_list( $protoevent->{prev_events} );
+
+            assert_json_number( $protoevent->{depth} );
+
+            $protoevent->{room_id} eq $room_id or
+               die "Expected 'room_id' to be $room_id";
+            $protoevent->{sender} eq $user_id or
+               die "Expected 'sender' to be $user_id";
+            $protoevent->{state_key} eq $user_id or
+               die "Expected 'state_key' to be $user_id";
+            $protoevent->{type} eq "m.room.member" or
+               die "Expected 'type' to be 'm.room.member'";
+
+            assert_json_keys( my $content = $protoevent->{content}, qw( membership ) );
+            $content->{membership} eq "join" or
+               die "Expected 'membership' to be 'join'";
+
+            my %event = (
+               ( map { $_ => $protoevent->{$_} } qw(
+                  auth_events content depth prev_events room_id sender
+                  state_key type ) ),
+
+               event_id         => $datastore->next_event_id,
+               origin           => $local_server_name,
+               origin_server_ts => $inbound_server->time_ms,
+            );
+
+            $datastore->sign_event( \%event );
+
+            $outbound_client->do_request_json(
+               method   => "PUT",
+               hostname => $first_home_server,
+               uri      => "/$versionprefix/send_join/$room_id/$event{event_id}",
+
+               content => \%event,
+            )
          })->then( sub {
-            my ( $event ) = @_;
+            my ( $response ) = @_;
 
-            # The joining HS (i.e. the SUT) should have invented the event ID
-            # for my membership event.
+            if( $versionprefix eq "v1" ) {
+               # /v1/send_join has an extraneous [200, ...] wrapper (see MSC1802)
+               $response->[0] == 200 or
+                  die "Expected first response element to be 200";
 
-            # TODO - sanity check the $event
+               $response = $response->[1];
+            }
 
+            assert_json_keys( $response, qw( auth_chain state ));
+
+            assert_json_nonempty_list( $response->{auth_chain} );
+            my @auth_chain = @{ $response->{auth_chain} };
+
+            log_if_fail "Auth chain", \@auth_chain;
+
+            foreach my $event ( @auth_chain ) {
+               assert_is_valid_pdu( $event );
+               $event->{room_id} eq $room_id or
+                  die "Expected auth_event room_id to be $room_id";
+            }
+
+            # Annoyingly, the "auth chain" isn't specified to arrive in any
+            # particular order. We'll have to keep walking it incrementally.
+
+            my %accepted_authevents;
+            while( @auth_chain ) {
+               my @accepted = extract_by {
+                  $inbound_server->auth_check_event( $_, \%accepted_authevents )
+               } @auth_chain;
+
+               unless( @accepted ) {
+                  log_if_fail "Unacceptable auth chain", \@auth_chain;
+
+                  die "Unable to find any more acceptable auth_chain events";
+               }
+
+               $accepted_authevents{$_->{event_id}} = $_ for @accepted;
+            }
+
+            assert_json_nonempty_list( $response->{state} );
+            my %state = partition_by { $_->{type} } @{ $response->{state} };
+
+            log_if_fail "State", \%state;
+
+            # TODO: lots more checking. Requires spec though
             Future->done(1);
-         }),
-      )
-   };
-
+         });
+      };
+}
 
 
 test "Inbound /v1/make_join rejects remote attempts to join local users to rooms",

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -217,7 +217,7 @@ test "Outbound federation passes make_join failures through to the client",
 
 
 foreach my $versionprefix ( qw ( v1 v2 ) ) {
-   test "Outbound federation can receive $versionprefix /send_join",
+   test "Inbound federation can receive $versionprefix /send_join",
       requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
                     local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
                     federation_user_id_fixture() ],

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -80,6 +80,12 @@ foreach my $versionprefix ( qw( v1 v2 ) ) {
          my $await_request_send_join;
 
          if( $versionprefix eq "v1" ) {
+            # If we only expect a response on the v1 endpoint, the homeserver will try to
+            # hit the v2 one, get a 404 from SyTest (because we didn't call
+            # await_request_v2_send_join), then fall back to the v1 endpoint. We rely on
+            # that 404 response from SyTest and that fallback mechanism to test that the
+            # homeserver can query the v1 endpoint, and correctly handles responses from
+            # it.
             $await_request_send_join = $inbound_server->await_request_v1_send_join( $room_id );
          }
          elsif( $versionprefix eq "v2" ) {

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -327,6 +327,127 @@ test "Inbound federation can receive v1 room-join requests",
    };
 
 
+
+test "Inbound federation supports v2 /send_join",
+   requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
+                 local_user_and_room_fixtures( room_opts => { room_version => "1" } ),
+                 federation_user_id_fixture() ],
+
+   do => sub {
+      my ( $outbound_client, $inbound_server, $creator, $room_id, $user_id ) = @_;
+      my $first_home_server = $creator->server_name;
+
+      my $local_server_name = $outbound_client->server_name;
+      my $datastore         = $inbound_server->datastore;
+
+      $outbound_client->do_request_json(
+         method   => "GET",
+         hostname => $first_home_server,
+         uri      => "/v1/make_join/$room_id/$user_id",
+      )->then( sub {
+         my ( $body ) = @_;
+         log_if_fail "make_join body", $body;
+
+         assert_json_keys( $body, qw( event ));
+
+         my $protoevent = $body->{event};
+
+         assert_json_keys( $protoevent, qw(
+            auth_events content depth room_id sender state_key type
+         ));
+
+         assert_json_nonempty_list( my $auth_events = $protoevent->{auth_events} );
+         foreach my $auth_event ( @$auth_events ) {
+            assert_json_list( $auth_event );
+            @$auth_event == 2 or
+               die "Expected auth_event list element to have 2 members";
+
+            assert_json_string( $auth_event->[0] );  # id
+            assert_json_object( $auth_event->[1] );  # hashes
+         }
+
+         assert_json_nonempty_list( $protoevent->{prev_events} );
+
+         assert_json_number( $protoevent->{depth} );
+
+         $protoevent->{room_id} eq $room_id or
+            die "Expected 'room_id' to be $room_id";
+         $protoevent->{sender} eq $user_id or
+            die "Expected 'sender' to be $user_id";
+         $protoevent->{state_key} eq $user_id or
+            die "Expected 'state_key' to be $user_id";
+         $protoevent->{type} eq "m.room.member" or
+            die "Expected 'type' to be 'm.room.member'";
+
+         assert_json_keys( my $content = $protoevent->{content}, qw( membership ) );
+         $content->{membership} eq "join" or
+            die "Expected 'membership' to be 'join'";
+
+         my %event = (
+            ( map { $_ => $protoevent->{$_} } qw(
+               auth_events content depth prev_events room_id sender
+               state_key type ) ),
+
+            event_id         => $datastore->next_event_id,
+            origin           => $local_server_name,
+            origin_server_ts => $inbound_server->time_ms,
+         );
+
+         $datastore->sign_event( \%event );
+
+         $outbound_client->do_request_json(
+            method   => "PUT",
+            hostname => $first_home_server,
+            uri      => "/v2/send_join/$room_id/$event{event_id}",
+
+            content => \%event,
+         )
+      })->then( sub {
+         my ( $response ) = @_;
+
+         assert_json_keys( $response, qw( auth_chain state ));
+
+         assert_json_nonempty_list( $response->{auth_chain} );
+         my @auth_chain = @{ $response->{auth_chain} };
+
+         log_if_fail "Auth chain", \@auth_chain;
+
+         foreach my $event ( @auth_chain ) {
+            assert_is_valid_pdu( $event );
+            $event->{room_id} eq $room_id or
+               die "Expected auth_event room_id to be $room_id";
+         }
+
+         # Annoyingly, the "auth chain" isn't specified to arrive in any
+         # particular order. We'll have to keep walking it incrementally.
+
+         my %accepted_authevents;
+         while( @auth_chain ) {
+            my @accepted = extract_by {
+               $inbound_server->auth_check_event( $_, \%accepted_authevents )
+            } @auth_chain;
+
+            unless( @accepted ) {
+               log_if_fail "Unacceptable auth chain", \@auth_chain;
+
+               die "Unable to find any more acceptable auth_chain events";
+            }
+
+            $accepted_authevents{$_->{event_id}} = $_ for @accepted;
+         }
+
+         assert_json_nonempty_list( $response->{state} );
+         my %state = partition_by { $_->{type} } @{ $response->{state} };
+
+         log_if_fail "State", \%state;
+
+         # TODO: lots more checking. Requires spec though
+         Future->done(1);
+      });
+   };
+
+
+
 test "Inbound /v1/make_join rejects remote attempts to join local users to rooms",
    requires => [ $main::OUTBOUND_CLIENT,
                  local_user_fixture(),


### PR DESCRIPTION
One half of testing the implementation of MSC1802 (https://github.com/matrix-org/synapse/issues/6293). Also adds support for `await_request_[...]` on non-v1 endpoints.