### PR TITLE
Fix OFFLINE support for the sytest-synapse docker image

### DIFF
--- a/scripts/synapse_sytest.sh
+++ b/scripts/synapse_sytest.sh
@@ -114,10 +114,11 @@ if [ -n "$OFFLINE" ]; then
     # if we're in offline mode, just put synapse into the virtualenv, and
     # hope that the deps are up-to-date.
     #
-    # (`pip install -e` likes to reinstall setuptools even if it's already installed,
-    # so we just run setup.py explicitly.)
-    #
-    (cd /src && /venv/bin/python setup.py -q develop)
+    # --no-use-pep517 works around what appears to be a pip issue
+    # (https://github.com/pypa/pip/issues/5402 possibly) where pip wants
+    # to reinstall any requirements for the build system, even if they are
+    # already installed.
+    /venv/bin/pip install --no-index --no-use-pep517 /src
 else
     # We've already created the virtualenv, but lets double check we have all
     # deps.


### PR DESCRIPTION
The sytest-synapse docker image is meant to support an OFFLINE mode, but this
doesn't currently work terribly well (when run against a readonly synapse, it
complains about readonly filesystem).

This change fixes it by installing synapse with `pip` instead of trying to run
`setup.py` directly.