### PR TITLE
Update NOT_FOUND error to BAD_ALIAS error.

### DIFF
--- a/tests/30rooms/05aliases.pl
+++ b/tests/30rooms/05aliases.pl
@@ -144,7 +144,7 @@ multi_test "Canonical alias can include alt_aliases",
                alias => $room_alias,
                alt_aliases => [ $bad_alias ],
             }
-         )->main::expect_matrix_error( 404, "M_NOT_FOUND" )
+         )->main::expect_matrix_error( 400, "M_BAD_ALIAS" )
             ->SyTest::pass_on_done( "m.room.canonical_alias rejects missing aliases" );
       })->then( sub {
          # Create an invalid alias name (starts with % instead of #).


### PR DESCRIPTION
Per a clarification in the spec, an alias that does not exist should be tread the same as an alias that points to the wrong room.

See https://github.com/matrix-org/matrix-doc/pull/2432#issuecomment-601242488

See matrix-org/synapse#7109 for the necessary Synapse changes.