### PR TITLE
Test Synapse with MAU limits enabled.

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -276,6 +276,9 @@ sub start
            },
         ) : (),
 
+        # We use a high limit so the limit is never reached, but enabling the
+        # limit ensures that the code paths get hit. This helps testing the
+        # feature with worker mode.
         limit_usage_by_mau => "true",
         max_mau_value => 50000000,
 

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -276,6 +276,9 @@ sub start
            },
         ) : (),
 
+        limit_usage_by_mau => "true",
+        max_mau_value => 50000000,
+
         map {
            defined $self->{$_} ? ( $_ => $self->{$_} ) : ()
         } qw(


### PR DESCRIPTION
We use a high limit so the limit is never reached, but enabling the
limit ensures that the code paths get hit. This helps testing the
feature with worker mode.

c.f. https://github.com/matrix-org/synapse/pull/6742