### PR TITLE
Fix race in 'Outbound federation can backfill events'

### DIFF
--- a/tests/50federation/34room-backfill.pl
+++ b/tests/50federation/34room-backfill.pl
@@ -76,67 +76,61 @@ test "Outbound federation can backfill events",
                },
             );
          })->then( sub {
+            # 10 m.room.message events + my own m.room.member
+            my $want_count = 11;
 
-            # It make take some time for the join to propagate, so we need to
-            # retry on failure.
-            retry_until_success {
+            # We may have to get more than once to have all 11 events
 
-               # 10 m.room.message events + my own m.room.member
-               my $want_count = 11;
+            my $token;
+            my @events;
 
-               # We may have to get more than once to have all 11 events
+            (
+               repeat {
+                  matrix_get_room_messages( $user, $room_id,
+                     limit => $want_count - scalar(@events),
+                     from  => $token,
+                  )->then( sub {
+                     my ( $body ) = @_;
+                     push @events, @{ $body->{chunk} };
 
-               my $token;
-               my @events;
+                     $token = $body->{end};
+                     Future->done;
+                  });
+               } while => sub { !shift->failure and @events < $want_count }
+            )->then( sub {
+               log_if_fail "Events", \@events;
 
-               (
-                  repeat {
-                     matrix_get_room_messages( $user, $room_id,
-                        limit => $want_count - scalar(@events),
-                        from  => $token,
-                     )->then( sub {
-                        my ( $body ) = @_;
-                        push @events, @{ $body->{chunk} };
+               assert_json_keys( $events[0], qw( type event_id room_id ));
+               assert_eq( $events[0]->{type}, "m.room.member",
+                  'events[0] type' );
 
-                        $token = $body->{end};
-                        Future->done;
-                     });
-                  } while => sub { !shift->failure and @events < $want_count }
-               )->then( sub {
-                  log_if_fail "Events", \@events;
+               my $member_event = shift @events;
+               assert_json_keys( $member_event,
+                  qw( type event_id room_id sender state_key content ));
 
-                  assert_json_keys( $events[0], qw( type event_id room_id ));
-                  assert_eq( $events[0]->{type}, "m.room.member",
-                     'events[0] type' );
+               assert_eq( $member_event->{type}, "m.room.member",
+                  'member event type' );
+               assert_eq( $member_event->{room_id}, $room_id,
+                  'member event room_id' );
+               assert_eq( $member_event->{sender}, $user->user_id,
+                  'member event sender' );
+               assert_eq( $member_event->{state_key}, $user->user_id,
+                  'member event state_key' );
+               assert_eq( $member_event->{content}{membership}, "join",
+                  'member event content.membership' );
 
-                  my $member_event = shift @events;
-                  assert_json_keys( $member_event,
-                     qw( type event_id room_id sender state_key content ));
+               foreach my $message ( @events ) {
+                  assert_json_keys( $message, qw( type event_id room_id sender ));
+                  assert_eq( $message->{type}, "m.room.message",
+                     'message type' );
+                  assert_eq( $message->{room_id}, $room_id,
+                     'message room_id' );
+                  assert_eq( $message->{sender}, $creator_id,
+                     'message sender' );
+               }
 
-                  assert_eq( $member_event->{type}, "m.room.member",
-                     'member event type' );
-                  assert_eq( $member_event->{room_id}, $room_id,
-                     'member event room_id' );
-                  assert_eq( $member_event->{sender}, $user->user_id,
-                     'member event sender' );
-                  assert_eq( $member_event->{state_key}, $user->user_id,
-                     'member event state_key' );
-                  assert_eq( $member_event->{content}{membership}, "join",
-                     'member event content.membership' );
-
-                  foreach my $message ( @events ) {
-                     assert_json_keys( $message, qw( type event_id room_id sender ));
-                     assert_eq( $message->{type}, "m.room.message",
-                        'message type' );
-                     assert_eq( $message->{room_id}, $room_id,
-                        'message room_id' );
-                     assert_eq( $message->{sender}, $creator_id,
-                        'message sender' );
-                  }
-
-                  Future->done(1);
-               });
-            }
+               Future->done(1);
+            });
          }),
       )
    };


### PR DESCRIPTION
This test will issue a `/join` for a remote room alias then attempt
to backpaginate in the room. The way the backpagination works
presents a race condition. Previously it:
 - Sent the `/join`, wait for 200 OK.
 - Hit `/sync` and remember `next_batch`
 - Hit `/messages` with `next_batch`.
 - If not enough messages, hit `/messages` again with `end` token from
   `/messages`.

In Dendrite, it's possible that `/sync` has not seen the join membership
event yet, resulting in a `next_batch` that represents the state *before*
the membership event. Backpagination then gets messages prior to the join
event, when the test expects it to include the join event. The fix is to
wait for the `m.room.member` event to come down `/sync` and THEN use the
`next_batch` token.