### PR TITLE
Room version 6 tests

### DIFF
--- a/lib/SyTest/Federation/Client.pm
+++ b/lib/SyTest/Federation/Client.pm
@@ -16,8 +16,7 @@ use SyTest::Assertions qw( :all );
 use URI::Escape qw( uri_escape );
 
 use constant SUPPORTED_ROOM_VERSIONS => [qw(
-   1 2 3 4 5
-   org.matrix.msc2260
+   1 2 3 4 5 6
 )];
 
 sub configure

--- a/lib/SyTest/Federation/Datastore.pm
+++ b/lib/SyTest/Federation/Datastore.pm
@@ -268,10 +268,13 @@ sub get_backfill_events
       my $event = eval { $self->get_event( $id ) }
          or next;
 
+      my $room = $self->get_room( $event->{room_id} ) or
+         croak "Unknown room $event->{room_id}";
+
       push @events, $event;
 
       push @event_ids, grep { !$exclude{$_} }
-                       map { $_->[0] } @{ $event->{prev_events} };
+                       @{ $room->event_ids_from_refs( $event->{prev_events} ) };
 
       # Don't include this event if we encounter it again
       $exclude{$id} = 1;

--- a/tests/00expect_http_fail.pl
+++ b/tests/00expect_http_fail.pl
@@ -172,3 +172,13 @@ sub expect_m_not_found
    );
 }
 push @EXPORT, qw( expect_m_not_found );
+
+
+sub expect_m_bad_json
+{
+   my $f = shift;
+   return expect_matrix_error(
+      $f, 400, 'M_BAD_JSON',
+   );
+}
+push @EXPORT, qw( expect_m_bad_json );

--- a/tests/30rooms/08levels.pl
+++ b/tests/30rooms/08levels.pl
@@ -156,7 +156,7 @@ foreach my $levelname (qw( ban kick redact )) {
 
                $levels->{$levelname} = 10000000;
             })->main::expect_http_403
-         })->SyTest::pass_on_done( "Fails at setting 75" );
+         })->SyTest::pass_on_done( "Fails at setting 10000000" );
       };
 }
 
@@ -178,5 +178,5 @@ multi_test "Users cannot set notifications powerlevel higher than their own",
 
             $levels->{notifications}{room} = 10000000;
          })->main::expect_http_403
-      })->SyTest::pass_on_done( "Fails at setting 75" );
+      })->SyTest::pass_on_done( "Fails at setting 10000000" );
    };

--- a/tests/32room-versions.pl
+++ b/tests/32room-versions.pl
@@ -1,7 +1,5 @@
 use URI::Escape qw( uri_escape );
 
-use SyTest::Federation::Client;
-
 # We test that some basic functionality works across all room versions
 foreach my $version ( qw ( 1 2 3 4 5 6 ) )  {
    multi_test "User can create and send/receive messages in a room with version $version",

--- a/tests/32room-versions.pl
+++ b/tests/32room-versions.pl
@@ -1,7 +1,9 @@
 use URI::Escape qw( uri_escape );
 
+use SyTest::Federation::Client;
+
 # We test that some basic functionality works across all room versions
-foreach my $version ( qw ( 1 2 3 4 5 ) )  {
+foreach my $version ( qw ( 1 2 3 4 5 6 ) )  {
    multi_test "User can create and send/receive messages in a room with version $version",
       requires => [ local_user_fixture() ],
 

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -1062,23 +1062,6 @@ test "Event with an invalid signature in the send_join response should not cause
       )
    };
 
-push @EXPORT, qw( expect_bad_json );
-
-sub expect_bad_json {
-   my ($f) = @_;
-
-   $f->main::expect_http_400
-   ->then(sub {
-      # done
-      my ($response) = @_;
-      log_if_fail "Response", $response;
-      my $body = decode_json($response->content);
-      log_if_fail "Body", $body;
-
-      assert_eq($body->{errcode}, "M_BAD_JSON", 'responsecode');
-      Future->done(1);
-   });
-};
 
 test "Inbound: room version 6 rejects invalid JSON",
    requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
@@ -1150,5 +1133,5 @@ test "Inbound: room version 6 rejects invalid JSON",
             uri      => "/v2/send_join/$room_id/xxx",
             content => \%event,
          )
-      })->main::expect_bad_json;
+      })->main::expect_m_bad_json;
    };

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -1070,7 +1070,7 @@ test "Event with an invalid signature in the send_join response should not cause
 # * Add a "bad" value into the returned prototype event.
 # * Make a request to `send_join`.
 # * Check that the response is M_BAD_JSON.
-test "Inbound: send_join rejects invalid JSON for room version 6 rejects",
+test "Inbound: send_join rejects invalid JSON for room version 6",
    requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
                  local_user_and_room_fixtures( room_opts => { room_version => "6" } ),
                  federation_user_id_fixture() ],

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -1062,7 +1062,7 @@ test "Event with an invalid signature in the send_join response should not cause
       )
    };
 
-test "Room version 6 rejects invalid JSON",
+test "Inbound: room version 6 rejects invalid JSON",
    requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
                  local_user_and_room_fixtures( room_opts => { room_version => "6" } ),
                  federation_user_id_fixture() ],
@@ -1094,7 +1094,7 @@ test "Room version 6 rejects invalid JSON",
             auth_events content depth room_id sender state_key type
          ));
 
