### PR TITLE
Add tests for validating alt_aliases of a canonical alias event.

### DIFF
--- a/tests/30rooms/05aliases.pl
+++ b/tests/30rooms/05aliases.pl
@@ -158,6 +158,26 @@ multi_test "Canonical alias can include alt_aliases",
             }
          )->main::expect_matrix_error( 400, "M_INVALID_PARAM" )
             ->SyTest::pass_on_done( "m.room.canonical_alias rejects invalid aliases" );
+      })->then( sub {
+         # Create a second room with an alias on it.
+         my $other_alias_name = $room_alias_name . "2";
+
+         matrix_create_room( $user,
+            room_alias_name => $other_alias_name,
+         )->then( sub {
+            my ( $other_room_id, $other_room_alias ) = @_;
+
+            # Attempt to set a canonical alias for the original room using an
+            # alias from the second room.
+            matrix_put_room_state( $user, $room_id,
+               type    => "m.room.canonical_alias",
+               content => {
+                  alias => $room_alias,
+                  alt_aliases => [ $other_room_alias ],
+               }
+            )->main::expect_matrix_error( 400, "M_BAD_ALIAS" )
+               ->SyTest::pass_on_done( "m.room.canonical_alias rejects alias pointing to different room" );
+            })
       });
    };
 

--- a/tests/30rooms/05aliases.pl
+++ b/tests/30rooms/05aliases.pl
@@ -90,6 +90,7 @@ multi_test "Canonical alias can be set",
             }
          )->SyTest::pass_on_done( "m.room.canonical_alias accepts present aliases" );
       })->then( sub {
+         # Create an unknown, but valid alias name.
          my $bad_alias = $room_alias =~ s/^#/#NOT-/r;
 
          matrix_put_room_state( $user, $room_id,
@@ -99,6 +100,64 @@ multi_test "Canonical alias can be set",
             }
          )->main::expect_http_4xx
             ->SyTest::pass_on_done( "m.room.canonical_alias rejects missing aliases" );
+      })->then( sub {
+         # Create an invalid alias name (starts with % instead of #).
+         my $bad_alias = $room_alias =~ s/^#/%/r;
+
+         matrix_put_room_state( $user, $room_id,
+            type    => "m.room.canonical_alias",
+            content => {
+               alias => $bad_alias,
+            }
+         )->main::expect_http_4xx
+            ->SyTest::pass_on_done( "m.room.canonical_alias rejects invalid aliases" );
+      });
+   };
+
+multi_test "Canonical alias can include alt_aliases",
+   requires => [ local_user_fixture(), room_alias_name_fixture() ],
+
+   do => sub {
+      my ( $user, $room_alias_name ) = @_;
+
+      my ( $room_id, $room_alias );
+
+      matrix_create_room( $user,
+         room_alias_name => $room_alias_name,
+      )->then( sub {
+         ( $room_id, $room_alias ) = @_;
+
+         matrix_put_room_state( $user, $room_id,
+            type    => "m.room.canonical_alias",
+            content => {
+               alias       => $room_alias,
+               alt_aliases => [ $room_alias ],
+            }
+         )->SyTest::pass_on_done( "m.room.canonical_alias accepts present aliases" );
+      })->then( sub {
+         # Create an unknown, but valid alias name.
+         my $bad_alias = $room_alias =~ s/^#/#NOT-/r;
+
+         matrix_put_room_state( $user, $room_id,
+            type    => "m.room.canonical_alias",
+            content => {
+               alias => $room_alias,
+               alt_aliases => [ $bad_alias ],
+            }
+         )->main::expect_http_4xx
+            ->SyTest::pass_on_done( "m.room.canonical_alias rejects missing aliases" );
+      })->then( sub {
+         # Create an invalid alias name (starts with % instead of #).
+         my $bad_alias = $room_alias =~ s/^#/%/r;
+
+         matrix_put_room_state( $user, $room_id,
+            type    => "m.room.canonical_alias",
+            content => {
+               alias => $room_alias,
+               alt_aliases => [ $bad_alias ],
+            }
+         )->main::expect_http_4xx
+            ->SyTest::pass_on_done( "m.room.canonical_alias rejects invalid aliases" );
       });
    };
 

--- a/tests/30rooms/05aliases.pl
+++ b/tests/30rooms/05aliases.pl
@@ -144,7 +144,7 @@ multi_test "Canonical alias can include alt_aliases",
                alias => $room_alias,
                alt_aliases => [ $bad_alias ],
             }
-         )->main::expect_http_4xx
+         )->main::expect_matrix_error( 404, "M_NOT_FOUND" )
             ->SyTest::pass_on_done( "m.room.canonical_alias rejects missing aliases" );
       })->then( sub {
          # Create an invalid alias name (starts with % instead of #).
@@ -156,7 +156,7 @@ multi_test "Canonical alias can include alt_aliases",
                alias => $room_alias,
                alt_aliases => [ $bad_alias ],
             }
-         )->main::expect_http_4xx
+         )->main::expect_matrix_error( 400, "M_INVALID_PARAM" )
             ->SyTest::pass_on_done( "m.room.canonical_alias rejects invalid aliases" );
       });
    };


### PR DESCRIPTION
This adds tests for the behavior for validating the `alt_aliases` field of a canonical alias event added to Synapse in matrix-org/synapse#6971.