### PR TITLE
Use /sync not /events to fetch data

### DIFF
--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -45,7 +45,6 @@ TEST_STATUS=0
 mkdir -p /logs
 ./run-tests.pl -I Dendrite::Monolith -d $GOBIN -W /src/sytest-whitelist -O tap --all \
     --work-directory="/work" \
-tests/50federation/36state.pl \
     "$@" > /logs/results.tap || TEST_STATUS=$?
 
 if [ $TEST_STATUS -ne 0 ]; then

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -45,6 +45,7 @@ TEST_STATUS=0
 mkdir -p /logs
 ./run-tests.pl -I Dendrite::Monolith -d $GOBIN -W /src/sytest-whitelist -O tap --all \
     --work-directory="/work" \
+tests/50federation/36state.pl \
     "$@" > /logs/results.tap || TEST_STATUS=$?
 
 if [ $TEST_STATUS -ne 0 ]; then

--- a/tests/50federation/36state.pl
+++ b/tests/50federation/36state.pl
@@ -287,6 +287,7 @@ test "Outbound federation requests missing prev_events and then asks for /state_
    do => sub {
       my ( $outbound_client, $inbound_server, $creator, $room_id, $user_id ) = @_;
       my $first_home_server = $creator->server_name;
+      log_if_fail "Room ID is ". $room_id;
 
       # in this test, we're going to create a DAG like this:
       #
@@ -336,7 +337,7 @@ test "Outbound federation requests missing prev_events and then asks for /state_
            );
       })->then( sub {
          ( $room ) = @_;
-
+         log_if_fail "User joined room ". $user_id;
          # Create and send B
          $sent_event_b = $room->create_and_insert_event(
             type => "test_state",
@@ -347,6 +348,7 @@ test "Outbound federation requests missing prev_events and then asks for /state_
                body => "event_b",
             },
          );
+         log_if_fail "User sent event B ". $sent_event_b->{event_id};
 
          Future->needs_all(
             $outbound_client->send_event(
@@ -355,13 +357,8 @@ test "Outbound federation requests missing prev_events and then asks for /state_
             ),
             await_sync_timeline_contains($creator, $room_id, check => sub {
                my ( $event ) = @_;
-               return unless $event->{type} eq "test_state";
-
                log_if_fail "Received event", $event;
-
-               assert_eq( $event->{event_id}, $sent_event_b->{event_id}, "Got unexpected event");
-
-               return 1;
+               return $event->{event_id} eq $sent_event_b->{event_id}
             }),
          );
       })->then( sub {
@@ -486,11 +483,14 @@ test "Outbound federation requests missing prev_events and then asks for /state_
          )->then( sub {
             # creator user should eventually receive the events
             Future->needs_all(
-               await_event_for( $creator, filter => sub {
-                  ( $_[0]->{event_id} // '' ) eq $sent_event_c->{event_id};
+               await_sync_timeline_contains($creator, $room_id, check => sub {
+                  my ( $event ) = @_;
+                  return $event->{event_id} eq $sent_event_c->{event_id}
                }),
-               await_event_for( $creator, filter => sub {
-                  ( $_[0]->{event_id} // '' ) eq $missing_event_x->{event_id};
+               await_sync_timeline_contains($creator, $room_id, check => sub {
+                  my ( $event ) = @_;
+                  log_if_fail "/sync event", $event;
+                  return $event->{event_id} eq $missing_event_x->{event_id}
                }),
             );
          })->then( sub {

--- a/tests/50federation/36state.pl
+++ b/tests/50federation/36state.pl
@@ -353,8 +353,15 @@ test "Outbound federation requests missing prev_events and then asks for /state_
                event       => $sent_event_b,
                destination => $first_home_server,
             ),
-            await_event_for( $creator, filter => sub {
-               ( $_[0]->{event_id} // '' ) eq $sent_event_b->{event_id};
+            await_sync_timeline_contains($creator, $room_id, check => sub {
+               my ( $event ) = @_;
+               return unless $event->{type} eq "test_state";
+
+               log_if_fail "Received event", $event;
+
+               assert_eq( $event->{event_id}, $sent_event_b->{event_id}, "Got unexpected event");
+
+               return 1;
             }),
          );
       })->then( sub {


### PR DESCRIPTION
Dendrite cannot run `Outbound federation requests missing prev_events and then asks for /state_ids and resolves the state` currently because it doesn't implement the deprecated `/events` endpoint. Modify the one bit where we rely on it to instead use `/sync`.