-         assert_json_nonempty_list( my $auth_events = $protoevent->{auth_events} );
+         assert_json_nonempty_list( $protoevent->{auth_events} );
 
          assert_json_nonempty_list( $protoevent->{prev_events} );
 
@@ -1130,14 +1130,13 @@ test "Room version 6 rejects invalid JSON",
             method   => "PUT",
             hostname => $first_home_server,
             uri      => "/v2/send_join/$room_id/xxx",
-
             content => \%event,
          )
       })->main::expect_http_400
       ->then( sub {
          my ( $response ) = @_;
          my $body = decode_json( $response->content );
-         log_if_fail "Join error response", $body;
+         log_if_fail "Send join error response", $body;
 
          assert_eq( $body->{errcode}, "M_BAD_JSON", 'responsecode' );
          Future->done(1);

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -1063,7 +1063,7 @@ test "Event with an invalid signature in the send_join response should not cause
    };
 
 
-test "Inbound: room version 6 rejects invalid JSON",
+test "Inbound: send_join rejects invalid JSON for room version 6 rejects",
    requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
                  local_user_and_room_fixtures( room_opts => { room_version => "6" } ),
                  federation_user_id_fixture() ],
@@ -1087,32 +1087,8 @@ test "Inbound: room version 6 rejects invalid JSON",
 
          log_if_fail "make_join body", $body;
 
-         assert_json_keys( $body, qw( event ));
-
-         my $protoevent = $body->{event};
-
-         assert_json_keys( $protoevent, qw(
-            auth_events content depth room_id sender state_key type
-         ));
-
-         assert_json_nonempty_list( $protoevent->{auth_events} );
-
-         assert_json_nonempty_list( $protoevent->{prev_events} );
-
-         assert_json_number( $protoevent->{depth} );
-
-         $protoevent->{room_id} eq $room_id or
-            die "Expected 'room_id' to be $room_id";
-         $protoevent->{sender} eq $user_id or
-            die "Expected 'sender' to be $user_id";
-         $protoevent->{state_key} eq $user_id or
-            die "Expected 'state_key' to be $user_id";
-         $protoevent->{type} eq "m.room.member" or
-            die "Expected 'type' to be 'm.room.member'";
-
-         assert_json_keys( my $content = $protoevent->{content}, qw( membership ) );
-         $content->{membership} eq "join" or
-            die "Expected 'membership' to be 'join'";
+         # It is assumed that the make_join response is sane, other tests ensure
+         # this behavior.
 
          my %event = (
             ( map { $_ => $protoevent->{$_} } qw(

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -1062,7 +1062,14 @@ test "Event with an invalid signature in the send_join response should not cause
       )
    };
 
-
+# A homeserver receiving a `send_join` request for a room version 6 room with
+# a bad JSON value (e.g. a float) should reject the request.
+#
+# To test this we need to:
+# * Send a successful `make_join` request.
+# * Add a "bad" value into the returned prototype event.
+# * Make a request to `send_join`.
+# * Check that the response is M_BAD_JSON.
 test "Inbound: send_join rejects invalid JSON for room version 6 rejects",
    requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
                  local_user_and_room_fixtures( room_opts => { room_version => "6" } ),
@@ -1087,6 +1094,8 @@ test "Inbound: send_join rejects invalid JSON for room version 6 rejects",
 
          log_if_fail "make_join body", $body;
 
+         my $protoevent = $body->{event};
+
          # It is assumed that the make_join response is sane, other tests ensure
          # this behavior.
 
@@ -1099,7 +1108,7 @@ test "Inbound: send_join rejects invalid JSON for room version 6 rejects",
             origin_server_ts => $inbound_server->time_ms,
          );
          # Insert a "bad" value into the send join, in this case a float.
-         ${event}{contents}{bad_val} = 1.1;
+         ${event}{content}{bad_val} = 1.1;
 
          $datastore->sign_event( \%event );
 

--- a/tests/50federation/33room-get-missing-events.pl
+++ b/tests/50federation/33room-get-missing-events.pl
@@ -10,7 +10,6 @@ test "Outbound federation can request missing events",
       my ( $outbound_client, $inbound_server, $creator, $room_id, $user_id ) = @_;
       my $first_home_server = $creator->server_name;
 
-      my $local_server_name = $inbound_server->server_name;
       my $datastore         = $inbound_server->datastore;
 
       my $missing_event_id;
@@ -422,7 +421,6 @@ test "Outbound federation will ignore a missing event with bad JSON for room ver
       my ( $outbound_client, $inbound_server, $creator, $room_id, $user_id ) = @_;
       my $first_home_server = $creator->server_name;
 
-      my $local_server_name = $inbound_server->server_name;
       my $datastore         = $inbound_server->datastore;
 
       $outbound_client->join_room(

--- a/tests/50federation/33room-get-missing-events.pl
+++ b/tests/50federation/33room-get-missing-events.pl
@@ -505,7 +505,7 @@ test "Outbound federation will ignore a missing event with bad JSON for room ver
                   events => \@events,
                } );
 
-               Future->done(1);
+               Future->done;
             }),
 
             # Can't use send_event here because that checks none were rejected.

