### PR TITLE
Fix flaky 50federation/40publicroomlist.pl

### DIFF
--- a/tests/50federation/40publicroomlist.pl
+++ b/tests/50federation/40publicroomlist.pl
@@ -29,74 +29,85 @@ test "Name/topic keys are correct",
             visibility      => "public",
             room_alias_name => $alias_local,
             %$room,
-         )
+         )->on_done( sub {
+            my ( $room_id ) = @_;
+            log_if_fail "Created room $room_id with alias $alias_local";
+         });
       } keys %rooms )
       ->then( sub {
-         $client->do_request_json(
-            method   => "GET",
-            hostname => $server_name,
-            uri      => "/v1/publicRooms",
-         )
-      })->then( sub {
-         my ( $body ) = @_;
+         my $iter = 0;
+         retry_until_success {
+            $client->do_request_json(
+                method   => "GET",
+                hostname => $server_name,
+                uri      => "/v1/publicRooms",
+            )->then( sub {
+               my ($body) = @_;
 
-         log_if_fail "publicRooms", $body;
+               $iter++;
+               log_if_fail "Iteration $iter: publicRooms result", $body;
 
-         assert_json_keys( $body, qw( chunk ));
-         assert_json_list( $body->{chunk} );
+               assert_json_keys($body, qw(chunk));
+               assert_json_list($body->{chunk});
 
-         my %seen = map {
-            $_ => 0,
-         } keys ( %rooms );
+               my %seen = map {
+                  $_ => 0,
+               } keys(%rooms);
 
-         foreach my $room ( @{ $body->{chunk} } ) {
-            assert_json_keys( $room,
-               qw( world_readable guest_can_join num_joined_members )
-            );
+               foreach my $room (@{$body->{chunk}}) {
+                  assert_json_keys($room,
+                      qw(world_readable guest_can_join num_joined_members)
+                  );
 
-            my $name = $room->{name};
-            my $topic = $room->{topic};
-            my $canonical_alias = $room->{canonical_alias};
+                  my $name = $room->{name};
+                  my $topic = $room->{topic};
+                  my $canonical_alias = $room->{canonical_alias};
 
-            my $aliases = $room->{aliases};
-            defined $aliases or next;
+                  my $aliases = $room->{aliases};
+                  defined $aliases or next;
 
-            foreach my $alias ( @{$aliases} ) {
-               foreach my $alias_local ( keys %rooms ) {
-                  $alias =~ m/^\Q#$alias_local:\E/ or next;
+                  foreach my $alias (@{$aliases}) {
+                     foreach my $alias_local (keys %rooms) {
+                        $alias =~ m/^\Q#$alias_local:\E/ or next;
 
-                  my $room_config = $rooms{$alias_local};
+                        my $room_config = $rooms{$alias_local};
 
-                  log_if_fail "Alias", $alias_local;
-                  log_if_fail "Room", $room;
+                        log_if_fail "Alias", $alias_local;
+                        log_if_fail "Room", $room;
 
-                  assert_eq( $canonical_alias, $alias, "canonical alias" );
-                  assert_eq( $room->{num_joined_members}, 1, "num_joined_members" );
+                        assert_eq($canonical_alias, $alias, "canonical alias");
+                        assert_eq($room->{num_joined_members}, 1, "num_joined_members");
 
-                  if( defined $name ) {
-                     assert_eq( $room_config->{name}, $name, 'room name' );
+                        if (defined $name) {
+                           assert_eq($room_config->{name}, $name, 'room name');
+                        }
+                        else {
+                           defined $room_config->{name} and die "Expected not to find a name";
+                        }
+
+                        if (defined $topic) {
+                           assert_eq($room_config->{topic}, $topic, 'room topic');
+                        }
+                        else {
+                           defined $room_config->{topic} and die "Expected not to find a topic";
+                        }
+
+                        $seen{$alias_local} = 1;
+                        last;
+                     }
                   }
-                  else {
-                     defined $room_config->{name} and die "Expected not to find a name";
-                  }
-
-                  if( defined $topic ) {
-                     assert_eq( $room_config->{topic}, $topic, 'room topic' );
-                  }
-                  else {
-                     defined $room_config->{topic} and die "Expected not to find a topic";
-                  }
-
-                  $seen{$alias_local} = 1;
-                  last;
                }
-            }
-         }
 
-         foreach my $key ( keys %seen ) {
-            $seen{$key} or die "Did not find a /publicRooms result for $key";
-         }
+               foreach my $key (keys %seen) {
+                  $seen{$key} or die "Did not find a /publicRooms result for $key";
+               }
 
-         Future->done(1);
+               Future->done(1);
+            })->on_fail(sub {
+               my ($exc) = @_;
+               chomp $exc;
+               log_if_fail "Iteration $iter: not ready yet: $exc";
+            });
+         };
       })
    }


### PR DESCRIPTION
This ports the changes (done in #354) from 30rooms/70publicroomslist.pl to 50federation/40publicroomlist.pl in order to fix a flaky test.

This test didn't seem to be causing any issues before matrix-org/synapse#6941, but the changes should be OK to merge before that.