### PR TITLE
Don't push Dendrite images to Docker Hub

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -9,7 +9,6 @@ Included currently is:
 - matrixdotorg/sytest:stretch and matrixdotorg/sytest:buster, base containers with SyTest dependencies installed
 - matrixdotorg/sytest-synapse:py35, a container which will run SyTest against Synapse on Python 3.5 + Stretch
 - matrixdotorg/sytest-synapse:py37, a container which will run SyTest against Synapse on Python 3.7 + Buster
-- matrixdotorg/sytest-dendrite:go111, a container which will run SyTest against Dendrite on Go 1.11 + Stretch
 - matrixdotorg/sytest-dendrite:go113, a container which will run SyTest against Dendrite on Go 1.13 + Buster
 
 ## Using the containers

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -9,4 +9,4 @@ docker build --pull ../ -f base.Dockerfile --build-arg DEBIAN_VERSION=bullseye -
 docker build ../ -f synapse.Dockerfile --build-arg DEBIAN_VERSION=stretch -t matrixdotorg/sytest-synapse:py35
 docker build ../ -f synapse.Dockerfile --build-arg DEBIAN_VERSION=buster -t matrixdotorg/sytest-synapse:py37
 docker build ../ -f synapse.Dockerfile --build-arg DEBIAN_VERSION=bullseye -t matrixdotorg/sytest-synapse:py38
-docker build ../ -f dendrite.Dockerfile --build-arg DEBIAN_VERSION=stretch --build-arg GO_VERSION="1.13.7" -t matrixdotorg/sytest-dendrite:go113 -t matrixdotorg/sytest-dendrite:latest
+docker build ../ -f dendrite.Dockerfile --build-arg DEBIAN_VERSION=stretch -t matrixdotorg/sytest-dendrite:go113 -t matrixdotorg/sytest-dendrite:latest

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -9,5 +9,4 @@ docker build --pull ../ -f base.Dockerfile --build-arg DEBIAN_VERSION=bullseye -
 docker build ../ -f synapse.Dockerfile --build-arg DEBIAN_VERSION=stretch -t matrixdotorg/sytest-synapse:py35
 docker build ../ -f synapse.Dockerfile --build-arg DEBIAN_VERSION=buster -t matrixdotorg/sytest-synapse:py37
 docker build ../ -f synapse.Dockerfile --build-arg DEBIAN_VERSION=bullseye -t matrixdotorg/sytest-synapse:py38
-docker build ../ -f dendrite.Dockerfile --build-arg DEBIAN_VERSION=stretch --build-arg GO_VERSION="1.11.13" -t matrixdotorg/sytest-dendrite:go111 
 docker build ../ -f dendrite.Dockerfile --build-arg DEBIAN_VERSION=stretch --build-arg GO_VERSION="1.13.7" -t matrixdotorg/sytest-dendrite:go113 -t matrixdotorg/sytest-dendrite:latest

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -10,6 +10,3 @@ docker push matrixdotorg/sytest:bullseye
 docker push matrixdotorg/sytest-synapse:py35
 docker push matrixdotorg/sytest-synapse:py37
 docker push matrixdotorg/sytest-synapse:py38
-docker push matrixdotorg/sytest-dendrite:latest
-docker push matrixdotorg/sytest-dendrite:go111
-docker push matrixdotorg/sytest-dendrite:go113


### PR DESCRIPTION
We use autobuild now for the Dendrite Sytest images so remove them from `push.sh`. We also don't need the Go 1.11 images anymore either.