--- a/tests/50federation/33room-get-missing-events.pl
+++ b/tests/50federation/33room-get-missing-events.pl
@@ -1,7 +1,6 @@
 test "Outbound federation can request missing events",
    requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
                  local_user_and_room_fixtures(
-                    user_opts => { with_events => 1 },
                     room_opts => { room_version => "1" },
                    ),
                  federation_user_id_fixture() ],
@@ -415,7 +414,6 @@ test "outliers whose auth_events are in a different room are correctly rejected"
 test "Outbound federation will ignore a missing event with bad JSON for room version 6",
    requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
                  local_user_and_room_fixtures(
-                    user_opts => { with_events => 1 },
                     room_opts => { room_version => "6" },
                    ),
                  federation_user_id_fixture() ],

--- a/tests/50federation/33room-get-missing-events.pl
+++ b/tests/50federation/33room-get-missing-events.pl
@@ -13,7 +13,7 @@ test "Outbound federation can request missing events",
       my $local_server_name = $inbound_server->server_name;
       my $datastore         = $inbound_server->datastore;
 
-      my $missing_event;
+      my $missing_event_id;
 
       $outbound_client->join_room(
          server_name => $first_home_server,
@@ -27,7 +27,7 @@ test "Outbound federation can request missing events",
          my $latest_event = $room->get_current_state_event( "m.room.member", $user_id );
 
          # Generate but don't send an event
-         $missing_event = $room->create_and_insert_event(
+         my $missing_event = $room->create_and_insert_event(
             type => "m.room.message",
 
             sender  => $user_id,
@@ -35,6 +35,7 @@ test "Outbound federation can request missing events",
                body => "Message 1",
             },
          );
+         $missing_event_id = $room->id_for_event( $missing_event );
 
          # Generate another one and do send it so it will refer to the
          # previous in its prev_events field
@@ -43,9 +44,7 @@ test "Outbound federation can request missing events",
 
             # This would be done by $room->create_and_insert_event anyway but lets be
             #   sure for this test
-            prev_events => [
-               [ $missing_event->{event_id}, $missing_event->{hashes} ],
-            ],
+            prev_events => $room->make_event_refs( $missing_event ),
 
             sender  => $user_id,
             content => {
@@ -65,13 +64,13 @@ test "Outbound federation can request missing events",
                assert_json_list( my $earliest = $body->{earliest_events} );
                @$earliest == 1 or
                   die "Expected a single 'earliest_event' ID";
-               assert_eq( $earliest->[0], $latest_event->{event_id},
+               assert_eq( $earliest->[0], $room->id_for_event( $latest_event ),
                   'earliest_events[0]' );
 
                assert_json_list( my $latest = $body->{latest_events} );
                @$latest == 1 or
                   die "Expected a single 'latest_events' ID";
-               assert_eq( $latest->[0], $sent_event->{event_id},
+               assert_eq( $latest->[0], $room->id_for_event( $sent_event ),
                   'latest_events[0]' );
 
                my @events = $datastore->get_backfill_events(
@@ -97,7 +96,7 @@ test "Outbound federation can request missing events",
          await_event_for( $creator, filter => sub {
             my ( $event ) = @_;
             return $event->{type} eq "m.room.message" &&
-                   $event->{event_id} eq $missing_event->{event_id};
+                   $event->{event_id} eq $missing_event_id;
          });
       });
    };
@@ -408,5 +407,122 @@ test "outliers whose auth_events are in a different room are correctly rejected"
             die "user became a member of the room without an invite";
          }
          Future->done;
+      });
+   };
+
+test "Outbound federation will ignore a missing event with bad JSON for room version 6",
+   requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
+                 local_user_and_room_fixtures(
+                    user_opts => { with_events => 1 },
+                    room_opts => { room_version => "6" },
+                   ),
+                 federation_user_id_fixture() ],
+
+   do => sub {
+      my ( $outbound_client, $inbound_server, $creator, $room_id, $user_id ) = @_;
+      my $first_home_server = $creator->server_name;
+
+      my $local_server_name = $inbound_server->server_name;
+      my $datastore         = $inbound_server->datastore;
+
+      my $missing_event_id;
+
+      $outbound_client->join_room(
+         server_name => $first_home_server,
+         room_id     => $room_id,
+         user_id     => $user_id,
+         version     => "6",
+      )->then( sub {
+         my ( $room ) = @_;
+
+         # TODO: We happen to know the latest event in the server should be my
+         #   m.room.member state event, but that's a bit fragile
+         my $latest_event = $room->get_current_state_event( "m.room.member", $user_id );
+
+         log_if_fail "Latest event", $latest_event;
+
+         # Generate but don't send an event
+         my $missing_event = $room->create_and_insert_event(
+            type => "m.room.message",
+
+            sender  => $user_id,
+            content => {
+               body => "Message 1",
+            },
+         );
+         $missing_event_id = $room->id_for_event( $missing_event );
+
+         log_if_fail "Missing event", $missing_event;
+
+         # Generate another one and do send it so it will refer to the
+         # previous in its prev_events field
+         my $sent_event = $room->create_and_insert_event(
+            type => "m.room.message",
+
+            # This would be done by $room->create_and_insert_event anyway but lets be
+            #   sure for this test
+            prev_events => $room->make_event_refs( $missing_event ),
+
+            sender  => $user_id,
+            content => {
+               body => "Message 2",
+            },
+         );
+
+         log_if_fail "Sent event", $sent_event;
+
+         Future->needs_all(
+            $inbound_server->await_request_get_missing_events( $room_id )
+            ->then( sub {
+               my ( $req ) = @_;
+               my $body = $req->body_from_json;
+
+               log_if_fail "Body", $body;
+
+               assert_json_keys( $body, qw( earliest_events latest_events limit ));
+               # TODO: min_depth but I have no idea what it does
+
+               assert_json_list( my $earliest = $body->{earliest_events} );
+               @$earliest == 1 or
+                  die "Expected a single 'earliest_event' ID";
+               assert_eq( $earliest->[0], $room->id_for_event( $latest_event ),
+                  'earliest_events[0]' );
+
+               assert_json_list( my $latest = $body->{latest_events} );
+               @$latest == 1 or
+                  die "Expected a single 'latest_events' ID";
+               assert_eq( $latest->[0], $room->id_for_event( $sent_event ),
+                  'latest_events[0]' );
+
+               my @events = $datastore->get_backfill_events(
+                  start_at    => $latest,
+                  stop_before => $earliest,
+                  limit       => $body->{limit},
+               );
+
+               log_if_fail "Backfilling", @events;
+
+               $req->respond_json( {
+                  events => \@events,
+               } );
+
+               Future->done(1);
+            }),
+
+            $outbound_client->send_event(
+               event       => $sent_event,
+               destination => $first_home_server,
+            ),
+         );
+      })->then( sub {
+         # creator user should eventually receive the missing event
+         await_event_for( $creator, filter => sub {
+            my ( $event ) = @_;
+
+            log_if_fail "Event", $event;
+
+            return $event->{type} eq "m.room.message" &&
+                   $event->{event_id} eq $missing_event_id;
+         });
       });
    };

