### PR TITLE
Add tests for outbound v2 invite API

### DIFF
--- a/lib/SyTest/Federation/Server.pm
+++ b/lib/SyTest/Federation/Server.pm
@@ -443,6 +443,10 @@ __PACKAGE__->mk_await_request_pair(
 );
 
 __PACKAGE__->mk_await_request_pair(
+   "v2", "invite", [qw( :room_id )],
+);
+
+__PACKAGE__->mk_await_request_pair(
    "v1", "event", [qw( :event_id )],
 );
 


### PR DESCRIPTION
This was added by MSC1794 back in January, but never got any tests for the outbound API. Until now we were relying on the v1 API.