### PR TITLE
Use r0 instead of 'unstable' for joined_members|rooms

### DIFF
--- a/tests/10apidoc/31room-state.pl
+++ b/tests/10apidoc/31room-state.pl
@@ -112,7 +112,7 @@ test "GET /rooms/:room_id/joined_members fetches my membership",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/unstable/rooms/$room_id/joined_members",
+         uri    => "/r0/rooms/$room_id/joined_members",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -220,7 +220,7 @@ test "GET /joined_rooms lists newly-created room",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/unstable/joined_rooms",
+         uri    => "/r0/joined_rooms",
       )->then( sub {
          my ( $body ) = @_;
 

--- a/tests/30rooms/40joinedapis.pl
+++ b/tests/30rooms/40joinedapis.pl
@@ -30,7 +30,7 @@ test "/joined_rooms returns only joined rooms",
       )->then( sub {
          do_request_json_for( $user,
             method => "GET",
-            uri => "/unstable/joined_rooms",
+            uri => "/r0/joined_rooms",
          )
       })->then( sub {
          my ( $body ) = @_;
@@ -92,7 +92,7 @@ test "/joined_members return joined members",
 
             do_request_json_for( $user,
                method => "GET",
-               uri => "/unstable/rooms/$room_id/joined_members",
+               uri => "/r0/rooms/$room_id/joined_members",
             )->then( sub {
                my ( $body ) = @_;
 


### PR DESCRIPTION
Dendrite is implementing these APIs and these APIs are already in
the r0 spec, so we should be testing against r0 and not unstable.