--- a/tests/50federation/33room-get-missing-events.pl
+++ b/tests/50federation/33room-get-missing-events.pl
@@ -411,6 +411,15 @@ test "outliers whose auth_events are in a different room are correctly rejected"
       });
    };
 
+# A homeserver receiving a response from `get_missing_events` for a version 6
+# room with a bad JSON value (e.g. a float) should discard the bad data.
+#
+# To test this we need to:
+# * Join a room.
+# * Add an event with "bad" data into the room history, but don't send it.
+# * Add a "good" event into the room history and send it.
+# * The homeserver attempts to get the missing event (with the bad data).
+# * Ensure that fetching the event results in an error.
 test "Outbound federation will ignore a missing event with bad JSON for room version 6",
    requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
                  local_user_and_room_fixtures(

--- a/tests/50federation/33room-get-missing-events.pl
+++ b/tests/50federation/33room-get-missing-events.pl
@@ -445,6 +445,7 @@ test "Outbound federation will ignore a missing event with bad JSON for room ver
             sender  => $user_id,
             content => {
                body    => "Message 1",
+               # Insert a bad value here so that this event cannot be fetched.
                bad_val => 1.1,
             },
          );
@@ -504,8 +505,6 @@ test "Outbound federation will ignore a missing event with bad JSON for room ver
                   events => \@events,
                } );
 
-               log_if_fail "Done here";
-
                Future->done(1);
             }),
 
@@ -523,8 +522,9 @@ test "Outbound federation will ignore a missing event with bad JSON for room ver
                my $pdus = $body->{pdus};
 
                # Sending the event fails since fetching the event results in
-               # invalid JSON.
+               # invalid JSON, thus we expect an error for the sent PDU.
                assert_json_keys( $pdus, $sent_event_id );
+               assert_json_keys( $pdus->{$sent_event_id}, qw( error ) );
 
                Future->done;
             }),

--- a/tests/50federation/34room-backfill.pl
+++ b/tests/50federation/34room-backfill.pl
@@ -517,15 +517,8 @@ test "Outbound federation rejects backfill containing invalid JSON for events in
             Future->done;
          }),
 
-         do_request_json_for( $user,
-            method => "POST",
-            uri    => "/r0/join/$room_alias",
-
-            content => {},
-         )->then( sub {
-            my ( $body ) = @_;
-
-            my $room_id = $body->{room_id};
+         matrix_join_room( $user, $room_alias )->then( sub {
+            my ( $room_id ) = @_;
 
             # It make take some time for the join to propagate, so we need to
             # retry on failure.

--- a/tests/50federation/34room-backfill.pl
+++ b/tests/50federation/34room-backfill.pl
@@ -553,7 +553,7 @@ test "Outbound federation rejects backfill containing invalid JSON for events in
                });
             };
 
-            Future->done(1);
+            Future->done;
          }),
       )
    };

--- a/tests/50federation/34room-backfill.pl
+++ b/tests/50federation/34room-backfill.pl
@@ -456,7 +456,7 @@ test "Backfilled events whose prev_events are in a different room do not allow c
 # * Add "bad" data into the room history.
 # * Join the room.
 # * Attempt to backfill the room history.
-# * Ensure that the "bad" event wil be discarded.
+# * Ensure that the "bad" event will be discarded.
 test "Outbound federation rejects backfill containing invalid JSON for events in room version 6",
    requires => [ local_user_fixture(), $main::INBOUND_SERVER, federation_user_id_fixture() ],
 

