### PR TITLE
Add support for synapse multi DB setups.

### DIFF
--- a/lib/SyTest/Homeserver.pm
+++ b/lib/SyTest/Homeserver.pm
@@ -376,6 +376,10 @@ sub _get_dbconfigs
 
       $db_configs{"main"} = \%db_config;
    }
+   else {
+      YAML::DumpFile( "$hs_dir/database.yaml", \%defaults );
+      %db_config = %defaults;
+   }
 
    # Go through each database and check the config and clear the database.
    foreach my $db ( keys %db_configs ) {

--- a/lib/SyTest/Homeserver.pm
+++ b/lib/SyTest/Homeserver.pm
@@ -296,6 +296,10 @@ It returns the config hash.
 
 =cut
 
+# This is now only used for Dendrite, as synapse uses `_get_dbconfigs`. It
+# probably makes more sense to have a dendrite specific handling, rather than
+# using synapse config format and then parsing and converting it into dendrite
+# config.
 sub _get_dbconfig
 {
    my $self = shift;

--- a/lib/SyTest/Homeserver.pm
+++ b/lib/SyTest/Homeserver.pm
@@ -369,14 +369,20 @@ sub _get_dbconfigs
    # Try and load the configs from the various locations.
    my ( %db_configs );
    if ( -f "$hs_dir/databases.yaml") {
+      $self->{output}->diag( "Using DB config from $hs_dir/databases.yaml" );
+
       %db_configs = %{ YAML::LoadFile( "$hs_dir/databases.yaml" ) };
    }
    elsif( -f "$hs_dir/database.yaml" ) {
+      $self->{output}->diag( "Using DB config from $hs_dir/database.yaml" );
+
       my %db_config = %{ YAML::LoadFile( "$hs_dir/database.yaml" ) };
 
       $db_configs{"main"} = \%db_config;
    }
    else {
+      $self->{output}->diag( "Using default DB config and writing to $hs_dir/database.yaml" );
+
       YAML::DumpFile( "$hs_dir/database.yaml", \%defaults );
       $db_configs{"main"} = \%defaults;
    }

--- a/lib/SyTest/Homeserver.pm
+++ b/lib/SyTest/Homeserver.pm
@@ -378,7 +378,7 @@ sub _get_dbconfigs
    }
    else {
       YAML::DumpFile( "$hs_dir/database.yaml", \%defaults );
-      %db_config = %defaults;
+      $db_configs{"main"} = \%defaults;
    }
 
    # Go through each database and check the config and clear the database.

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -106,29 +106,26 @@ sub start
 
    my $hs_dir = $self->{hs_dir};
 
-   my %db_config = $self->_get_dbconfig(
+   my %db_configs = $self->_get_dbconfigs(
       type => 'sqlite',
       args => {
          database => ":memory:", #"$hs_dir/homeserver.db",
       },
    );
 
-   my $db_type = $db_config{type};
+   # convert sytest db args onto synapse db args
+   for my $db ( keys %db_configs ) {
+      my %db_config = %{ $db_configs{$db} };
 
-   # map sytest db args onto synapse db args
-   my %synapse_db_config;
-   if( $db_type eq "pg" ) {
-      %synapse_db_config = (
-         name => 'psycopg2',
-         args => $db_config{args},
-      );
-   }
-   else {
-      # must be sqlite
-      %synapse_db_config = (
-         name => 'sqlite3',
-         args => $db_config{args},
-      );
+      my $db_type = $db_config{type};
+
+      if( $db_type eq "pg" ) {
+         $db_configs{$db}{name} = 'psycopg2';
+      }
+      else {
+         # must be sqlite
+         $db_configs{$db}{name} = 'sqlite3';
+      }
    }
 
    # Clean up the media_store directory each time, or else it fills up with
@@ -210,7 +207,7 @@ sub start
         },
 
         enable_registration => "true",
-        database => \%synapse_db_config,
+        databases => \%db_configs,
         macaroon_secret_key => $macaroon_secret_key,
         registration_shared_secret => $registration_shared_secret,
 

--- a/scripts/synapse_sytest.sh
+++ b/scripts/synapse_sytest.sh
@@ -26,10 +26,12 @@ if [ -n "$MULTI_POSTGRES" ]; then
     su -c 'eatmydata /usr/lib/postgresql/*/bin/pg_ctl -w -D $PGDATA start' postgres
 
     # Make the test databases for the two Synapse servers that will be spun up
-    su -c 'psql -c "CREATE DATABASE pg1_main;"' postgres
-    su -c 'psql -c "CREATE DATABASE pg1_state;"' postgres
-    su -c 'psql -c "CREATE DATABASE pg2_main;"' postgres
-    su -c 'psql -c "CREATE DATABASE pg2_state;"' postgres
+    su -c psql postgres <<EOF
+CREATE DATABASE pg1_main;
+CREATE DATABASE pg1_state;
+CREATE DATABASE pg2_main;
+CREATE DATABASE pg2_state;
+EOF
 
     mkdir -p "/work/server-0"
     mkdir -p "/work/server-1"

--- a/scripts/synapse_sytest.sh
+++ b/scripts/synapse_sytest.sh
@@ -16,7 +16,73 @@ cd "$(dirname $0)/.."
 mkdir /work
 
 # PostgreSQL setup
-if [ -n "$POSTGRES" ]; then
+if [ -n "$MULTI_POSTGRES" ]; then
+    # In this mode we want to run synapse against multiple split out databases.
+
+    # We increase the max connections as we have more databases.
+    echo -e "max_connections=1000" >> /var/run/postgresql/data/postgresql.conf
+
+    # Start the database
+    su -c 'eatmydata /usr/lib/postgresql/*/bin/pg_ctl -w -D $PGDATA start' postgres
+
+    # Make the test databases for the two Synapse servers that will be spun up
+    su -c 'psql -c "CREATE DATABASE pg1_main;"' postgres
+    su -c 'psql -c "CREATE DATABASE pg1_state;"' postgres
+    su -c 'psql -c "CREATE DATABASE pg2_main;"' postgres
+    su -c 'psql -c "CREATE DATABASE pg2_state;"' postgres
+
+    mkdir -p "/work/server-0"
+    mkdir -p "/work/server-1"
+
+    # We leave user, password, host blank to use the defaults (unix socket and
+    # local auth)
+    cat > "/work/server-0/databases.yaml" << EOF
+main:
+    name: psycopg2
+    data_stores:
+        - main
+    args:
+        database: pg1_main
+        user: postgres
+        password: $PGPASSWORD
+        host: localhost
+        sslmode: disable
+state_db:
+    name: psycopg2
+    data_stores:
+        - state
+    args:
+        database: pg1_state
+        user: postgres
+        password: $PGPASSWORD
+        host: localhost
+        sslmode: disable
+EOF
+
+    cat > "/work/server-1/databases.yaml" << EOF
+main:
+    name: psycopg2
+    data_stores:
+        - main
+    args:
+        database: pg2_main
+        user: postgres
+        password: $PGPASSWORD
+        host: localhost
+        sslmode: disable
+state_db:
+    name: psycopg2
+    data_stores:
+        - state
+    args:
+        database: pg2_state
+        user: postgres
+        password: $PGPASSWORD
+        host: localhost
+        sslmode: disable
+EOF
+
+elif [ -n "$POSTGRES" ]; then
     export PGUSER=postgres
     export POSTGRES_DB_1=pg1
     export POSTGRES_DB_2=pg2


### PR DESCRIPTION
This allows specifying a `databases.yaml` file that contains multiple
databases.

I don't really know if this is the right way of doing it.

Uses https://github.com/matrix-org/synapse/pull/6580