### PR TITLE
Update dendrite.Dockerfile

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -9,5 +9,5 @@ docker build --pull ../ -f base.Dockerfile --build-arg DEBIAN_VERSION=bullseye -
 docker build ../ -f synapse.Dockerfile --build-arg DEBIAN_VERSION=stretch -t matrixdotorg/sytest-synapse:py35
 docker build ../ -f synapse.Dockerfile --build-arg DEBIAN_VERSION=buster -t matrixdotorg/sytest-synapse:py37
 docker build ../ -f synapse.Dockerfile --build-arg DEBIAN_VERSION=bullseye -t matrixdotorg/sytest-synapse:py38
-docker build ../ -f dendrite.Dockerfile --build-arg DEBIAN_VERSION=stretch --build-arg GO_VERSION="1.11.13" -t matrixdotorg/sytest-dendrite:go111 -t matrixdotorg/sytest-dendrite:latest
-docker build ../ -f dendrite.Dockerfile --build-arg DEBIAN_VERSION=stretch --build-arg GO_VERSION="1.13.4" -t matrixdotorg/sytest-dendrite:go113
+docker build ../ -f dendrite.Dockerfile --build-arg DEBIAN_VERSION=stretch --build-arg GO_VERSION="1.11.13" -t matrixdotorg/sytest-dendrite:go111 
+docker build ../ -f dendrite.Dockerfile --build-arg DEBIAN_VERSION=stretch --build-arg GO_VERSION="1.13.7" -t matrixdotorg/sytest-dendrite:go113 -t matrixdotorg/sytest-dendrite:latest

--- a/docker/dendrite.Dockerfile
+++ b/docker/dendrite.Dockerfile
@@ -1,11 +1,9 @@
 ARG DEBIAN_VERSION=buster
-
 FROM matrixdotorg/sytest:${DEBIAN_VERSION}
 
-ARG GO_VERSION
+ARG GO_VERSION=1.13.7
 ENV GO_DOWNLOAD https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz
 
-# Install Go 1.11
 RUN mkdir -p /goroot /gopath
 RUN wget -q $GO_DOWNLOAD -O go.tar.gz
 RUN tar xf go.tar.gz -C /goroot --strip-components=1


### PR DESCRIPTION
This specifies a default Go version (1.13.7) to hopefully help facilitate Docker Hub autobuilds.