--- a/tests/50federation/34room-backfill.pl
+++ b/tests/50federation/34room-backfill.pl
@@ -11,7 +11,7 @@ test "Outbound federation can backfill events",
       my $local_server_name = $inbound_server->server_name;
       my $datastore         = $inbound_server->datastore;
 
-      my $room_alias = "#50fed-31backfill:$local_server_name";
+      my $room_alias = "#50fed-34backfill:$local_server_name";
 
       my $room = $datastore->create_room(
          creator => $creator_id,
@@ -457,7 +457,7 @@ test "Outbound federation rejects backfill containing invalid JSON for events in
       my $local_server_name = $inbound_server->server_name;
       my $datastore         = $inbound_server->datastore;
 
-      my $room_alias = "#50fed-31backfill:$local_server_name";
+      my $room_alias = "#50fed-34backfill-bad-json:$local_server_name";
 
       my $room = $datastore->create_room(
          creator      => $creator_id,

--- a/tests/50federation/35room-invite.pl
+++ b/tests/50federation/35room-invite.pl
@@ -783,7 +783,7 @@ test "Inbound federation rejects invites which include invalid JSON for room ver
 
       # Note that only v2 supports providing different room versions.
       do_v2_invite_request( $room, $server_name, $outbound_client, $invite )
-      ->main::expect_http_400();
+      ->main::expect_bad_json;
    };
 
 test "Outbound federation rejects invite response which include invalid JSON for room version 6",
@@ -821,15 +821,7 @@ test "Outbound federation rejects invite response which include invalid JSON for
 
             Future->done;
          }),
-      )->main::expect_http_400
-      ->then( sub {
-         my ( $response ) = @_;
-         my $body = decode_json( $response->content );
-         log_if_fail "Send join error response", $body;
-
-         assert_eq( $body->{errcode}, "M_BAD_JSON", 'responsecode' );
-         Future->done(1);
-      });
+      )->main::expect_bad_json;
    };
 
 test "Inbound federation rejects invite rejections which include invalid JSON for room version 6",
@@ -915,13 +907,5 @@ test "Inbound federation rejects invite rejections which include invalid JSON fo
             uri      => "/v2/send_leave/$room_id/xxx",
             content => \%event,
            )
-      })->main::expect_http_400
-      ->then( sub {
-         my ( $response ) = @_;
-         my $body = decode_json( $response->content );
-         log_if_fail "Send join error response", $body;
-
-         assert_eq( $body->{errcode}, "M_BAD_JSON", 'responsecode' );
-         Future->done(1);
-      });
+      })->main::expect_bad_json;
    };

--- a/tests/50federation/35room-invite.pl
+++ b/tests/50federation/35room-invite.pl
@@ -783,7 +783,7 @@ test "Inbound federation rejects invites which include invalid JSON for room ver
 
       # Note that only v2 supports providing different room versions.
       do_v2_invite_request( $room, $server_name, $outbound_client, $invite )
-      ->main::expect_bad_json;
+      ->main::expect_m_bad_json;
    };
 
 test "Outbound federation rejects invite response which include invalid JSON for room version 6",
@@ -821,7 +821,7 @@ test "Outbound federation rejects invite response which include invalid JSON for
 
             Future->done;
          }),
-      )->main::expect_bad_json;
+      )->main::expect_m_bad_json;
    };
 
 test "Inbound federation rejects invite rejections which include invalid JSON for room version 6",
@@ -907,5 +907,5 @@ test "Inbound federation rejects invite rejections which include invalid JSON fo
             uri      => "/v2/send_leave/$room_id/xxx",
             content => \%event,
            )
-      })->main::expect_bad_json;
+      })->main::expect_m_bad_json;
    };

--- a/tests/50federation/51transactions.pl
+++ b/tests/50federation/51transactions.pl
@@ -82,6 +82,6 @@ test "Server rejects invalid JSON in a version 6 room",
          $outbound_client->send_transaction(
              pdus => \@pdus,
              destination => $creator->server_name,
-         )->main::expect_m_bad_json();
+         )->main::expect_m_bad_json;
       });
    };

--- a/tests/50federation/51transactions.pl
+++ b/tests/50federation/51transactions.pl
@@ -82,6 +82,6 @@ test "Server rejects invalid JSON in a version 6 room",
          $outbound_client->send_transaction(
              pdus => \@pdus,
              destination => $creator->server_name,
-         )->main::expect_bad_json();
+         )->main::expect_m_bad_json();
       });
    };

--- a/tests/80torture/20json.pl
+++ b/tests/80torture/20json.pl
@@ -15,7 +15,7 @@ test "Invalid JSON integers",
                msgtype => "sytest.dummy",
                body    => 9007199254740992,  # 2 ** 53
             },
-         )->followed_by( \&main::expect_http_400 ),
+         )->main::expect_bad_json,
 
          do_request_json_for( $user,
             method  => "POST",
@@ -24,7 +24,7 @@ test "Invalid JSON integers",
                msgtype => "sytest.dummy",
                body    => -9007199254740992,  # -2 ** 53
             },
-         )->followed_by( \&main::expect_http_400 ),
+         )->main::expect_bad_json,
       );
    };
 
@@ -44,7 +44,7 @@ test "Invalid JSON floats",
             msgtype => "sytest.dummy",
             body    => 1.1,
          },
-      )->followed_by( \&main::expect_http_400 );
+      )->main::expect_bad_json;
    };
 
 # Special values (like inf/nan) should be rejected. Note that these values are
