### PR TITLE
Stop checking for aliases in the public room list.

### DIFF
--- a/tests/30rooms/13guestaccess.pl
+++ b/tests/30rooms/13guestaccess.pl
@@ -365,29 +365,27 @@ test "GET /publicRooms lists rooms",
                my %isOK = map { $_ => 0 } keys %rooms;
 
                foreach my $room ( @{ $body->{chunk} } ) {
-                  my $aliases = $room->{aliases};
+                  my $canonical_alias = $room->{canonical_alias};
                   assert_json_boolean( my $world_readable = $room->{world_readable} );
                   assert_json_boolean( my $guest_can_join = $room->{guest_can_join} );
 
-                  foreach my $alias ( @{$aliases} ) {
-                     my $alias_local = first { $alias =~ m/^#$_:/ } keys %rooms;
-                     next unless $alias_local;
-                     my $settings = $rooms{$alias_local};
+                  my $alias_local = first { $canonical_alias =~ m/^#$_:/ } keys %rooms;
+                  next unless $alias_local;
+                  my $settings = $rooms{$alias_local};
 
-                     if(( $settings->{history_visibility} // "" ) eq "world_readable" ) {
-                        $world_readable or die "Expected $alias_local to be world_readable";
-                     } else {
-                        $world_readable and die "Expected $alias_local not to be world_readable";
-                     }
-
-                     if(( $settings->{guest_access} // "" ) eq "can_join" ) {
-                        $guest_can_join or die "Expected $alias_local to be guest-joinable";
-                     } else {
-                        $guest_can_join and die "Expected $alias_local not to be guest-joinable";
-                     }
-
-                     $isOK{$alias_local} = 1;
+                  if(( $settings->{history_visibility} // "" ) eq "world_readable" ) {
+                     $world_readable or die "Expected $alias_local to be world_readable";
+                  } else {
+                     $world_readable and die "Expected $alias_local not to be world_readable";
                   }
+
+                  if(( $settings->{guest_access} // "" ) eq "can_join" ) {
+                     $guest_can_join or die "Expected $alias_local to be guest-joinable";
+                  } else {
+                     $guest_can_join and die "Expected $alias_local not to be guest-joinable";
+                  }
+
+                  $isOK{$alias_local} = 1;
                }
 
                foreach my $alias ( keys %rooms ) {
@@ -462,17 +460,15 @@ test "GET /publicRooms includes avatar URLs",
                );
 
                foreach my $room ( @{ $body->{chunk} } ) {
-                  my $aliases = $room->{aliases};
+                  my $canonical_alias = $room->{canonical_alias};
 
-                  foreach my $alias ( @{$aliases} ) {
-                     if( $alias =~ m/^\Q#worldreadable:/ ) {
-                        $isOK{worldreadable} =
-                           ( $room->{avatar_url} eq "https://example.com/ringtails.jpg" );
-                     }
-                     elsif( $alias =~ m/^\Q#nonworldreadable:/ ) {
-                        $isOK{nonworldreadable} =
-                           ( $room->{avatar_url} eq "https://example.com/ruffed.jpg" );
-                     }
+                  if( $canonical_alias =~ m/^\Q#worldreadable:/ ) {
+                     $isOK{worldreadable} =
+                        ( $room->{avatar_url} eq "https://example.com/ringtails.jpg" );
+                  }
+                  elsif( $canonical_alias =~ m/^\Q#nonworldreadable:/ ) {
+                     $isOK{nonworldreadable} =
+                        ( $room->{avatar_url} eq "https://example.com/ruffed.jpg" );
                   }
                }
 

--- a/tests/30rooms/70publicroomslist.pl
+++ b/tests/30rooms/70publicroomslist.pl
@@ -59,40 +59,32 @@ test "Name/topic keys are correct",
                   my $topic = $room->{topic};
                   my $canonical_alias = $room->{canonical_alias};
 
-                  my $aliases = $room->{aliases};
-                  if( not defined $aliases ) {
-                     next;
-                  }
+                  foreach my $alias_local ( keys %rooms ) {
+                     $canonical_alias =~ m/^\Q#$alias_local:\E/ or next;
 
-                  foreach my $alias ( @{$aliases} ) {
-                     foreach my $alias_local ( keys %rooms ) {
-                        $alias =~ m/^\Q#$alias_local:\E/ or next;
+                     my $room_config = $rooms{$alias_local};
 
-                        my $room_config = $rooms{$alias_local};
+                     assert_eq( $room->{num_joined_members}, 1, "member count for '$alias_local'" );
 
-                        assert_eq( $canonical_alias, $alias, "canonical_alias" );
-                        assert_eq( $room->{num_joined_members}, 1, "member count for '$alias_local'" );
+                     # The rooms should get created "atomically", so we should never
+                     # see any out of the public rooms list in the wrong state. If
+                     # we see a room we expect it to already be in the right state.
 
-                        # The rooms should get created "atomically", so we should never
-                        # see any out of the public rooms list in the wrong state. If
-                        # we see a room we expect it to already be in the right state.
-
-                        if( defined $name ) {
-                           assert_eq( $room_config->{name}, $name, "room name for '$alias_local'" );
-                        }
-                        else {
-                           defined $room_config->{name} and die "Expected not to find a name for '$alias_local'";
-                        }
-
-                        if( defined $topic ) {
-                           assert_eq( $room_config->{topic}, $topic, "room topic for '$alias_local'" );
-                        }
-                        else {
-                           defined $room_config->{topic} and die "Expected not to find a topic for '$alias_local'";
-                        }
-
-                        $isOK{$alias_local} = 1;
+                     if( defined $name ) {
+                        assert_eq( $room_config->{name}, $name, "room name for '$alias_local'" );
                      }
+                     else {
+                        defined $room_config->{name} and die "Expected not to find a name for '$alias_local'";
+                     }
+
+                     if( defined $topic ) {
+                        assert_eq( $room_config->{topic}, $topic, "room topic for '$alias_local'" );
+                     }
+                     else {
+                        defined $room_config->{topic} and die "Expected not to find a topic for '$alias_local'";
+                     }
+
+                     $isOK{$alias_local} = 1;
                   }
                }
 

--- a/tests/50federation/40publicroomlist.pl
+++ b/tests/50federation/40publicroomlist.pl
@@ -63,38 +63,32 @@ test "Name/topic keys are correct",
                   my $topic = $room->{topic};
                   my $canonical_alias = $room->{canonical_alias};
 
-                  my $aliases = $room->{aliases};
-                  defined $aliases or next;
+                  foreach my $alias_local (keys %rooms) {
+                     $canonical_alias =~ m/^\Q#$alias_local:\E/ or next;
 
-                  foreach my $alias (@{$aliases}) {
-                     foreach my $alias_local (keys %rooms) {
-                        $alias =~ m/^\Q#$alias_local:\E/ or next;
+                     my $room_config = $rooms{$alias_local};
 
-                        my $room_config = $rooms{$alias_local};
+                     log_if_fail "Alias", $alias_local;
+                     log_if_fail "Room", $room;
 
-                        log_if_fail "Alias", $alias_local;
-                        log_if_fail "Room", $room;
+                     assert_eq($room->{num_joined_members}, 1, "num_joined_members");
 
-                        assert_eq($canonical_alias, $alias, "canonical alias");
-                        assert_eq($room->{num_joined_members}, 1, "num_joined_members");
-
-                        if (defined $name) {
-                           assert_eq($room_config->{name}, $name, 'room name');
-                        }
-                        else {
-                           defined $room_config->{name} and die "Expected not to find a name";
-                        }
-
-                        if (defined $topic) {
-                           assert_eq($room_config->{topic}, $topic, 'room topic');
-                        }
-                        else {
-                           defined $room_config->{topic} and die "Expected not to find a topic";
-                        }
-
-                        $seen{$alias_local} = 1;
-                        last;
+                     if (defined $name) {
+                        assert_eq($room_config->{name}, $name, 'room name');
                      }
+                     else {
+                        defined $room_config->{name} and die "Expected not to find a name";
+                     }
+
+                     if (defined $topic) {
+                        assert_eq($room_config->{topic}, $topic, 'room topic');
+                     }
+                     else {
+                        defined $room_config->{topic} and die "Expected not to find a topic";
+                     }
+
+                     $seen{$alias_local} = 1;
+                     last;
                   }
                }
 


### PR DESCRIPTION
The `/publicRooms` API is going to stop returning the "aliases" key, so SyTest needs to stop looking for it.

Much of the changes here are de-indenting, the [diff looks a bit better without whitespace](https://github.com/matrix-org/sytest/pull/817/files?w=1).