### PR TITLE
Test for backfilled events whose prev_events cross room boundaries

### DIFF
--- a/tests/50federation/34room-backfill.pl
+++ b/tests/50federation/34room-backfill.pl
@@ -1,5 +1,7 @@
 use Future::Utils qw( repeat );
 
+my $json = JSON->new->convert_blessed(1)->utf8(1);
+
 test "Outbound federation can backfill events",
    requires => [ local_user_fixture(), $main::INBOUND_SERVER, federation_user_id_fixture() ],
 
@@ -244,5 +246,200 @@ test "Backfill checks the events requested belong to the room",
          # the response should be empty.
          assert_eq( 0, scalar @{$body->{pdus}}, 'response should be empty' );
          Future->done(1);
+      });
+   };
+
+test "Backfilled events whose prev_events are in a different room do not allow cross-room back-pagination",
+   requires => [
+      federated_rooms_fixture( room_count => 2 ),
+      $main::INBOUND_SERVER,
+      $main::OUTBOUND_CLIENT,
+   ],
+
+   do => sub {
+      my ( $creator_user, $sytest_user_id, $room1, $room2, $inbound_server, $outbound_client ) = @_;
+      my $synapse_server_name = $creator_user->http->server_name;
+      my $room2_id = $room2->room_id;
+
+      # we're going to create four events, P, Q, R, S. P is in room1; Q, R and
+      # S are in room2, but Q's auth_events points to P.
+      #
+      # We send event S over federation, and allow the server to backfill R,
+      # leaving the server with a gap in the dag.
+      #
+      # Then we send P, which is a normal event.
+      #
+      # Finally we back-paginate, allow Q to land, and make sure that we don't
+      # end up seeing P.
+
+      # create the events
+      my ( $event_P, $event_id_P ) = $room1->create_and_insert_event(
+         type    => "m.room.message",
+         sender  => $sytest_user_id,
+         content => { body => "event P" },
+      );
+
+      my ( $event_Q, $event_id_Q ) = $room2->create_and_insert_event(
+         type        => "m.room.message",
+         sender      => $sytest_user_id,
+         content     => { body => "event Q" },
+         prev_events => $room2->make_event_refs( $event_P ),
+      );
+
+      my ( $event_R, $event_id_R ) = $room2->create_and_insert_event(
+         type        => "m.room.message",
+         sender      => $sytest_user_id,
+         content     => { body => "event R" },
+      );
+
+      my ( $event_S, $event_id_S ) = $room2->create_and_insert_event(
+         type        => "m.room.message",
+         sender      => $sytest_user_id,
+         content     => { body => "event S" },
+      );
+
+      log_if_fail "events P, Q, R, S", [ $event_id_P, $event_id_Q, $event_id_R, $event_id_S ];
+
+      Future->needs_all(
+         # kick things off by sending S over federation
+         $outbound_client->send_event(
+            event => $event_S,
+            destination => $synapse_server_name,
+         ),
+
+         # we expect to get a missing_events request
+         $inbound_server->await_request_get_missing_events( $room2_id )
+         ->then( sub {
+            my ( $req ) = @_;
+
+            my $body = $req->body_from_json;
+            log_if_fail "/get_missing_events request", $body;
+
+            assert_deeply_eq(
+               $body->{latest_events},
+               [ $event_id_S ],
+               "latest_events in /get_missing_events request",
+            );
+
+            # just return R
+            my $resp = { events => [ $event_R ] };
+
+            log_if_fail "/get_missing_events response", $resp;
+            $req->respond_json( $resp );
+            Future->done(1);
+         }),
+
+         # there will still be a gap, so then we expect a state_ids request
+         $inbound_server->await_request_state_ids(
+            $room2_id, $event_id_Q,
+         )->then( sub {
+            my ( $req, @params ) = @_;
+            log_if_fail "/state_ids request", \@params;
+
+            my %state  = %{ $room2->{current_state} };
+            my $resp = {
+               pdu_ids => [
+                  map { $room2->id_for_event( $_ ) } values( %state ),
+               ],
+
+               # XXX we're supposed to return the whole auth chain here,
+               # not just Q's auth_events. It doesn't matter too much
+               # here though.
+               auth_chain_ids => $room2->event_ids_from_refs( $event_Q->{auth_events} ),
+            };
+
+            log_if_fail "/state_ids response", $resp;
+            $req->respond_json( $resp );
+            Future->done(1);
+         }),
+      )->then( sub {
+         # now let's send event P
+         $outbound_client->send_event(
+            event => $event_P,
+            destination => $synapse_server_name,
+         );
+      })->then( sub {
+         # wait for it to arrive
+         my $filter = $json->encode( { room => { timeline => { limit => 2 }}} );
+         await_sync_timeline_contains(
+            $creator_user, $room2_id,
+            filter => $filter,
+            check => sub {
+               $_[0]->{event_id} eq $event_id_S
+            },
+         );
+      })->then( sub {
+         my ( $sync_body ) = @_;
+         my $room2_sync = $sync_body->{rooms}->{join}->{$room2_id};
+         log_if_fail "sync body", $room2_sync;
+
+         my $prev_batch = $room2_sync->{timeline}->{prev_batch};
+         assert_ok( $prev_batch, "prev_batch" );
+
+         # now back-paginate, and provide event Q (and P, for good measure) when the
+         # server backfills.
+         Future->needs_all(
+            do_request_json_for(
+               $creator_user,
+               method => "GET",
+               uri    => "/r0/rooms/$room2_id/messages",
+               params => {
+                  dir  => "b",
+                  from => $prev_batch,
+               },
+            ),
+
+            $inbound_server->await_request_backfill( $room2_id )->then( sub {
+               my ( $req ) = @_;
+
+               $req->respond_json( {
+                  origin           => $inbound_server->server_name,
+                  origin_server_ts => $inbound_server->time_ms,
+                  pdus             => [
+                     $event_Q,
+                     $event_P,
+                  ],
+               });
+               Future->done;
+            }),
+
+            # the server will (should) see the prev_event link to P as a hole in the dag,
+            # so will send us another state_ids request at Q.
+            $inbound_server->await_request_state_ids(
+               $room2_id, $event_id_Q,
+            )->then( sub {
+               my ( $req, @params ) = @_;
+               log_if_fail "/state_ids request", \@params;
+
+               my %state  = %{ $room2->{current_state} };
+               my $resp = {
+                  pdu_ids => [
+                     map { $room2->id_for_event( $_ ) } values( %state ),
+                  ],
+                  auth_chain_ids => $room2->event_ids_from_refs( $event_Q->{auth_events} ),
+               };
+
+               log_if_fail "/state_ids response", $resp;
+               $req->respond_json( $resp );
+               Future->done(1);
+             }),
+         )->then( sub {
+             my ( $messages ) = @_;
+             log_if_fail "/messages result", $messages;
+
+             # ensure that P does not feature in the list.
+             die 'too few events' if @{$messages->{chunk}} < 2;
+             foreach my $ev ( @{$messages->{chunk}} ) {
+                if( $ev->{type} eq 'm.room.member' ) {
+                   # our join event, so we're ok.
+                   last;
+                }
+
+                # otherwise it should only be event Q.
+                assert_eq( $ev->{type}, 'm.room.message', 'event_type' );
+                assert_eq( $ev->{content}->{body}, 'event Q' );
+             }
+             Future->done;
+          });
       });
    };


### PR DESCRIPTION
AFAIK this has always worked reasonably acceptably, but it seems we should have some tests for it.