@@ -69,7 +69,7 @@ test "Invalid JSON special values",
                msgtype => "sytest.dummy",
                body    => "NaN" + 0,
             },
-         )->followed_by( \&main::expect_http_400 ),
+         )->main::expect_bad_json,
 
          do_request_json_for( $user,
             method  => "POST",
@@ -78,7 +78,7 @@ test "Invalid JSON special values",
                msgtype => "sytest.dummy",
                body    => "inf" + 0,
             },
-         )->followed_by( \&main::expect_http_400 ),
+         )->main::expect_bad_json,
 
          do_request_json_for( $user,
             method  => "POST",
@@ -87,7 +87,7 @@ test "Invalid JSON special values",
                msgtype => "sytest.dummy",
                body    => "-inf" + 0,
             },
-         )->followed_by( \&main::expect_http_400 ),
+         )->main::expect_bad_json,
 
          # Try some Python magic values.
          $user->http->do_request(
@@ -98,7 +98,7 @@ test "Invalid JSON special values",
             },
             content      => '{"msgtype": "sytest.dummy", "body": Infinity}',
             content_type => "application/json",
-         )->followed_by( \&main::expect_http_400 ),
+         )->main::expect_bad_json,
 
          $user->http->do_request(
             method       => "POST",
@@ -108,7 +108,7 @@ test "Invalid JSON special values",
             },
             content      => '{"msgtype": "sytest.dummy", "body": -Infinity}',
             content_type => "application/json",
-         )->followed_by( \&main::expect_http_400 ),
+         )->main::expect_bad_json,
 
          $user->http->do_request(
             method       => "POST",
@@ -118,6 +118,6 @@ test "Invalid JSON special values",
             },
             content      => '{"msgtype": "sytest.dummy", "body": NaN}',
             content_type => "application/json",
-         )->followed_by( \&main::expect_http_400 ),
+         )->main::expect_bad_json,
       );
    };

--- a/tests/80torture/20json.pl
+++ b/tests/80torture/20json.pl
@@ -52,7 +52,7 @@ test "Invalid JSON floats",
             uri     => "/r0/rooms/$room_id/send/sytest.dummy",
             content => {
                msgtype => "sytest.dummy",
-               body    => "NaN",
+               body    => "NaN" + 0,
             },
          )->followed_by( \&main::expect_http_400 ),
 
@@ -61,7 +61,7 @@ test "Invalid JSON floats",
             uri     => "/r0/rooms/$room_id/send/sytest.dummy",
             content => {
                msgtype => "sytest.dummy",
-               body    => "inf",
+               body    => "inf" + 0,
             },
          )->followed_by( \&main::expect_http_400 ),
 
@@ -70,7 +70,7 @@ test "Invalid JSON floats",
             uri     => "/r0/rooms/$room_id/send/sytest.dummy",
             content => {
                msgtype => "sytest.dummy",
-               body    => "-inf",
+               body    => "-inf" + 0,
             },
          )->followed_by( \&main::expect_http_400 ),
       );

--- a/tests/80torture/20json.pl
+++ b/tests/80torture/20json.pl
@@ -1,7 +1,7 @@
 # Test integers that are outside of the range of [-2 ^ 53 + 1, 2 ^ 53 - 1].
 test "Invalid JSON integers",
    requires => [ local_user_and_room_fixtures(
-      room_opts => { room_version => "org.matrix.strict_canonicaljson" }
+      room_opts => { room_version => "6" }
    ), ],
 
    do => sub {
@@ -31,7 +31,7 @@ test "Invalid JSON integers",
 # Floats (including NaN, Infinity, and -Infinity) should be rejected.
 test "Invalid JSON floats",
    requires => [ local_user_and_room_fixtures(
-      room_opts => { room_version => "org.matrix.strict_canonicaljson" }
+      room_opts => { room_version => "6" }
    ), ],
 
    do => sub {

--- a/tests/80torture/20json.pl
+++ b/tests/80torture/20json.pl
@@ -27,3 +27,51 @@ test "Invalid JSON integers",
          )->followed_by( \&main::expect_http_400 ),
       );
    };
+
+# Floats (including NaN, Infinity, and -Infinity) should be rejected.
+test "Invalid JSON floats",
+   requires => [ local_user_and_room_fixtures(
+      room_opts => { room_version => "org.matrix.strict_canonicaljson" }
+   ), ],
+
+   do => sub {
+      my ( $user, $room_id ) = @_;
+
+      Future->needs_all(
+         do_request_json_for( $user,
+            method  => "POST",
+            uri     => "/r0/rooms/$room_id/send/sytest.dummy",
+            content => {
+               msgtype => "sytest.dummy",
+               body    => 1.1,
+            },
+         )->followed_by( \&main::expect_http_400 ),
+
+         do_request_json_for( $user,
+            method  => "PUT",
+            uri     => "/r0/rooms/$room_id/send/sytest.dummy",
+            content => {
+               msgtype => "sytest.dummy",
+               body    => "NaN",
+            },
+         )->followed_by( \&main::expect_http_400 ),
+
+         do_request_json_for( $user,
+            method  => "PUT",
+            uri     => "/r0/rooms/$room_id/send/sytest.dummy",
+            content => {
+               msgtype => "sytest.dummy",
+               body    => "inf",
+            },
+         )->followed_by( \&main::expect_http_400 ),
+
+         do_request_json_for( $user,
+            method  => "PUT",
+            uri     => "/r0/rooms/$room_id/send/sytest.dummy",
+            content => {
+               msgtype => "sytest.dummy",
+               body    => "-inf",
+            },
+         )->followed_by( \&main::expect_http_400 ),
+      );
+   };

