### PR TITLE
Add a test for an event with an invalid signature

### DIFF
--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -959,7 +959,7 @@ test "Outbound federation rejects m.room.create events with an unknown room vers
       )
    };
 
-test "Outbound federation event with an invalid signature should not break",
+test "Event with an invalid signature in the send_join response should not cause room join to fail",
    requires => [ local_user_fixture(), $main::INBOUND_SERVER,
                  federation_user_id_fixture() ],
 

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -969,7 +969,7 @@ test "Event with an invalid signature in the send_join response should not cause
       my $local_server_name = $inbound_server->server_name;
       my $datastore         = $inbound_server->datastore;
 
-      my $room_alias = "#50fed-room-alias:$local_server_name";
+      my $room_alias = "#50fed-room-alias-invalid-sig:$local_server_name";
       my $room = $datastore->create_room(
          creator => $creator_id,
          alias   => $room_alias,

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -1055,10 +1055,7 @@ test "Outbound federation event with an invalid signature should not break",
          })->then( sub {
             my ( $event ) = @_;
 
-            # The joining HS (i.e. the SUT) should have invented the event ID
-            # for my membership event.
-
-            # TODO - sanity check the $event
+            assert_json_keys( $event->{content}, qw( membership ) );
 
             Future->done(1);
          }),


### PR DESCRIPTION
This reproduces the issue in matrix-org/synapse#6978.

Note that I created this test by copying, so it is a bit duplicative. I'm unsure how much of it is worth keeping.

On current develop (sans matrix-org/synapse#6996) this fails on the `log_if_fail "send_join event", $event;` line.