### PR TITLE
Fix power levels being sent as strings

### DIFF
--- a/tests/30rooms/60version_upgrade.pl
+++ b/tests/30rooms/60version_upgrade.pl
@@ -338,7 +338,6 @@ test "/upgrade copies the power levels to the new room",
          $creator, $room_id, sub {
             ( $pl_content ) = @_;
             $pl_content->{users}->{'@test:xyz'} = 40;
-            log_if_fail "PL content in old room", $pl_content;
          }
       )->then( sub {
          matrix_sync( $creator );


### PR DESCRIPTION
Yes, `log_if_fail` modifies its inputs. FUN TIMES.