### PR TITLE
Add tests for a user with sufficient power level removing an alias.

### DIFF
--- a/tests/30rooms/05aliases.pl
+++ b/tests/30rooms/05aliases.pl
@@ -254,8 +254,15 @@ test "Users with sufficient power-level can delete other's aliases",
            content => {},
          )
       })->then( sub {
-         Future->done(1);
-      })
+         my ( $res ) = @_;
+         log_if_fail "Unable to delete alias", $res;
+
+         do_request_json_for(
+            $user,
+            method => "GET",
+            uri  => "/r0/directory/room/$room_alias",
+         );
+      })->main::expect_http_404;
    };
 
 test "Can delete canonical alias",

--- a/tests/30rooms/05aliases.pl
+++ b/tests/30rooms/05aliases.pl
@@ -135,8 +135,6 @@ test "Regular users can add and delete aliases when m.room.aliases is restricted
    do => sub {
       my ( $creator, $other_user, $room_id, $alias ) = @_;
 
-      my $server_name = $other_user->http->server_name;
-
       matrix_change_room_power_levels(
          $creator, $room_id, sub {
             $_[0]->{events}->{'m.room.aliases'} = 50;
@@ -168,8 +166,6 @@ test "Regular users can add and delete aliases when m.room.aliases is restricted
 
 sub _test_can_create_and_delete_alias {
    my ( $room_id, $user, $alias ) = @_;
-
-   my $server_name = $user->http->server_name;
 
    do_request_json_for( $user,
       method => "PUT",
@@ -209,7 +205,6 @@ test "Users can't delete other's aliases",
 
    do => sub {
       my ( $user, $room_id, $other_user, $room_alias ) = @_;
-      my $server_name = $user->http->server_name;
 
       do_request_json_for( $user,
          method => "PUT",
@@ -232,7 +227,6 @@ test "Users with sufficient power-level can delete other's aliases",
 
    do => sub {
       my ( $user, $room_id, $other_user, $room_alias ) = @_;
-      my $server_name = $user->http->server_name;
 
       matrix_change_room_power_levels(
          $user, $room_id, sub {
@@ -306,7 +300,6 @@ test "Alias creators can delete alias with no ops",
 
    do => sub {
       my ( $creator, $other_user, $room_alias ) = @_;
-      my $server_name = $creator->http->server_name;
       my $room_id;
 
       matrix_create_and_join_room( [ $creator, $other_user ] )
@@ -336,7 +329,6 @@ test "Alias creators can delete canonical alias with no ops",
 
    do => sub {
       my ( $creator, $other_user, $room_alias ) = @_;
-      my $server_name = $creator->http->server_name;
       my $room_id;
 
       matrix_create_and_join_room( [ $creator, $other_user ] )


### PR DESCRIPTION
SyTests for the behavior in matrix-org/synapse#6986.

A user should be able to delete an alias if they have sufficient power level (enough to modify the canonical alias event). There's already a separate test for a user not being able to delete aliases if they don't have power levels.

I verified that against a develop of master (i.e without matrix-org/synapse#6986) the added test here fails.