--- a/tests/80torture/20json.pl
+++ b/tests/80torture/20json.pl
@@ -15,7 +15,7 @@ test "Invalid JSON integers",
                msgtype => "sytest.dummy",
                body    => 9007199254740992,  # 2 ** 53
             },
-         )->main::expect_bad_json,
+         )->main::expect_m_bad_json,
 
          do_request_json_for( $user,
             method  => "POST",
@@ -24,7 +24,7 @@ test "Invalid JSON integers",
                msgtype => "sytest.dummy",
                body    => -9007199254740992,  # -2 ** 53
             },
-         )->main::expect_bad_json,
+         )->main::expect_m_bad_json,
       );
    };
 
@@ -44,7 +44,7 @@ test "Invalid JSON floats",
             msgtype => "sytest.dummy",
             body    => 1.1,
          },
-      )->main::expect_bad_json;
+      )->main::expect_m_bad_json;
    };
 
 # Special values (like inf/nan) should be rejected. Note that these values are

--- a/tests/80torture/20json.pl
+++ b/tests/80torture/20json.pl
@@ -1,6 +1,8 @@
 # Test integers that are outside of the range of [-2 ^ 53 + 1, 2 ^ 53 - 1].
 test "Invalid JSON integers",
-   requires => [ local_user_and_room_fixtures() ],
+   requires => [ local_user_and_room_fixtures(
+      room_opts => { room_version => "org.matrix.strict_canonicaljson" }
+   ), ],
 
    do => sub {
       my ( $user, $room_id ) = @_;

--- a/tests/80torture/20json.pl
+++ b/tests/80torture/20json.pl
@@ -50,6 +50,9 @@ test "Invalid JSON floats",
 # Special values (like inf/nan) should be rejected. Note that these values are
 # not technically valid JSON, but extensions that some programming languages
 # support automatically.
+#
+# Note that these tests don't explictely check for M_BAD_JSON since the
+# homeserver's parser might not even be able to parse the string.
 test "Invalid JSON special values",
    requires => [ local_user_and_room_fixtures(
       room_opts => { room_version => "6" }
@@ -69,7 +72,7 @@ test "Invalid JSON special values",
                msgtype => "sytest.dummy",
                body    => "NaN" + 0,
             },
-         )->main::expect_bad_json,
+         )->main::expect_http_400,
 
          do_request_json_for( $user,
             method  => "POST",
@@ -78,7 +81,7 @@ test "Invalid JSON special values",
                msgtype => "sytest.dummy",
                body    => "inf" + 0,
             },
-         )->main::expect_bad_json,
+         )->main::expect_http_400,
 
          do_request_json_for( $user,
             method  => "POST",
@@ -87,7 +90,7 @@ test "Invalid JSON special values",
                msgtype => "sytest.dummy",
                body    => "-inf" + 0,
             },
-         )->main::expect_bad_json,
+         )->main::expect_http_400,
 
          # Try some Python magic values.
          $user->http->do_request(
@@ -98,7 +101,7 @@ test "Invalid JSON special values",
             },
             content      => '{"msgtype": "sytest.dummy", "body": Infinity}',
             content_type => "application/json",
-         )->main::expect_bad_json,
+         )->main::expect_http_400,
 
          $user->http->do_request(
             method       => "POST",
@@ -108,7 +111,7 @@ test "Invalid JSON special values",
             },
             content      => '{"msgtype": "sytest.dummy", "body": -Infinity}',
             content_type => "application/json",
-         )->main::expect_bad_json,
+         )->main::expect_http_400,
 
          $user->http->do_request(
             method       => "POST",
@@ -118,6 +121,6 @@ test "Invalid JSON special values",
             },
             content      => '{"msgtype": "sytest.dummy", "body": NaN}',
             content_type => "application/json",
-         )->main::expect_bad_json,
+         )->main::expect_http_400,
       );
    };

