### PR TITLE
Change room_fixture to run matrix_create_room_synced by default

### DIFF
--- a/tests/10apidoc/33room-members.pl
+++ b/tests/10apidoc/33room-members.pl
@@ -531,7 +531,12 @@ sub room_fixture
       setup => sub {
          my ( $user ) = @_;
 
-         matrix_create_room_synced( $user, %args )->then( sub {
+         my $sync = 1;
+         if ( exists($args{synced}) && $args{synced} == 0 ) {
+            $sync = 0;
+         }
+
+         ( $sync ? matrix_create_room_synced( $user, %args ) : matrix_create_room( $user, %args ) )->then( sub {
             my ( $room_id ) = @_;
             # matrix_create_room returns the room_id and the room_alias if
             #  one was set. However we only want to return the room_id

--- a/tests/10apidoc/33room-members.pl
+++ b/tests/10apidoc/33room-members.pl
@@ -531,7 +531,7 @@ sub room_fixture
       setup => sub {
          my ( $user ) = @_;
 
-         matrix_create_room( $user, %args )->then( sub {
+         matrix_create_room_synced( $user, %args )->then( sub {
             my ( $room_id ) = @_;
             # matrix_create_room returns the room_id and the room_alias if
             #  one was set. However we only want to return the room_id

--- a/tests/10apidoc/33room-members.pl
+++ b/tests/10apidoc/33room-members.pl
@@ -512,6 +512,11 @@ server and return the room id.
 C<$user_fixture> should be a Fixture which will provide a User when
 provisioned.
 
+C<opts> can contain a boolean key called C<synced>, which determines whether to
+perform a user /sync request after creating the room. This involves inserting
+and checking for a 'm.room.test' event in the room state, which may be
+undesirable in some cases. Defaults to 1.
+
 Any other options are passed into C<matrix_create_room>, whence they are passed
 on to the server.
 
@@ -531,8 +536,12 @@ sub room_fixture
       setup => sub {
          my ( $user ) = @_;
 
+         # Determine whether to create room synced or not. Default is synced
+         #
+         # This will insert a m.room.test event into room state which
+         # some tests may not want
          my $sync = 1;
-         if ( exists($args{synced}) && $args{synced} == 0 ) {
+         if ( exists( $args{synced} ) && $args{synced} == 0 ) {
             $sync = 0;
          }
 

--- a/tests/30rooms/01state.pl
+++ b/tests/30rooms/01state.pl
@@ -263,7 +263,9 @@ sub set_test_state
 }
 
 test "Setting state twice is idempotent",
-   requires => [ local_user_and_room_fixtures() ],
+   # Setting synced to 1 inserts a m.room.test object into the
+   # timeline which this test does not expect
+   requires => [ local_user_and_room_fixtures( room_opts => { synced => 0 } ) ],
 
    check => sub {
       my ( $user, $room_id ) = @_;

--- a/tests/50federation/33room-get-missing-events.pl
+++ b/tests/50federation/33room-get-missing-events.pl
@@ -105,7 +105,9 @@ test "Outbound federation can request missing events",
 foreach my $vis (qw( world_readable shared invite joined )) {
    test "Inbound federation can return missing events for $vis visibility",
       requires => [ $main::OUTBOUND_CLIENT,
-                    local_user_and_room_fixtures(),
+                    # Setting synced to 1 inserts a m.room.test object into the
+                    # timeline which this test does not expect
+                    local_user_and_room_fixtures( room_opts => { synced => 0 } ),
                     federation_user_id_fixture() ],
 
       do => sub {


### PR DESCRIPTION
This PR adds an optional boolean parameter to `room_fixture` (and thus other fixtures that rely on it) called `synced` which affects whether `matrix_create_room_synced` or `matrix_create_room` is used when creating a room. This helps fix test `/upgrade creates a new room` which was flaky on worker mode. Reason being we weren't waiting for all room events to come down sync before upgrading the room (and then checking that a `m.room.tombstone` was the only new event in the timeline).

This is coupled with a Synapse PR which un-blacklists the above mentioned test: https://github.com/matrix-org/synapse/pull/7228

This may allow us to unblacklist some other tests as well, although I currently don't know which ones. Presumably we can check with dendrite's [show-expected-fail-tests.sh](https://github.com/matrix-org/dendrite/blob/master/show-expected-fail-tests.sh) script. We should do that anyways.