### PR TITLE
Small comment fixes for consistency

### DIFF
--- a/tests/30rooms/12thirdpartyinvite.pl
+++ b/tests/30rooms/12thirdpartyinvite.pl
@@ -190,7 +190,7 @@ test "Can invite unbound 3pid over federation with no ops into a private room",
       matrix_create_and_join_room(
          [ $creator, $inviter ],
          visibility => "private",
-         preset => "private_chat",
+         preset => "private_chat",  # Allow default PL users to invite others
          with_invite => 1,
       )->then( sub {
          my ( $room_id ) = @_;

--- a/tests/41end-to-end-keys/06-device-lists.pl
+++ b/tests/41end-to-end-keys/06-device-lists.pl
@@ -689,8 +689,7 @@ test "If user leaves room, remote user changes device and rejoins we see update 
 
       matrix_create_room( $creator,
          invite => [ $remote_user->user_id ],
-         # Allow default PL users to invite others
-         preset => "private_chat",
+         preset => "private_chat",  # Allow default PL users to invite others
       )->then( sub {
          ( $room_id ) = @_;
 


### PR DESCRIPTION
Just some small comment fixes for consistency, off the back of https://github.com/matrix-org/sytest/pull/805 which I didn't want to delay any further.

These comments are meant to be consistent with other lines as seen here:

https://github.com/matrix-org/sytest/blob/748fcd926c956c1f1a4f57f42ecef500ff6104ec/tests/30rooms/12thirdpartyinvite.pl#L174

https://github.com/matrix-org/sytest/blob/748fcd926c956c1f1a4f57f42ecef500ff6104ec/tests/30rooms/12thirdpartyinvite.pl#L63