### PR TITLE
Add test for updating room aliases on upgraded room join

### DIFF
--- a/tests/10apidoc/30room-create.pl
+++ b/tests/10apidoc/30room-create.pl
@@ -356,7 +356,7 @@ sub room_alias_name_fixture
 
 =head2 room_alias_fixture
 
-   $fixture = room_alias_fixture( prefix => $prefix, remote => false )
+   $fixture = room_alias_fixture( prefix => $prefix, remote => 0 )
 
 Returns a new Fixture, which when provisioned will allocate a name for a new
 room alias on the first homeserver, and return it as a string. Note that this

--- a/tests/10apidoc/30room-create.pl
+++ b/tests/10apidoc/30room-create.pl
@@ -318,7 +318,7 @@ sub matrix_create_room
    });
 }
 
-push @EXPORT, qw( room_alias_name_fixture room_alias_fixture matrix_create_room_synced );
+push @EXPORT, qw( room_alias_name_fixture room_alias_fixture remote_room_alias_fixture matrix_create_room_synced );
 
 my $next_alias_name = 0;
 
@@ -356,7 +356,7 @@ sub room_alias_name_fixture
 
 =head2 room_alias_fixture
 
-   $fixture = room_alias_fixture( prefix => $prefix )
+   $fixture = room_alias_fixture( prefix => $prefix, info => $info )
 
 Returns a new Fixture, which when provisioned will allocate a name for a new
 room alias on the first homeserver, and return it as a string. Note that this
@@ -366,6 +366,9 @@ new unique name for one.
 An optional prefix string can be provided, which will be prepended onto the
 alias name.
 
+An optional remote boolean can be supplied, which will generate an alias for
+the remote homeserver instead.
+
 =cut
 
 sub room_alias_fixture
@@ -374,7 +377,8 @@ sub room_alias_fixture
 
    return fixture(
       requires => [
-         room_alias_name_fixture( prefix => $args{prefix} ), $main::HOMESERVER_INFO[0],
+         room_alias_name_fixture( prefix => $args{prefix} ),
+         exists($args{remote}) ? $main::HOMESERVER_INFO[1] : $main::HOMESERVER_INFO[0],
       ],
 
       setup => sub {
@@ -383,6 +387,27 @@ sub room_alias_fixture
          Future->done( sprintf "#%s:%s", $alias_name, $info->server_name );
       },
    );
+}
+
+=head2 remote_room_alias_fixture
+
+   $fixture = remote_room_alias_fixture( prefix => $prefix )
+
+Returns a new Fixture, which when provisioned will allocate a name for a new
+room alias on the second homeserver, and return it as a string. Note that this
+does not actually create the alias on the server itself, it simply suggests a
+new unique name for one.
+
+An optional prefix string can be provided, which will be prepended onto the
+alias name.
+
+=cut
+
+sub remote_room_alias_fixture
+{
+   my %args = @_;
+
+   return room_alias_fixture( prefix => $args{prefix}, remote => 1 );
 }
 
 

--- a/tests/10apidoc/30room-create.pl
+++ b/tests/10apidoc/30room-create.pl
@@ -356,7 +356,7 @@ sub room_alias_name_fixture
 
 =head2 room_alias_fixture
 
-   $fixture = room_alias_fixture( prefix => $prefix, info => $info )
+   $fixture = room_alias_fixture( prefix => $prefix, remote => false )
 
 Returns a new Fixture, which when provisioned will allocate a name for a new
 room alias on the first homeserver, and return it as a string. Note that this
@@ -367,7 +367,7 @@ An optional prefix string can be provided, which will be prepended onto the
 alias name.
 
 An optional remote boolean can be supplied, which will generate an alias for
-the remote homeserver instead.
+the second homeserver instead.
 
 =cut
 
@@ -378,7 +378,7 @@ sub room_alias_fixture
    return fixture(
       requires => [
          room_alias_name_fixture( prefix => $args{prefix} ),
-         exists($args{remote}) ? $main::HOMESERVER_INFO[1] : $main::HOMESERVER_INFO[0],
+         $args{remote} ? $main::HOMESERVER_INFO[1] : $main::HOMESERVER_INFO[0],
       ],
 
       setup => sub {

--- a/tests/10apidoc/33room-members.pl
+++ b/tests/10apidoc/33room-members.pl
@@ -611,7 +611,7 @@ through to C<setup_user>.
 
 =item room_opts => HASH
 
-Options to use when creating the room. Thes are passed into into
+Options to use when creating the room. These are passed into
 C<matrix_create_room>, whence they are passed on to the server.
 
 =back


### PR DESCRIPTION
Synapse PR: https://github.com/matrix-org/synapse/pull/6946

Having a `remote_room_alias_fixture` method seemed useful.

Test `/upgrade moves aliases to the new room` was edited as the `$server_name` variable was not used.