### PR TITLE
Have frontend proxy persist events when using redis

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -295,9 +295,8 @@ sub start
         max_mau_value => 50000000,
 
         redis => {
-           enabled  => $self->{redis_host} ne '',
-           password => "foobar",
-           host     => $self->{redis_host},
+           enabled => $self->{redis_host} ne '',
+           host    => $self->{redis_host},
         },
 
         map {

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -284,7 +284,7 @@ sub start
            },
         },
 
-        writers => {
+        stream_writers => {
            events => $self->{redis_host} ne '' ? "frontend_proxy1" : "master",
         },
 

--- a/tests/10apidoc/33room-members.pl
+++ b/tests/10apidoc/33room-members.pl
@@ -496,6 +496,8 @@ sub matrix_create_and_join_room
          } @local_members,
       )
    })->then( sub {
+      log_if_fail "Created room_id=$room_id";
+
       Future->done( $room_id,
          ( $with_alias ? ( $room_alias_fullname ) : () )
       );
@@ -660,7 +662,7 @@ sub matrix_join_room_synced
 
    matrix_do_and_wait_for_sync( $user,
       do => sub {
-         matrix_join_room( $user, $room_id_or_alias, %params );
+         retry_until_success { matrix_join_room( $user, $room_id_or_alias, %params ) }
       },
       check => sub { exists $_[0]->{rooms}{join}{$_[1]} },
    );

--- a/tests/10apidoc/36room-levels.pl
+++ b/tests/10apidoc/36room-levels.pl
@@ -139,7 +139,7 @@ sub matrix_change_room_power_levels
       my ( $levels ) = @_;
       $func->( $levels );
 
-      matrix_put_room_state( $user, $room_id, type => "m.room.power_levels",
+      matrix_put_room_state_synced( $user, $room_id, type => "m.room.power_levels",
          content => $levels,
       );
    });

--- a/tests/30rooms/06invite.pl
+++ b/tests/30rooms/06invite.pl
@@ -137,7 +137,7 @@ sub invited_user_can_reject_invite
 
    matrix_invite_user_to_room( $creator, $invitee, $room_id )
    ->then( sub {
-      matrix_leave_room( $invitee, $room_id )
+      matrix_leave_room_synced( $invitee, $room_id )
    })->then( sub {
       matrix_get_room_state( $creator, $room_id,
          type      => "m.room.member",

--- a/tests/30rooms/07ban.pl
+++ b/tests/30rooms/07ban.pl
@@ -16,15 +16,19 @@ test "Banned user is kicked and may not rejoin until unbanned",
 
          content => { user_id => $banned_user->user_id, reason => "testing" },
       )->then( sub {
-         matrix_get_room_state( $creator, $room_id,
-            type      => "m.room.member",
-            state_key => $banned_user->user_id,
-         )
-      })->then( sub {
-         my ( $body ) = @_;
-         $body->{membership} eq "ban" or
-            die "Expected banned user membership to be 'ban'";
+         retry_until_success {
+            matrix_get_room_state( $creator, $room_id,
+               type      => "m.room.member",
+               state_key => $banned_user->user_id,
+            )->then( sub {
+               my ( $body ) = @_;
+               $body->{membership} eq "ban" or
+                  die "Expected banned user membership to be 'ban'";
 
+               Future->done( 1 )
+            })
+         }
+      })->then( sub {
          matrix_join_room( $banned_user, $room_id )
             ->main::expect_http_403;  # Must be unbanned first
       })->then( sub {
@@ -75,15 +79,19 @@ test "Remote banned user is kicked and may not rejoin until unbanned",
 
          content => { user_id => $banned_user->user_id, reason => "testing" },
       )->then( sub {
-         matrix_get_room_state( $creator, $room_id,
-            type      => "m.room.member",
-            state_key => $banned_user->user_id,
-         )
-      })->then( sub {
-         my ( $body ) = @_;
-         $body->{membership} eq "ban" or
-            die "Expected banned user membership to be 'ban'";
+         retry_until_success {
+            matrix_get_room_state( $creator, $room_id,
+               type      => "m.room.member",
+               state_key => $banned_user->user_id,
+            )->then( sub {
+               my ( $body ) = @_;
+               $body->{membership} eq "ban" or
+                  die "Expected banned user membership to be 'ban'";
 
+               Future->done( 1 )
+            })
+         }
+      })->then( sub {
          repeat_until_true {
             matrix_get_room_state( $banned_user, $room_id,
                type      => "m.room.member",

--- a/tests/30rooms/12thirdpartyinvite.pl
+++ b/tests/30rooms/12thirdpartyinvite.pl
@@ -242,11 +242,13 @@ sub can_invite_unbound_3pid
          matrix_join_room( $invitee, $room_id )
       }
    })->then( sub {
-      matrix_get_room_state( $inviter, $room_id,
-         type      => "m.room.member",
-         state_key => $invitee->user_id,
-      )
-   })->followed_by( assert_membership( "join" ) );
+      retry_until_success {
+         matrix_get_room_state( $inviter, $room_id,
+            type      => "m.room.member",
+            state_key => $invitee->user_id,
+         )->followed_by( assert_membership( "join" ) )
+      }
+   })
 }
 
 test "Can invite unbound 3pid over federation with users from both servers",

--- a/tests/31sync/06state.pl
+++ b/tests/31sync/06state.pl
@@ -774,7 +774,7 @@ test "Current state appears in timeline in private history with many messages be
                  qw( can_sync ) ],
 
    # sending 50 messages can take a while
-   timeout => 20000,
+   timeout => 20,
 
    check => sub {
       my ( $creator, $syncer, $invitee ) = @_;
@@ -834,7 +834,7 @@ test "Current state appears in timeline in private history with many messages af
                  qw( can_sync ) ],
 
    # sending 50 messages can take a while
-   timeout => 20000,
+   timeout => 20,
 
    check => sub {
       my ( $creator, $syncer, $invitee ) = @_;

--- a/tests/31sync/15lazy-members.pl
+++ b/tests/31sync/15lazy-members.pl
@@ -286,7 +286,7 @@ test "The only membership state included in a gapped incremental sync is for sen
 
 test "Gapped incremental syncs include all state changes",
    # sending 50 messages can take a while
-   timeout => 20000,
+   timeout => 20,
 
    requires => [ local_user_fixtures( 4 ),
                  qw( can_sync ) ],

--- a/tests/41end-to-end-keys/06-device-lists.pl
+++ b/tests/41end-to-end-keys/06-device-lists.pl
@@ -180,12 +180,12 @@ test "Can query remote device keys using POST after notification",
 
       my $room_id;
 
-      matrix_create_room( $user1 )->then( sub {
+      matrix_create_room_synced( $user1 )->then( sub {
          ( $room_id ) = @_;
 
-         matrix_invite_user_to_room( $user1, $user2, $room_id )
+         matrix_invite_user_to_room_synced( $user1, $user2, $room_id )
       })->then( sub {
-         matrix_join_room( $user2, $room_id );
+         matrix_join_room_synced( $user2, $room_id );
       })->then( sub {
          matrix_sync( $user1 );
       })->then( sub {
@@ -236,12 +236,12 @@ test "Device deletion propagates over federation",
 
       my $room_id;
 
-      matrix_create_room( $user1 )->then( sub {
+      matrix_create_room_synced( $user1 )->then( sub {
          ( $room_id ) = @_;
 
-         matrix_invite_user_to_room( $user1, $user2, $room_id )
+         matrix_invite_user_to_room_synced( $user1, $user2, $room_id )
       })->then( sub {
-         matrix_join_room( $user2, $room_id );
+         matrix_join_room_synced( $user2, $room_id );
       })->then( sub {
          matrix_sync( $user1 );
       })->then( sub {
@@ -295,12 +295,12 @@ test "If remote user leaves room, changes device and rejoins we see update in sy
 
       my $room_id;
 
-      matrix_create_room( $creator,
+      matrix_create_room_synced( $creator,
          invite => [ $remote_leaver->user_id ],
       )->then( sub {
          ( $room_id ) = @_;
 
-         matrix_join_room( $remote_leaver, $room_id );
+         matrix_join_room_synced( $remote_leaver, $room_id );
       })->then( sub {
          matrix_sync( $creator );
       })->then( sub {
@@ -344,18 +344,18 @@ test "If remote user leaves room we no longer receive device updates",
 
       my $room_id;
 
-      matrix_create_room( $creator )->then( sub {
+      matrix_create_room_synced( $creator )->then( sub {
          ( $room_id ) = @_;
 
          matrix_sync( $creator );
       })->then( sub {
-         matrix_invite_user_to_room( $creator, $remote_leaver, $room_id )
+         matrix_invite_user_to_room_synced( $creator, $remote_leaver, $room_id )
       })->then( sub {
-         matrix_join_room( $remote_leaver, $room_id );
+         matrix_join_room_synced( $remote_leaver, $room_id );
       })->then( sub {
-         matrix_invite_user_to_room( $creator, $remote2, $room_id )
+         matrix_invite_user_to_room_synced( $creator, $remote2, $room_id )
       })->then( sub {
-         matrix_join_room( $remote2, $room_id );
+         matrix_join_room_synced( $remote2, $room_id );
       })->then( sub {
          log_if_fail "Created and joined room";
 
@@ -442,10 +442,10 @@ test "Local device key changes appear in /keys/changes",
 
       my ( $room_id, $from_token, $to_token );
 
-      matrix_create_room( $user1 )->then( sub {
+      matrix_create_room_synced( $user1 )->then( sub {
          ( $room_id ) = @_;
 
-         matrix_join_room( $user2, $room_id );
+         matrix_join_room_synced( $user2, $room_id );
       })->then( sub {
          matrix_sync( $user1 );
       })->then( sub {
@@ -504,7 +504,7 @@ test "New users appear in /keys/changes",
 
       my ( $room_id, $from_token, $to_token );
 
-      matrix_create_room( $user1 )->then( sub {
+      matrix_create_room_synced( $user1 )->then( sub {
          ( $room_id ) = @_;
 
          matrix_sync( $user1 );
@@ -556,12 +556,12 @@ test "If remote user leaves room, changes device and rejoins we see update in /k
 
       my ( $room_id, $from_token, $to_token );
 
-      matrix_create_room( $creator,
+      matrix_create_room_synced( $creator,
          invite => [ $remote_leaver->user_id ],
       )->then( sub {
          ( $room_id ) = @_;
 
-         matrix_join_room( $remote_leaver, $room_id );
+         matrix_join_room_synced( $remote_leaver, $room_id );
       })->then( sub {
          matrix_sync( $creator );
       })->then( sub {
@@ -618,12 +618,12 @@ test "Get left notifs in sync and /keys/changes when other user leaves",
 
       my ( $room_id, $from_token );
 
-      matrix_create_room( $creator,
+      matrix_create_room_synced( $creator,
          invite => [ $other_user->user_id ],
       )->then( sub {
          ( $room_id ) = @_;
 
-         matrix_join_room( $other_user, $room_id );
+         matrix_join_room_synced( $other_user, $room_id );
       })->then( sub {
          matrix_sync( $creator );
       })->then( sub {
@@ -674,12 +674,12 @@ test "Get left notifs for other users in sync and /keys/changes when user leaves
 
       my ( $room_id, $from_token );
 
-      matrix_create_room( $creator,
+      matrix_create_room_synced( $creator,
          invite => [ $other_user->user_id ],
       )->then( sub {
          ( $room_id ) = @_;
 
-         matrix_join_room( $other_user, $room_id );
+         matrix_join_room_synced( $other_user, $room_id );
       })->then( sub {
          matrix_sync( $creator );
       })->then( sub {
@@ -729,7 +729,7 @@ test "If user leaves room, remote user changes device and rejoins we see update 
 
       my ( $room_id, $from_token, $to_token );
 
-      matrix_create_room( $creator,
+      matrix_create_room_synced( $creator,
          invite => [ $remote_user->user_id ],
          preset => "private_chat",  # Allow default PL users to invite others
       )->then( sub {

--- a/tests/41end-to-end-keys/06-device-lists.pl
+++ b/tests/41end-to-end-keys/06-device-lists.pl
@@ -735,7 +735,7 @@ test "If user leaves room, remote user changes device and rejoins we see update 
       )->then( sub {
          ( $room_id ) = @_;
 
-         matrix_join_room( $remote_user, $room_id );
+         matrix_join_room_synced( $remote_user, $room_id );
       })->then( sub {
          matrix_sync( $creator );
       })->then( sub {
@@ -757,7 +757,7 @@ test "If user leaves room, remote user changes device and rejoins we see update 
             matrix_invite_user_to_room( $remote_user, $creator, $room_id )
          }
       })->then( sub {
-         matrix_join_room( $creator, $room_id );
+         matrix_join_room_synced( $creator, $room_id )
       })->then( sub {
          sync_until_user_in_device_list(
             $creator, $remote_user, msg => 'Second body',

--- a/tests/48admin.pl
+++ b/tests/48admin.pl
@@ -387,6 +387,8 @@ multi_test "Shutdown room",
 
          $new_room_id = $body->{new_room_id};
 
+         log_if_fail "Shutdown room, new room ID", $new_room_id;
+
          matrix_send_room_text_message( $user, $room_id, body => "Hello" )
          ->main::expect_http_403;
       })->SyTest::pass_on_done( "User cannot post in room" )
@@ -412,12 +414,13 @@ multi_test "Shutdown room",
 
          pass( "Aliases were repointed" );
 
-         matrix_get_room_state( $user, $new_room_id,
-            type      => "m.room.name",
-            state_key => "",
-         );
-      })->SyTest::pass_on_done( "User was added to new room" )
-      ->then( sub {
+         retry_until_success {
+            matrix_get_room_state( $user, $new_room_id,
+               type      => "m.room.name",
+               state_key => "",
+            )->SyTest::pass_on_done( "User was added to new room" )
+         }
+      })->then( sub {
          matrix_send_room_text_message( $user, $new_room_id, body => "Hello" )
          ->main::expect_http_403;
       })->SyTest::pass_on_done( "User cannot send into new room" );

--- a/tests/50federation/31room-send.pl
+++ b/tests/50federation/31room-send.pl
@@ -156,8 +156,8 @@ test "Ephemeral messages received from servers are correctly expired",
 
       my $filter = '{"types":["m.room.message"]}';
 
-      matrix_invite_user_to_room( $local_user, $federated_user, $room_id )->then( sub {
-         matrix_join_room( $federated_user, $room_id )
+      matrix_invite_user_to_room_synced( $local_user, $federated_user, $room_id )->then( sub {
+         matrix_join_room_synced( $federated_user, $room_id )
       })->then( sub {
          my $now_ms = int( time() * 1000 );
 

--- a/tests/52user-directory/01public.pl
+++ b/tests/52user-directory/01public.pl
@@ -152,7 +152,7 @@ foreach my $type (qw( join_rules history_visibility )) {
       requires => [ local_user_fixtures( 2 ) ],
 
       # matrix_get_user_dir_synced creates two new users and a room, which is kinda slow.
-      timeout => 20000,
+      timeout => 20,
 
       check => sub {
          my ( $creator, $user ) = @_;
@@ -250,7 +250,7 @@ multi_test "Users stay in directory when join_rules are changed but history_visi
    requires => [ local_user_fixtures( 2 ) ],
 
    # matrix_get_user_dir_synced creates two new users and a room, which is kinda slow.
-   timeout => 20000,
+   timeout => 20,
 
    check => sub {
       my ( $creator, $user ) = @_;

--- a/tests/90jira/SYN-442.pl
+++ b/tests/90jira/SYN-442.pl
@@ -68,7 +68,8 @@ multi_test "Test that we can be reinvited to a room we created",
          })->SyTest::pass_on_done( "User A received the invite from user B" )
       })->then( sub {
 
-         matrix_join_room( $user_1, $room_id )
-            ->SyTest::pass_on_done( "User A joined the room" )
+         retry_until_success {
+            matrix_join_room( $user_1, $room_id )
+         }->SyTest::pass_on_done( "User A joined the room" )
       })->then_done(1);
    };


### PR DESCRIPTION
Requires: https://github.com/matrix-org/synapse/pull/7517

I chose to use frontend proxy rather than the event creator to ensure we test the HTTP replication routing. (We could use a new worker, but that is surprisingly faffy)