### PR TITLE
Fix Dendrite's Sytest script

### DIFF
--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -17,6 +17,9 @@ mkdir /work
 # Start the database
 su -c 'eatmydata /usr/lib/postgresql/*/bin/pg_ctl -w -D $PGDATA start' postgres
 
+# Create required databases
+su -c 'for i in pg1 pg2 sytest_template; do psql -c "CREATE DATABASE $i;"; done' postgres
+
 export PGUSER=postgres
 export POSTGRES_DB_1=pg1
 export POSTGRES_DB_2=pg2

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -56,18 +56,7 @@ fi
 echo >&2 "--- Copying assets"
 
 # Copy out the logs
-lsb_release -a
-pwd
-apt update
-apt install tree
-tree /work
-tree /src
-# TODO: Change /work/server-1 to /work/server-1/dendrite-logs once sytest is capable of
-#  spinning up multiple dendrites
 rsync -r --ignore-missing-args --min-size=1B -av /work/server-0 /work/server-1 /logs --include "*/" --include="*.log.*" --include="*.log" --exclude="*"
-tree /logs
-cat /work/server-0/dendrite.yaml
-cat /work/server-0/database.yaml
 
 if [ $TEST_STATUS -ne 0 ]; then
     # Build the annotation

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -67,6 +67,7 @@ tree /src
 # TODO: Change /work/server-1 to /work/server-1/dendrite-logs once sytest is capable of
 #  spinning up multiple dendrites
 rsync --ignore-missing-args --min-size=1B -av /work/server-0/dendrite-logs /work/server-1 /logs --include "*/" --include="*.log.*" --include="*.log" --exclude="*"
+tree /logs
 
 if [ $TEST_STATUS -ne 0 ]; then
     # Build the annotation

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -17,19 +17,8 @@ mkdir /work
 # Start the database
 su -c 'eatmydata /usr/lib/postgresql/*/bin/pg_ctl -w -D $PGDATA start' postgres
 
-# Make the test databases
-su -c "psql -c \"CREATE USER dendrite PASSWORD 'itsasecret'\" postgres"
-su -c 'for i in account device mediaapi syncapi roomserver serverkey federationsender publicroomsapi appservice naffka sytest_template; do psql -c "CREATE DATABASE $i OWNER dendrite;"; done' postgres
-
-# Write dendrite configuration
-mkdir -p "/work/server-0"
-cat > "/work/server-0/database.yaml" << EOF
-args:
-    user: $PGUSER
-    database: $PGUSER
-    host: $PGHOST
-type: pg
-EOF
+# Write out the configuration for a PostgreSQL Dendrite
+./scripts/prep_sytest_for_postgres.sh
 
 # Build dendrite
 echo >&2 "--- Building dendrite from source"
@@ -62,7 +51,6 @@ pwd
 apt update
 apt install tree
 tree /work
-tree /workdir
 tree /src
 # TODO: Change /work/server-1 to /work/server-1/dendrite-logs once sytest is capable of
 #  spinning up multiple dendrites

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -34,7 +34,7 @@ EOF
 # Build dendrite
 echo >&2 "--- Building dendrite from source"
 cd /src
-/src/build.sh
+./build.sh
 cd -
 
 # Run the tests

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -52,7 +52,12 @@ fi
 echo >&2 "--- Copying assets"
 
 # Copy out the logs
-rsync --ignore-missing-args --min-size=1B -av server-0 server-1 /logs --include "*/" --include="*.log.*" --include="*.log" --include="dendrite-logs/*.log" --exclude="*"
+lsb_release -a
+pwd
+apt update
+apt install tree
+tree /work
+rsync --ignore-missing-args --min-size=1B -av /work/server-0 /work/server-1 /logs --include "*/" --include="*.log.*" --include="*.log" --exclude="*"
 
 if [ $TEST_STATUS -ne 0 ]; then
     # Build the annotation

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -50,8 +50,8 @@ else
     echo >&2 -e "run-tests \e[32mPASSED\e[0m"
 fi
 
-# Check for new tests to be added to testfile
-/src/show-expected-fail-tests.sh /logs/results.tap /src/testfile || TEST_STATUS=$?
+# Check for new tests to be added to the test whitelist
+/src/show-expected-fail-tests.sh /logs/results.tap /src/sytest-whitelist || TEST_STATUS=$?
 
 echo >&2 "--- Copying assets"
 

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -40,7 +40,8 @@ echo >&2 "+++ Running tests"
 
 TEST_STATUS=0
 mkdir -p /logs
-./run-tests.pl -I Dendrite::Monolith -d /src/bin -W /src/testfile -O tap --all \
+./run-tests.pl -I Dendrite::Monolith -d /src/bin -O tap --all \
+    -W /src/testfile -B /src/sytest-blacklist \
     --work-directory="/work" \
     "$@" > /logs/results.tap || TEST_STATUS=$?
 

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -40,7 +40,7 @@ echo >&2 "+++ Running tests"
 
 TEST_STATUS=0
 mkdir -p /logs
-./run-tests.pl -I Dendrite::Monolith -d /src/bin -W /src/testfile -O tap --all \
+./run-tests.pl -I Dendrite::Monolith -d /src/bin -W /src/sytest-whitelist -O tap --all \
     --work-directory="/work" \
     "$@" > /logs/results.tap || TEST_STATUS=$?
 

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -68,8 +68,8 @@ tree /src
 #  spinning up multiple dendrites
 rsync -r --ignore-missing-args --min-size=1B -av /work/server-0 /work/server-1 /logs --include "*/" --include="*.log.*" --include="*.log" --exclude="*"
 tree /logs
