### PR TITLE
Add event ID to /v1/invite and /v2/invite on Sytest federation server

### DIFF
--- a/lib/SyTest/Federation/Server.pm
+++ b/lib/SyTest/Federation/Server.pm
@@ -439,11 +439,11 @@ __PACKAGE__->mk_await_request_pair(
 );
 
 __PACKAGE__->mk_await_request_pair(
-   "v1", "invite", [qw( :room_id )],
+   "v1", "invite", [qw( :room_id :event_id )],
 );
 
 __PACKAGE__->mk_await_request_pair(
-   "v2", "invite", [qw( :room_id )],
+   "v2", "invite", [qw( :room_id :event_id )],
 );
 
 __PACKAGE__->mk_await_request_pair(


### PR DESCRIPTION
According to [the spec](https://matrix.org/docs/spec/server_server/r0.1.3#put-matrix-federation-v2-invite-roomid-eventid), there should be an `:event_id` parameter here.