### PR TITLE
"Running tests" section for dendrite sytest output

### DIFF
--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -31,6 +31,8 @@ args:
 type: pg
 EOF
 
+# Run the tests
+echo >&2 "+++ Running tests"
 
 # Run the tests
 mkdir -p /logs


### PR DESCRIPTION
Just as we have in Synapse:

https://github.com/matrix-org/sytest/blob/c01db908019e85361f6ce0740674eacc6e55da69/scripts/synapse_sytest.sh#L128-L129

Else we end up with the test output showing under "Preparing postgres for dendrite", which is unintuitive.