### PR TITLE
Add tests where the session is abused for interactive auth.

### DIFF
--- a/tests/10apidoc/12device_management.pl
+++ b/tests/10apidoc/12device_management.pl
@@ -335,3 +335,61 @@ test "DELETE /device/{deviceId} with no body gives a 401",
          matrix_delete_device( $user, $DEVICE_ID, undef );
       })->main::expect_http_401;
   };
+
+
+test "The deleted device must be consistent through an interactive auth session",
+   requires => [ local_user_fixture( with_events => 0 ) ],
+
+   do => sub {
+      my ( $user ) = @_;
+
+      my $DEVICE_ID = "login_device";
+      my $SECOND_DEVICE_ID = "second_device";
+
+      # Create two devices.
+      matrix_login_again_with_user(
+         $user,
+         device_id => $DEVICE_ID,
+         initial_device_display_name => "device display",
+      )->then( sub {
+         matrix_login_again_with_user(
+            $user,
+            device_id => $SECOND_DEVICE_ID,
+            initial_device_display_name => "device display",
+         )
+      })->then( sub {
+         # Initiate the interactive authentication session with the first device.
+         matrix_delete_device( $user, $DEVICE_ID, {} );
+      })->main::expect_http_401->then( sub {
+         my ( $resp ) = @_;
+
+         my $body = decode_json $resp->content;
+
+         log_if_fail( "Response to empty body", $body );
+
+         assert_json_keys( $body, qw( session params flows ));
+
+         # Continue the interactive authentication session (by providing
+         # credentials), but attempt to delete the second device.
+         matrix_delete_device( $user, $SECOND_DEVICE_ID, {
+             auth => {
+                type     => "m.login.password",
+                user     => $user->user_id,
+                password => $user->password,
+                session  => $body->{session},
+             }
+         })->main::expect_http_403;
+      })->then( sub {
+         # The device delete was rejected (the device should still exist).
+         matrix_get_device( $user, $SECOND_DEVICE_ID );
+      })->then( sub {
+         my ( $device ) = @_;
+         assert_json_keys(
+            $device,
+            qw( device_id user_id display_name ),
+         );
+         assert_eq( $device->{device_id}, $SECOND_DEVICE_ID );
+         assert_eq( $device->{display_name}, "device display" );
+         Future->done( 1 );
+      });
+   };


### PR DESCRIPTION
This attempts to make some (currently failing) test cases where the session is abused to change the item being acted upon between initiating ui-auth and completing it.
matrix-org/synapse#7068