### PR TITLE
Modify login tests to be spec compliant

### DIFF
--- a/tests/10apidoc/02login.pl
+++ b/tests/10apidoc/02login.pl
@@ -82,7 +82,10 @@ test "POST /login can log in as a user",
 
          content => {
             type     => "m.login.password",
-            user     => $user_id,
+            identifier => {
+               type => "m.id.user",
+               user => $user_id,
+            },
             password => $password,
          },
       )->then( sub {
@@ -114,7 +117,10 @@ test "POST /login returns the same device_id as that in the request",
 
          content => {
             type     => "m.login.password",
-            user     => $user_id,
+            identifier => {
+               type => "m.id.user",
+               user => $user_id,
+            },
             password => $password,
             device_id => $device_id,
          },
@@ -146,7 +152,10 @@ test "POST /login can log in as a user with just the local part of the id",
 
          content => {
             type     => "m.login.password",
-            user     => $user_localpart,
+            identifier => {
+               type => "m.id.user",
+               user => $user_localpart,
+            },
             password => $password,
          },
       )->then( sub {
@@ -174,7 +183,10 @@ test "POST /login as non-existing user is rejected",
 
          content => {
             type     => "m.login.password",
-            user     => "i-ought-not-to-exist",
+            identifier => {
+               type => "m.id.user",
+               user => "i-ought-not-to-exist",
+            },
             password => "XXX",
          },
       )->main::expect_http_403;
@@ -193,7 +205,10 @@ test "POST /login wrong password is rejected",
 
          content => {
             type     => "m.login.password",
-            user     => $user_id,
+            identifier => {
+               type => "m.id.user",
+               user => $user_id,
+            },
             password => "${password}wrong",
          },
       )->main::expect_http_403->then( sub {
@@ -225,7 +240,10 @@ sub matrix_login_again_with_user
       uri     => "/r0/login",
       content  => {
          type     => "m.login.password",
-         user     => $user->user_id,
+         identifier => {
+            type => "m.id.user",
+            user => $user->user_id,
+         },
          password => $user->password,
          %args,
       },

--- a/tests/14account/02deactivate.pl
+++ b/tests/14account/02deactivate.pl
@@ -67,7 +67,10 @@ test "After deactivating account, can't log in with password",
             uri     => "/r0/login",
             content => {
                type     => "m.login.password",
-               user     => $user->user_id,
+               identifier => {
+                  type => "m.id.user",
+                  user => $user->user_id,
+               },
                password => $user->password,
             }
          # We don't mandate the exact failure code here


### PR DESCRIPTION
The 'identifier' key is required as per:
  https://matrix.org/docs/spec/client_server/r0.6.0#post-matrix-client-r0-login

Synapse likely falls back to previous logic if this key is missing
but Dendrite will just fail, correctly stating that the identifier
key is missing.

This is currently preventing the login tests from succeeding on Dendrite.