### PR TITLE
Pass through DENDRITE_TRACE_ env vars to the dendrite binary

### DIFF
--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -286,6 +286,8 @@ sub _start_monolith
       setup => [
          env => {
             LOG_DIR => $self->{hs_dir},
+            DENDRITE_TRACE_SQL => $ENV{'DENDRITE_TRACE_SQL'},
+            DENDRITE_TRACE_HTTP => $ENV{'DENDRITE_TRACE_HTTP'},
          },
       ],
       command => [ @command ],


### PR DESCRIPTION
This means you can do things like:
```
docker run --name sytest --rm -v "/Users/kegan/github/dendrite:/src" -v "/Users/kegan/logs:/logs" -e "POSTGRES=0" -e "DENDRITE_TRACE_HTTP=1" -e "DENDRITE_TRACE_SQL=1" matrixdotorg/sytest-dendrite:latest
```
to have it log HTTP/SQL queries. Tested it works with and without specifying them.