### PR TITLE
Fix and move dendrite master branch check

### DIFF
--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -18,11 +18,11 @@ else
     else
         # Otherwise, try and find out what the branch that the Synapse/Dendrite checkout is using. Fall back to develop if it's not a branch.
         branch_name="$(git --git-dir=/src/.git symbolic-ref HEAD 2>/dev/null)" || branch_name="develop"
+    fi
 
-        if [ "$SYTEST_TARGET" == "dendrite" ] && [ branch_name == "master" ]; then
-            # Dendrite uses master as its main branch. If the branch is master, we probably want sytest develop
-            branch_name="develop"
-        fi
+    if [ "$SYTEST_TARGET" == "dendrite" ] && [ "$branch_name" == "master" ]; then
+        # Dendrite uses master as its main branch. If the branch is master, we probably want sytest develop
+        branch_name="develop"
     fi
 
     # Try and fetch the branch


### PR DESCRIPTION
This check wasn't running if `$BUILDKITE_BRANCH` wasn't set (which is always in our CI).

Likewise the `[ branch_name == "master" ]` check didn't mean anything as `branch_name` is missing a `$`.