### PR TITLE
Add dendrite's logs to buildkite's artifacts

### DIFF
--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -52,7 +52,7 @@ fi
 echo >&2 "--- Copying assets"
 
 # Copy out the logs
-rsync --ignore-missing-args --min-size=1B -av server-0 server-1 /logs --include "*/" --include="*.log.*" --include="*.log" --exclude="*"
+rsync --ignore-missing-args --min-size=1B -av server-0 server-1 /logs --include "*/" --include="*.log.*" --include="*.log" --include="dendrite-logs/*.log" --exclude="*"
 
 if [ $TEST_STATUS -ne 0 ]; then
     # Build the annotation


### PR DESCRIPTION
Dendrite's logs are dropped in `server-x/dendrite-logs/ComponentX.log`. Edit the rsync command to pick them up.