-cat /work/dendrite.yaml
-cat /work/database.yaml
+cat /work/server-0/dendrite.yaml
+cat /work/server-0/database.yaml
 
 if [ $TEST_STATUS -ne 0 ]; then
     # Build the annotation

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -17,7 +17,13 @@ mkdir /work
 # Start the database
 su -c 'eatmydata /usr/lib/postgresql/*/bin/pg_ctl -w -D $PGDATA start' postgres
 
+export PGUSER=postgres
+export POSTGRES_DB_1=pg1
+export POSTGRES_DB_2=pg2
+
 # Write out the configuration for a PostgreSQL Dendrite
+# Note: Dendrite can run entirely within a single database as all of the tables have
+# component prefixes
 ./scripts/prep_sytest_for_postgres.sh
 
 # Build dendrite

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -64,7 +64,9 @@ apt install tree
 tree /work
 tree /workdir
 tree /src
-rsync --ignore-missing-args --min-size=1B -av /work/server-0/dendrite-logs /work/server-1/dendrite-logs /logs --include "*/" --include="*.log.*" --include="*.log" --exclude="*"
+# TODO: Change /work/server-1 to /work/server-1/dendrite-logs once sytest is capable of
+#  spinning up multiple dendrites
+rsync --ignore-missing-args --min-size=1B -av /work/server-0/dendrite-logs /work/server-1 /logs --include "*/" --include="*.log.*" --include="*.log" --exclude="*"
 
 if [ $TEST_STATUS -ne 0 ]; then
     # Build the annotation

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -66,8 +66,10 @@ tree /workdir
 tree /src
 # TODO: Change /work/server-1 to /work/server-1/dendrite-logs once sytest is capable of
 #  spinning up multiple dendrites
-rsync --ignore-missing-args --min-size=1B -av /work/server-0/dendrite-logs /work/server-1 /logs --include "*/" --include="*.log.*" --include="*.log" --exclude="*"
+rsync -r --ignore-missing-args --min-size=1B -av /work/server-0 /work/server-1 /logs --include "*/" --include="*.log.*" --include="*.log" --exclude="*"
 tree /logs
+cat /work/dendrite.yaml
+cat /work/database.yaml
 
 if [ $TEST_STATUS -ne 0 ]; then
     # Build the annotation

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -33,7 +33,9 @@ EOF
 
 # Build dendrite
 echo >&2 "--- Building dendrite from source"
+cd /src
 /src/build.sh
+cd -
 
 # Run the tests
 mkdir -p /logs

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -51,7 +51,8 @@ else
 fi
 
 # Check for new tests to be added to the test whitelist
-/src/show-expected-fail-tests.sh /logs/results.tap /src/sytest-whitelist || TEST_STATUS=$?
+/src/show-expected-fail-tests.sh /logs/results.tap /src/sytest-whitelist \
+    /src/sytest-blacklist || TEST_STATUS=$?
 
 echo >&2 "--- Copying assets"
 

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -64,7 +64,7 @@ apt install tree
 tree /work
 tree /workdir
 tree /src
-rsync --ignore-missing-args --min-size=1B -av /work/server-0 /work/server-1 /logs --include "*/" --include="*.log.*" --include="*.log" --exclude="*"
+rsync --ignore-missing-args --min-size=1B -av /work/server-0/dendrite-logs /work/server-1/dendrite-logs /logs --include "*/" --include="*.log.*" --include="*.log" --exclude="*"
 
 if [ $TEST_STATUS -ne 0 ]; then
     # Build the annotation

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -31,6 +31,9 @@ args:
 type: pg
 EOF
 
+# Build dendrite
+echo >&2 "--- Building dendrite from source"
+/src/build.sh
 
 # Run the tests
 mkdir -p /logs

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -40,8 +40,7 @@ echo >&2 "+++ Running tests"
 
 TEST_STATUS=0
 mkdir -p /logs
-./run-tests.pl -I Dendrite::Monolith -d /src/bin -O tap --all \
-    -W /src/testfile -B /src/sytest-blacklist \
+./run-tests.pl -I Dendrite::Monolith -d /src/bin -W /src/testfile -O tap --all \
     --work-directory="/work" \
     "$@" > /logs/results.tap || TEST_STATUS=$?
 

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -57,6 +57,8 @@ pwd
 apt update
 apt install tree
 tree /work
+tree /workdir
+tree /src
 rsync --ignore-missing-args --min-size=1B -av /work/server-0 /work/server-1 /logs --include "*/" --include="*.log.*" --include="*.log" --exclude="*"
 
 if [ $TEST_STATUS -ne 0 ]; then


### PR DESCRIPTION
This PR fixes a number of problems with dendrite's CI:

* Create a single postgres database for each Dendrite instance (and one for sytest's stuff), instead of a bunch of different databases that were only used by one Dendrite.
* Actually build dendrite
* Add a separate section for test progress so that tests aren't placed in the "Preparing sytest for dendrite..." section
* Add dendrite logs to Artifacts
* 

This PR should be merged at the same time as https://github.com/matrix-org/dendrite/pull/848