### PR TITLE
Test that remote device list is refetched on leave/rejoin

### DIFF
--- a/lib/SyTest/Federation/Client.pm
+++ b/lib/SyTest/Federation/Client.pm
@@ -248,10 +248,13 @@ sub join_room
       $self->do_request_json(
          method   => "PUT",
          hostname => $server_name,
-         uri      => "/v2/send_join/$room_id/$event_id",
+         uri      => "/v1/send_join/$room_id/$event_id",
          content  => $member_event,
       )->then( sub {
          my ( $join_body ) = @_;
+
+         # /v1/send_join has an extraneous [ 200, ... ] wrapper (see MSC1802)
+         $join_body = $join_body->[1];
 
          my $room = SyTest::Federation::Room->new(
             datastore => $store,

--- a/lib/SyTest/Federation/Client.pm
+++ b/lib/SyTest/Federation/Client.pm
@@ -248,13 +248,10 @@ sub join_room
       $self->do_request_json(
          method   => "PUT",
          hostname => $server_name,
-         uri      => "/v1/send_join/$room_id/$event_id",
+         uri      => "/v2/send_join/$room_id/$event_id",
          content  => $member_event,
       )->then( sub {
          my ( $join_body ) = @_;
-
-         # /v1/send_join has an extraneous [ 200, ... ] wrapper (see MSC1802)
-         $join_body = $join_body->[1];
 
          my $room = SyTest::Federation::Room->new(
             datastore => $store,
@@ -270,6 +267,8 @@ sub join_room
          $room->insert_outlier_event( $_ ) for @events;
 
          $room->insert_event( $member_event );
+
+         $store->{rooms_by_id}{ $room->room_id } = $room;
 
          Future->done( $room );
       });

--- a/lib/SyTest/Federation/Datastore.pm
+++ b/lib/SyTest/Federation/Datastore.pm
@@ -301,7 +301,10 @@ sub get_auth_chain_events
    while( @event_ids ) {
       my $event = $events_by_id{shift @event_ids};
 
-      my @auth_ids = map { $_->[0] } @{ $event->{auth_events} };
+      my $room = $self->get_room( $event->{room_id} ) or
+         croak "Unknown room $event->{room_id}";
+
+      my @auth_ids = @{ $room->event_ids_from_refs( $event->{auth_events} ) };
 
       foreach my $id ( @auth_ids ) {
          next if $events_by_id{$id};

--- a/lib/SyTest/Federation/Room.pm
+++ b/lib/SyTest/Federation/Room.pm
@@ -321,6 +321,10 @@ sub insert_outlier_event
 
    croak "Event not ref" unless ref $event;
 
+   my $event_id = $self->id_for_event( $event );
+
+   $self->{datastore}->put_event( $event_id, $event );
+
    if( defined $event->{state_key} ) {
       $self->{current_state}{ join "\0", $event->{type}, $event->{state_key} }
          = $event;

--- a/lib/SyTest/Federation/Server.pm
+++ b/lib/SyTest/Federation/Server.pm
@@ -274,10 +274,13 @@ sub on_request_federation_v1_make_join
          404, "Not found", [ Content_length => 0 ], "",
       ) );
 
+   my $room_version = $room->room_version;
+
    Future->done( json => {
       event => $room->make_join_protoevent(
          user_id => $user_id,
       ),
+      room_version => "$room_version",
    } );
 }
 
@@ -308,7 +311,7 @@ sub on_request_federation_v2_send_join
    my $event = $req->body_from_json;
 
    my @auth_chain = $store->get_auth_chain_events(
-      map { $_->[0] } @{ $event->{auth_events} }
+      @{ $room->event_ids_from_refs( $event->{auth_events} ) }
    );
    my @state_events = $room->current_state_events;
 
@@ -477,6 +480,15 @@ sub on_request_federation_v1_send
 
    # A PDU is an event
    foreach my $event ( @{ $body->{pdus} } ) {
+      my $room = $self->{datastore}->get_room( $event->{room_id} );
+
+      if ( $room ) {
+         my $event_id = $room->id_for_event( $event );
+         $room->insert_event( $event );
+      } else {
+         warn "Unknown room ${ $event->{room_id} }"
+      }
+
       next if $self->on_event( $event );
 
       warn "TODO: Unhandled incoming event of type '$event->{type}'";

--- a/lib/SyTest/Federation/Server.pm
+++ b/lib/SyTest/Federation/Server.pm
@@ -559,7 +559,8 @@ sub on_event
 
 =head2 await_request_v1_send_join_reject_v2
 
-   $fut = $server->await_request_v1_send_join_reject_v2( $room_id )
+   $fut = $server->await_request_v1_send_join_reject_v2( $room_id );
+   my ( $request, $room_id, $event_id ) = $fut->get;
 
 Awaits inbound request for /v1/send_join endpoint while rejecting inbound
 requests to /v2/send_join. Using the C<await_request_v1_send_join> standard

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -848,6 +848,7 @@ test "Outbound federation rejects send_join responses with no m.room.create even
             @auth_chain = grep { $_->{type} ne 'm.room.create' } @auth_chain;
 
             $req->respond_json(
+               # /v1/send_join has an extraneous [200, ...] wrapper (see MSC1802)
                my $response = [ 200, {
                   auth_chain => \@auth_chain,
                   state      => [ $room->current_state_events ],

--- a/tests/50federation/40devicelists.pl
+++ b/tests/50federation/40devicelists.pl
@@ -274,7 +274,7 @@ test "Server correctly resyncs when server leaves and rejoins a room",
 
       # At first the server shares a room with the federated user, who at that
       # point has a single device. The server will then leave and then rejoin
-      # the room, in the mean time the federated user has added a device, but
+      # the room. In the mean time the federated user has added a device, but
       # won't have poked the server as they didn't share a room.
       #
       # When the server rejoins the subsequent calls by clients to fetch keys

--- a/tests/50federation/50no-deextrem-outliers.pl
+++ b/tests/50federation/50no-deextrem-outliers.pl
@@ -51,7 +51,6 @@ test "Forward extremities remain so even after the next events are populated as 
          ->on_done( sub {
             my ( $pl_event_b ) = @_;
             $pl_event_b_id = $room->id_for_event( $pl_event_b );
-            $room->insert_event( $pl_event_b );
          }),
       )->then( sub {
          my %state_before_c = %{ $room->{current_state} };


### PR DESCRIPTION
Test for matrix-org/synapse#6797