### PR TITLE
Remove test which uses unspecced /events?dir=b

### DIFF
--- a/tests/10apidoc/34room-messages.pl
+++ b/tests/10apidoc/34room-messages.pl
@@ -103,8 +103,9 @@ sub matrix_send_room_message
       content => $opts{content},
    )->then( sub {
       my ( $body ) = @_;
-
-      Future->done( $body->{event_id} );
+      my ( $event_id ) = $body->{event_id};
+      log_if_fail "Sent '$type' event in $room_id: $event_id";
+      Future->done( $event_id );
    });
 }
 


### PR DESCRIPTION
I've got annoyed with trying to make this test pass. It uses "/events?dir=b"
which isn't even specced, but it seems to expect it to block until an event
arrives, which is (a) strange and (b) unreliable in a worker setup.