--- a/tests/80torture/20json.pl
+++ b/tests/80torture/20json.pl
@@ -18,7 +18,7 @@ test "Invalid JSON integers",
          )->followed_by( \&main::expect_http_400 ),
 
          do_request_json_for( $user,
-            method  => "PUT",
+            method  => "POST",
             uri     => "/r0/rooms/$room_id/send/sytest.dummy",
             content => {
                msgtype => "sytest.dummy",
@@ -48,7 +48,7 @@ test "Invalid JSON floats",
          )->followed_by( \&main::expect_http_400 ),
 
          do_request_json_for( $user,
-            method  => "PUT",
+            method  => "POST",
             uri     => "/r0/rooms/$room_id/send/sytest.dummy",
             content => {
                msgtype => "sytest.dummy",
@@ -57,7 +57,7 @@ test "Invalid JSON floats",
          )->followed_by( \&main::expect_http_400 ),
 
          do_request_json_for( $user,
-            method  => "PUT",
+            method  => "POST",
             uri     => "/r0/rooms/$room_id/send/sytest.dummy",
             content => {
                msgtype => "sytest.dummy",
@@ -66,7 +66,7 @@ test "Invalid JSON floats",
          )->followed_by( \&main::expect_http_400 ),
 
          do_request_json_for( $user,
-            method  => "PUT",
+            method  => "POST",
             uri     => "/r0/rooms/$room_id/send/sytest.dummy",
             content => {
                msgtype => "sytest.dummy",

--- a/tests/80torture/20json.pl
+++ b/tests/80torture/20json.pl
@@ -28,7 +28,7 @@ test "Invalid JSON integers",
       );
    };
 
-# Floats (including NaN, Infinity, and -Infinity) should be rejected.
+# Floats should be rejected.
 test "Invalid JSON floats",
    requires => [ local_user_and_room_fixtures(
       room_opts => { room_version => "6" }
@@ -37,16 +37,31 @@ test "Invalid JSON floats",
    do => sub {
       my ( $user, $room_id ) = @_;
 
-      Future->needs_all(
-         do_request_json_for( $user,
-            method  => "POST",
-            uri     => "/r0/rooms/$room_id/send/sytest.dummy",
-            content => {
-               msgtype => "sytest.dummy",
-               body    => 1.1,
-            },
-         )->followed_by( \&main::expect_http_400 ),
+      do_request_json_for( $user,
+         method  => "POST",
+         uri     => "/r0/rooms/$room_id/send/sytest.dummy",
+         content => {
+            msgtype => "sytest.dummy",
+            body    => 1.1,
+         },
+      )->followed_by( \&main::expect_http_400 );
+   };
 
+# Special values (like inf/nan) should be rejected. Note that these values are
+# not technically valid JSON, but extensions that some programming languages
+# support automatically.
+test "Invalid JSON special values",
+   requires => [ local_user_and_room_fixtures(
+      room_opts => { room_version => "6" }
+   ), ],
+
+   do => sub {
+      my ( $user, $room_id ) = @_;
+
+      my $http = $user->http;
+
+      Future->needs_all(
+         # Try some Perl magic values.
          do_request_json_for( $user,
             method  => "POST",
             uri     => "/r0/rooms/$room_id/send/sytest.dummy",
@@ -72,6 +87,37 @@ test "Invalid JSON floats",
                msgtype => "sytest.dummy",
                body    => "-inf" + 0,
             },
+         )->followed_by( \&main::expect_http_400 ),
+
+         # Try some Python magic values.
+         $user->http->do_request(
+            method       => "POST",
+            uri          => "/r0/rooms/$room_id/send/sytest.dummy",
+            params       => {
+               access_token => $user->access_token,
+            },
+            content      => '{"msgtype": "sytest.dummy", "body": Infinity}',
+            content_type => "application/json",
+         )->followed_by( \&main::expect_http_400 ),
+
+         $user->http->do_request(
+            method       => "POST",
+            uri          => "/r0/rooms/$room_id/send/sytest.dummy",
+            params       => {
+               access_token => $user->access_token,
+            },
+            content      => '{"msgtype": "sytest.dummy", "body": -Infinity}',
+            content_type => "application/json",
+         )->followed_by( \&main::expect_http_400 ),
+
+         $user->http->do_request(
+            method       => "POST",
+            uri          => "/r0/rooms/$room_id/send/sytest.dummy",
+            params       => {
+               access_token => $user->access_token,
+            },
+            content      => '{"msgtype": "sytest.dummy", "body": NaN}',
+            content_type => "application/json",
          )->followed_by( \&main::expect_http_400 ),
       );
    };

--- a/tests/80torture/20json.pl
+++ b/tests/80torture/20json.pl
@@ -1,0 +1,27 @@
+# Test integers that are outside of the range of [-2 ^ 53 + 1, 2 ^ 53 - 1].
+test "Invalid JSON integers",
+   requires => [ local_user_and_room_fixtures() ],
+
+   do => sub {
+      my ( $user, $room_id ) = @_;
+
+      Future->needs_all(
+         do_request_json_for( $user,
+            method  => "POST",
+            uri     => "/r0/rooms/$room_id/send/sytest.dummy",
+            content => {
+               msgtype => "sytest.dummy",
+               body    => 9007199254740992,  # 2 ** 53
+            },
+         )->followed_by( \&main::expect_http_400 ),
+
+         do_request_json_for( $user,
+            method  => "PUT",
+            uri     => "/r0/rooms/$room_id/send/sytest.dummy",
+            content => {
+               msgtype => "sytest.dummy",
+               body    => -9007199254740992,  # -2 ** 53
+            },
+         )->followed_by( \&main::expect_http_400 ),
+      );
+   };


### PR DESCRIPTION
This adds some sytests for room version 6, mostly geared around the integer validation of [MSC2540](https://github.com/matrix-org/matrix-doc/pull/2540).

This requires matrix-org/synapse#7506

### To Do:

Bad event sent to:
* [x] `/_matrix/federation/v1/send`
* [x] `/_matrix/federation/vN/send_join`
* [x] `/_matrix/federation/vN/send_leave`
* [x] `/_matrix/federation/vN/invite`

Bad event returned from:
* [x] `/_matrix/federation/v1/backfill/{roomId}`
* [x] `/_matrix/federation/v1/get_missing_events/{roomId}`
