### PR TITLE
Add API environment variable for Dendrite monolith

### DIFF
--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -282,6 +282,9 @@ sub _start_monolith
       '--tls-key', $self->{paths}{tls_key},
    );
 
+   push(@command, '-api') if $ENV{'API'} == '1';
+   $output->diag( "Starting Dendrite with: @command" );
+
    return $self->_start_process_and_await_connectable(
       setup => [
          env => {


### PR DESCRIPTION
This is to go hand-in-hand with matrix-org/dendrite#1057. 