### PR TITLE
Make message history pagination test less flaky

### DIFF
--- a/tests/30rooms/04messages.pl
+++ b/tests/30rooms/04messages.pl
@@ -215,14 +215,14 @@ test "Message history can be paginated",
             body => "Message number $_[0]"
          )
       } foreach => [ 1 .. 20 ] )->then( sub {
-         await_sync( $user, check => sub {
-            sync_timeline_contains( $_[0], $room_id, sub {
+         await_sync_timeline_contains(
+            $user, $room_id, check => sub {
                any {
                   $_->{type} eq "m.room.message"
                   && $_->{content}{body} eq "Message number 20"
                } @_;
-            });
-         });
+            },
+         );
       })->then( sub {
          matrix_get_room_messages( $user, $room_id, limit => 5 )
       })->then( sub {

--- a/tests/30rooms/04messages.pl
+++ b/tests/30rooms/04messages.pl
@@ -215,6 +215,15 @@ test "Message history can be paginated",
             body => "Message number $_[0]"
          )
       } foreach => [ 1 .. 20 ] )->then( sub {
+         await_sync( $user, check => sub {
+            sync_timeline_contains( $_[0], $room_id, sub {
+               any {
+                  $_->{type} eq "m.room.message"
+                  && $_->{content}{body} eq "Message number 20"
+               } @_;
+            });
+         });
+      })->then( sub {
          matrix_get_room_messages( $user, $room_id, limit => 5 )
       })->then( sub {
          my ( $body ) = @_;


### PR DESCRIPTION
Dendrite has a [failing test](https://buildkite.com/matrix-dot-org/dendrite/builds/1145#annotation-SyTest%20-%20:go:%201.13%20/%20:postgres:%209.6) that gets fixed when some waiting is added before the `matrix_get_room_messages` call here.

Signed-off-by: Alex Chen <minecnly@gmail.com>

(Not actually a Perl user but thought this should be rather simple; please feel free to point out problems.)