### PR TITLE
Remove room alias check for createRoom response

### DIFF
--- a/tests/10apidoc/30room-create.pl
+++ b/tests/10apidoc/30room-create.pl
@@ -23,7 +23,6 @@ test "POST /createRoom makes a public room",
 
          assert_json_keys( $body, qw( room_id room_alias ));
          assert_json_nonempty_string( $body->{room_id} );
-         assert_json_nonempty_string( $body->{room_alias} );
 
          Future->done(1);
       });


### PR DESCRIPTION
It seems in the spec that room creation response does not have a room_alias. 

Check this issue for more information: https://git.koesters.xyz/timo/conduit/issues/23.