### PR TITLE
Add ability to exclude tests for deprecated endpoints

### DIFF
--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -50,6 +50,11 @@ is described in more detail in the following sections.
     Provides an ``ARRAY`` reference giving a list of named requirements and
     fixture objects.
 
+``deprecated_endpoints``
+    A flag to indicate whether the test targets endpoints that have been
+    deprecated in the spec. These tests will be ignored automatically if
+    the ``--exclude-deprecated`` flag is provided to Sytest. 
+
 A call to ``test`` is a simplified version of ``multi_test`` which produces
 only a single line of test output indicating success or failure automatically.
 A call to ``multi_test`` can make use of additional functions within the body

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -182,8 +182,8 @@ Options:
    -n, --no-tls                 - prefer plaintext client connections where
                                   possible
 
-       --exclude-deprecated     - don't run tests that claim to use deprecated
-                                  endpoints
+       --exclude-deprecated     - don't run tests that specifically test deprecated
+	                              endpoints
 
        --bind-host HOST         - when starting listeners (eg homeservers or
                                   test httpds), bind to this hostname instead of
@@ -866,7 +866,7 @@ TESTS: foreach my $test ( @TESTS ) {
 
    my $m = $test->multi ? "enter_multi_test" : "enter_test";
 
-   # If the test claims to require deprecated endpoints and we're not allowing those
+   # If the test specifically tests deprecated endpoints and we're not allowing those
    # then skip the test altogether - there's no point in even showing it as skipped.
    my @requires = @{ $test->requires // [] };
    foreach my $req ( @requires ) {

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -183,7 +183,7 @@ Options:
                                   possible
 
        --exclude-deprecated     - don't run tests that specifically test deprecated
-	                              endpoints
+                                  endpoints
 
        --bind-host HOST         - when starting listeners (eg homeservers or
                                   test httpds), bind to this hostname instead of
@@ -866,7 +866,7 @@ $OUTPUT->status(
 
 # Now run the tests
 my $prev_filename;
-TESTS: foreach my $test ( @TESTS ) {
+foreach my $test ( @TESTS ) {
    if( !$prev_filename or $prev_filename ne $test->file ) {
       $OUTPUT->run_file( $prev_filename = $test->file );
    }

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -919,7 +919,7 @@ TESTS: foreach my $test ( @TESTS ) {
       passed  => $passed_count,
       failed  => $failed_count,
       skipped => $skipped_count,
-	  excluded => $excluded_count,
+      excluded => $excluded_count,
    );
 }
 

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -617,7 +617,7 @@ sub _push_test
    }
 
    if( $params{deprecated_endpoints} ) {
-       if ( $INCLUDE_DEPRECATED_ENDPOINTS ) {
+       if ( !$INCLUDE_DEPRECATED_ENDPOINTS ) {
            $excluded_count ++;
            return;
        }

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -616,6 +616,13 @@ sub _push_test
       return;
    }
 
+   if( $params{deprecated_endpoints} ) {
+       if ( $INCLUDE_DEPRECATED_ENDPOINTS ) {
+           $excluded_count ++;
+           return;
+       }
+   }
+
    push @TESTS, Test( $filename, $name, $multi,
       @params{qw( expect_fail proves requires check do timeout )} );
 }
@@ -865,16 +872,6 @@ TESTS: foreach my $test ( @TESTS ) {
    }
 
    my $m = $test->multi ? "enter_multi_test" : "enter_test";
-
-   # If the test specifically tests deprecated endpoints and we're not allowing those
-   # then skip the test altogether - there's no point in even showing it as skipped.
-   my @requires = @{ $test->requires // [] };
-   foreach my $req ( @requires ) {
-		if ($req eq "deprecated_endpoints" && !$INCLUDE_DEPRECATED_ENDPOINTS) {
-		   $excluded_count++;
-		   next TESTS;
-		}
-   }
 
    # Check if this test has been blocked by the blacklist. If so, mark as expected fail
    if ( scalar( $BLACKLIST_FILE ) and exists $TEST_BLACKLIST{ $test->name } ) {

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -618,7 +618,6 @@ sub _push_test
 
    if( $params{deprecated_endpoints} ) {
        if ( !$INCLUDE_DEPRECATED_ENDPOINTS ) {
-           $excluded_count ++;
            return;
        }
    }
@@ -853,7 +852,6 @@ my $failed_count = 0;
 my $expected_fail_count = 0;
 my $passed_count = 0;
 my $skipped_count = 0;
-my $excluded_count = 0;
 
 $OUTPUT->status(
    tests   => scalar @TESTS,
@@ -861,7 +859,6 @@ $OUTPUT->status(
    passed  => $passed_count,
    failed  => $failed_count,
    skipped => $skipped_count,
-   excluded => $excluded_count,
 );
 
 # Now run the tests
@@ -916,7 +913,6 @@ foreach my $test ( @TESTS ) {
       passed  => $passed_count,
       failed  => $failed_count,
       skipped => $skipped_count,
-      excluded => $excluded_count,
    );
 }
 

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -182,19 +182,19 @@ Options:
    -n, --no-tls                 - prefer plaintext client connections where
                                   possible
 
-   --exclude-deprecated         - don't run tests that claim to use deprecated
+       --exclude-deprecated     - don't run tests that claim to use deprecated
                                   endpoints
 
-   --bind-host HOST             - when starting listeners (eg homeservers or
+       --bind-host HOST         - when starting listeners (eg homeservers or
                                   test httpds), bind to this hostname instead of
                                   'localhost'.
 
    -p, --port-range START:MAX   - pool of TCP ports to allocate from
 
-   --work-directory DIR         - where we put working files (server configs,
+       --work-directory DIR     - where we put working files (server configs,
                                   mostly). Defaults to '.'.
 
-   --room-version VERSION       - use the given room version for the majority of
+       --room-version VERSION   - use the given room version for the majority of
                                   tests
 .
    write STDERR;

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -44,7 +44,7 @@ echo >&2 "+++ Running tests"
 TEST_STATUS=0
 mkdir -p /logs
 ./run-tests.pl -I Dendrite::Monolith -d $GOBIN -W /src/sytest-whitelist -O tap --all \
-    --work-directory="/work" \
+    --work-directory="/work" --exclude-deprecated \
     "$@" > /logs/results.tap || TEST_STATUS=$?
 
 if [ $TEST_STATUS -ne 0 ]; then

--- a/tests/10apidoc/03events-initial.pl
+++ b/tests/10apidoc/03events-initial.pl
@@ -2,7 +2,7 @@ use List::UtilsBy qw( extract_first_by );
 use Future::Utils qw( repeat );
 
 test "GET /events initially",
-   requires => [ $main::SPYGLASS_USER ],
+   requires => [ $main::SPYGLASS_USER, qw ( deprecated_endpoints ) ],
 
    check => sub {
       my ( $user ) = @_;
@@ -28,7 +28,7 @@ test "GET /events initially",
    };
 
 test "GET /initialSync initially",
-   requires => [ $main::SPYGLASS_USER ],
+   requires => [ $main::SPYGLASS_USER, qw ( deprecated_endpoints ) ],
 
    proves => [qw( can_initial_sync )],
 

--- a/tests/10apidoc/03events-initial.pl
+++ b/tests/10apidoc/03events-initial.pl
@@ -2,7 +2,8 @@ use List::UtilsBy qw( extract_first_by );
 use Future::Utils qw( repeat );
 
 test "GET /events initially",
-   requires => [ $main::SPYGLASS_USER, qw ( deprecated_endpoints ) ],
+   deprecated_endpoints => 1,
+   requires => [ $main::SPYGLASS_USER ],
 
    check => sub {
       my ( $user ) = @_;
@@ -28,7 +29,8 @@ test "GET /events initially",
    };
 
 test "GET /initialSync initially",
-   requires => [ $main::SPYGLASS_USER, qw ( deprecated_endpoints ) ],
+   deprecated_endpoints => 1,
+   requires => [ $main::SPYGLASS_USER ],
 
    proves => [qw( can_initial_sync )],
 

--- a/tests/10apidoc/31room-state.pl
+++ b/tests/10apidoc/31room-state.pl
@@ -238,8 +238,10 @@ test "GET /joined_rooms lists newly-created room",
    };
 
 test "POST /rooms/:room_id/state/m.room.name sets name",
+   # TODO: deprecated endpoint used in this test
+
    requires => [ $user_fixture, $room_fixture,
-                 qw( can_room_initial_sync deprecated_endpoints )],
+                 qw( can_room_initial_sync )],
 
    proves => [qw( can_set_room_name )],
 
@@ -294,8 +296,10 @@ test "GET /rooms/:room_id/state/m.room.name gets name",
 my $topic = "A new topic for the room";
 
 test "POST /rooms/:room_id/state/m.room.topic sets topic",
+   # TODO: deprecated endpoint used in this test
+   
    requires => [ $user_fixture, $room_fixture,
-                 qw( can_room_initial_sync deprecated_endpoints )],
+                 qw( can_room_initial_sync )],
 
    proves => [qw( can_set_room_topic )],
 

--- a/tests/10apidoc/31room-state.pl
+++ b/tests/10apidoc/31room-state.pl
@@ -133,7 +133,7 @@ test "GET /rooms/:room_id/joined_members fetches my membership",
    };
 
 test "GET /rooms/:room_id/initialSync fetches initial sync state",
-   requires => [ $user_fixture, $room_fixture ],
+   requires => [ $user_fixture, $room_fixture, qw ( deprecated_endpoints ) ],
 
    proves => [qw( can_room_initial_sync )],
 
@@ -239,7 +239,7 @@ test "GET /joined_rooms lists newly-created room",
 
 test "POST /rooms/:room_id/state/m.room.name sets name",
    requires => [ $user_fixture, $room_fixture,
-                 qw( can_room_initial_sync )],
+                 qw( can_room_initial_sync deprecated_endpoints )],
 
    proves => [qw( can_set_room_name )],
 
@@ -295,7 +295,7 @@ my $topic = "A new topic for the room";
 
 test "POST /rooms/:room_id/state/m.room.topic sets topic",
    requires => [ $user_fixture, $room_fixture,
-                 qw( can_room_initial_sync )],
+                 qw( can_room_initial_sync deprecated_endpoints )],
 
    proves => [qw( can_set_room_topic )],
 

--- a/tests/10apidoc/31room-state.pl
+++ b/tests/10apidoc/31room-state.pl
@@ -133,7 +133,8 @@ test "GET /rooms/:room_id/joined_members fetches my membership",
    };
 
 test "GET /rooms/:room_id/initialSync fetches initial sync state",
-   requires => [ $user_fixture, $room_fixture, qw ( deprecated_endpoints ) ],
+   deprecated_endpoints => 1,
+   requires => [ $user_fixture, $room_fixture ],
 
    proves => [qw( can_room_initial_sync )],
 

--- a/tests/21presence-events.pl
+++ b/tests/21presence-events.pl
@@ -3,8 +3,9 @@ my $PRESENCE_LIST_URI = "/r0/presence/list/:user_id";
 
 
 test "initialSync sees my presence status",
+   deprecated_endpoints => 1,
    requires => [ local_user_fixture( with_events => 1 ),
-                 qw( can_initial_sync, deprecated_endpoints )],
+                 qw( can_initial_sync )],
 
    check => sub {
       my ( $user ) = @_;

--- a/tests/21presence-events.pl
+++ b/tests/21presence-events.pl
@@ -4,7 +4,7 @@ my $PRESENCE_LIST_URI = "/r0/presence/list/:user_id";
 
 test "initialSync sees my presence status",
    requires => [ local_user_fixture( with_events => 1 ),
-                 qw( can_initial_sync )],
+                 qw( can_initial_sync, deprecated_endpoints )],
 
    check => sub {
       my ( $user ) = @_;

--- a/tests/30rooms/01state.pl
+++ b/tests/30rooms/01state.pl
@@ -265,7 +265,7 @@ sub set_test_state
 test "Setting state twice is idempotent",
    # Setting synced to 1 inserts a m.room.test object into the
    # timeline which this test does not expect
-   requires => [ local_user_and_room_fixtures( room_opts => { synced => 0 } ) ],
+   requires => [ local_user_and_room_fixtures( room_opts => { synced => 0 } ), qw ( deprecated_endpoints ) ],
 
    check => sub {
       my ( $user, $room_id ) = @_;
@@ -287,7 +287,7 @@ test "Setting state twice is idempotent",
    };
 
 test "Joining room twice is idempotent",
-   requires => [ local_user_and_room_fixtures() ],
+   requires => [ local_user_and_room_fixtures(), qw ( deprecated_endpoints ) ],
 
    check => sub {
       my ( $user, $room_id ) = @_;

--- a/tests/30rooms/01state.pl
+++ b/tests/30rooms/01state.pl
@@ -263,9 +263,11 @@ sub set_test_state
 }
 
 test "Setting state twice is idempotent",
+   # TODO: deprecated endpoint used in this test
+   
    # Setting synced to 1 inserts a m.room.test object into the
    # timeline which this test does not expect
-   requires => [ local_user_and_room_fixtures( room_opts => { synced => 0 } ), qw ( deprecated_endpoints ) ],
+   requires => [ local_user_and_room_fixtures( room_opts => { synced => 0 } ) ],
 
    check => sub {
       my ( $user, $room_id ) = @_;
@@ -287,7 +289,9 @@ test "Setting state twice is idempotent",
    };
 
 test "Joining room twice is idempotent",
-   requires => [ local_user_and_room_fixtures(), qw ( deprecated_endpoints ) ],
+   # TODO: deprecated endpoint used in this test
+
+   requires => [ local_user_and_room_fixtures()],
 
    check => sub {
       my ( $user, $room_id ) = @_;

--- a/tests/30rooms/01state.pl
+++ b/tests/30rooms/01state.pl
@@ -264,7 +264,6 @@ sub set_test_state
 
 test "Setting state twice is idempotent",
    # TODO: deprecated endpoint used in this test
-   
    # Setting synced to 1 inserts a m.room.test object into the
    # timeline which this test does not expect
    requires => [ local_user_and_room_fixtures( room_opts => { synced => 0 } ) ],
@@ -290,7 +289,6 @@ test "Setting state twice is idempotent",
 
 test "Joining room twice is idempotent",
    # TODO: deprecated endpoint used in this test
-
    requires => [ local_user_and_room_fixtures()],
 
    check => sub {

--- a/tests/30rooms/01state.pl
+++ b/tests/30rooms/01state.pl
@@ -92,8 +92,9 @@ test "Setting room topic reports m.room.topic to myself",
    };
 
 test "Global initialSync",
+   deprecated_endpoints => 1,
    requires => [ $user_fixture, $room_fixture,
-                qw( can_initial_sync can_set_room_topic deprecated_endpoints )],
+                qw( can_initial_sync can_set_room_topic )],
 
    check => sub {
       my ( $user, $room_id ) = @_;
@@ -146,8 +147,9 @@ test "Global initialSync",
    };
 
 test "Global initialSync with limit=0 gives no messages",
+   deprecated_endpoints => 1,
    requires => [ $user_fixture, $room_fixture,
-                qw( can_initial_sync deprecated_endpoints )],
+                qw( can_initial_sync )],
 
    check => sub {
       my ( $user, $room_id ) = @_;
@@ -169,8 +171,9 @@ test "Global initialSync with limit=0 gives no messages",
    };
 
 test "Room initialSync",
+   deprecated_endpoints => 1,
    requires => [ $user_fixture, $room_fixture,
-                qw( can_room_initial_sync deprecated_endpoints )],
+                qw( can_room_initial_sync )],
 
    check => sub {
       my ( $user, $room_id ) = @_;
@@ -217,8 +220,9 @@ test "Room initialSync",
    };
 
 test "Room initialSync with limit=0 gives no messages",
+   deprecated_endpoints => 1,
    requires => [ $user_fixture, $room_fixture,
-                qw( can_initial_sync deprecated_endpoints )],
+                qw( can_initial_sync )],
 
    check => sub {
       my ( $user, $room_id ) = @_;

--- a/tests/30rooms/01state.pl
+++ b/tests/30rooms/01state.pl
@@ -93,7 +93,7 @@ test "Setting room topic reports m.room.topic to myself",
 
 test "Global initialSync",
    requires => [ $user_fixture, $room_fixture,
-                qw( can_initial_sync can_set_room_topic )],
+                qw( can_initial_sync can_set_room_topic deprecated_endpoints )],
 
    check => sub {
       my ( $user, $room_id ) = @_;
@@ -147,7 +147,7 @@ test "Global initialSync",
 
 test "Global initialSync with limit=0 gives no messages",
    requires => [ $user_fixture, $room_fixture,
-                qw( can_initial_sync )],
+                qw( can_initial_sync deprecated_endpoints )],
 
    check => sub {
       my ( $user, $room_id ) = @_;
@@ -170,7 +170,7 @@ test "Global initialSync with limit=0 gives no messages",
 
 test "Room initialSync",
    requires => [ $user_fixture, $room_fixture,
-                qw( can_room_initial_sync )],
+                qw( can_room_initial_sync deprecated_endpoints )],
 
    check => sub {
       my ( $user, $room_id ) = @_;
@@ -218,7 +218,7 @@ test "Room initialSync",
 
 test "Room initialSync with limit=0 gives no messages",
    requires => [ $user_fixture, $room_fixture,
-                qw( can_initial_sync )],
+                qw( can_initial_sync deprecated_endpoints )],
 
    check => sub {
       my ( $user, $room_id ) = @_;

--- a/tests/30rooms/01state.pl
+++ b/tests/30rooms/01state.pl
@@ -293,7 +293,7 @@ test "Setting state twice is idempotent",
 
 test "Joining room twice is idempotent",
    # TODO: deprecated endpoint used in this test
-   requires => [ local_user_and_room_fixtures()],
+   requires => [ local_user_and_room_fixtures() ],
 
    check => sub {
       my ( $user, $room_id ) = @_;

--- a/tests/30rooms/02members-local.pl
+++ b/tests/30rooms/02members-local.pl
@@ -54,8 +54,9 @@ test "New room members see their own join event",
    };
 
 test "New room members see existing users' presence in room initialSync",
+   deprecated_endpoints => 1,
    requires => [ $creator_fixture, $local_user_fixture, $room_fixture,
-                 qw( can_room_initial_sync deprecated_endpoints )],
+                 qw( can_room_initial_sync )],
 
    check => sub {
       my ( $first_user, $local_user, $room_id ) = @_;
@@ -118,8 +119,9 @@ test "Existing members see new members' presence",
    };
 
 test "All room members see all room members' presence in global initialSync",
+   deprecated_endpoints => 1,
    requires => [ $creator_fixture, $local_user_fixture, $room_fixture,
-                 qw( can_initial_sync deprecated_endpoints )],
+                 qw( can_initial_sync )],
 
    check => sub {
       my ( $first_user, $local_user, $room_id ) = @_;

--- a/tests/30rooms/02members-local.pl
+++ b/tests/30rooms/02members-local.pl
@@ -55,7 +55,7 @@ test "New room members see their own join event",
 
 test "New room members see existing users' presence in room initialSync",
    requires => [ $creator_fixture, $local_user_fixture, $room_fixture,
-                 qw( can_room_initial_sync )],
+                 qw( can_room_initial_sync deprecated_endpoints )],
 
    check => sub {
       my ( $first_user, $local_user, $room_id ) = @_;
@@ -119,7 +119,7 @@ test "Existing members see new members' presence",
 
 test "All room members see all room members' presence in global initialSync",
    requires => [ $creator_fixture, $local_user_fixture, $room_fixture,
-                 qw( can_initial_sync )],
+                 qw( can_initial_sync deprecated_endpoints )],
 
    check => sub {
       my ( $first_user, $local_user, $room_id ) = @_;

--- a/tests/30rooms/03members-remote.pl
+++ b/tests/30rooms/03members-remote.pl
@@ -88,7 +88,7 @@ test "New room members see their own join event",
 
 test "New room members see existing members' presence in room initialSync",
    requires => [ $creator_fixture, $remote_user_fixture, $room_fixture,
-                 qw( can_join_remote_room_by_alias can_room_initial_sync )],
+                 qw( can_join_remote_room_by_alias can_room_initial_sync deprecated_endpoints )],
 
    do => sub {
       my ( $first_user, $user, $room_id, $room_alias ) = @_;
@@ -158,7 +158,7 @@ test "Existing members see new member's presence",
 
 test "New room members see first user's profile information in global initialSync",
    requires => [ $creator_fixture, $remote_user_fixture, $room_fixture,
-                 qw( can_join_remote_room_by_alias can_initial_sync can_set_displayname can_set_avatar_url )],
+                 qw( can_join_remote_room_by_alias can_initial_sync can_set_displayname can_set_avatar_url deprecated_endpoints )],
 
    check => sub {
       my ( $first_user, $user, $room_id, $room_alias ) = @_;
@@ -184,7 +184,7 @@ test "New room members see first user's profile information in global initialSyn
 
 test "New room members see first user's profile information in per-room initialSync",
    requires => [ $creator_fixture, $remote_user_fixture, $room_fixture,
-                 qw( can_room_initial_sync can_set_displayname can_set_avatar_url )],
+                 qw( can_room_initial_sync can_set_displayname can_set_avatar_url deprecated_endpoints )],
 
    check => sub {
       my ( $first_user, $user, $room_id, $room_alias ) = @_;

--- a/tests/30rooms/03members-remote.pl
+++ b/tests/30rooms/03members-remote.pl
@@ -158,7 +158,7 @@ test "Existing members see new member's presence",
    };
 
 test "New room members see first user's profile information in global initialSync",
-
+   deprecated_endpoints => 1,
    requires => [ $creator_fixture, $remote_user_fixture, $room_fixture,
                  qw( can_join_remote_room_by_alias can_initial_sync can_set_displayname can_set_avatar_url )],
 

--- a/tests/30rooms/03members-remote.pl
+++ b/tests/30rooms/03members-remote.pl
@@ -87,8 +87,9 @@ test "New room members see their own join event",
    };
 
 test "New room members see existing members' presence in room initialSync",
+   deprecated_endpoints => 1,
    requires => [ $creator_fixture, $remote_user_fixture, $room_fixture,
-                 qw( can_join_remote_room_by_alias can_room_initial_sync deprecated_endpoints )],
+                 qw( can_join_remote_room_by_alias can_room_initial_sync )],
 
    do => sub {
       my ( $first_user, $user, $room_id, $room_alias ) = @_;
@@ -157,8 +158,9 @@ test "Existing members see new member's presence",
    };
 
 test "New room members see first user's profile information in global initialSync",
+
    requires => [ $creator_fixture, $remote_user_fixture, $room_fixture,
-                 qw( can_join_remote_room_by_alias can_initial_sync can_set_displayname can_set_avatar_url deprecated_endpoints )],
+                 qw( can_join_remote_room_by_alias can_initial_sync can_set_displayname can_set_avatar_url )],
 
    check => sub {
       my ( $first_user, $user, $room_id, $room_alias ) = @_;
@@ -183,8 +185,9 @@ test "New room members see first user's profile information in global initialSyn
    };
 
 test "New room members see first user's profile information in per-room initialSync",
+   deprecated_endpoints => 1,
    requires => [ $creator_fixture, $remote_user_fixture, $room_fixture,
-                 qw( can_room_initial_sync can_set_displayname can_set_avatar_url deprecated_endpoints )],
+                 qw( can_room_initial_sync can_set_displayname can_set_avatar_url )],
 
    check => sub {
       my ( $first_user, $user, $room_id, $room_alias ) = @_;

--- a/tests/30rooms/06invite.pl
+++ b/tests/30rooms/06invite.pl
@@ -42,7 +42,7 @@ multi_test "Can invite users to invite-only rooms",
          $creator_fixture,
          local_user_fixture(),
          inviteonly_room_fixture( creator => $creator_fixture ),
-         qw( can_invite_room ),
+         qw( can_invite_room deprecated_endpoints ),
       ];
    },
 
@@ -79,7 +79,8 @@ multi_test "Can invite users to invite-only rooms",
 
 test "Uninvited users cannot join the room",
    requires => [ local_user_fixture(),
-                 inviteonly_room_fixture( creator => local_user_fixture() ) ],
+                 inviteonly_room_fixture( creator => local_user_fixture() ),
+				 qw ( deprecated_endpoints ) ],
 
    check => sub {
       my ( $uninvited, $room_id ) = @_;
@@ -95,7 +96,8 @@ test "Invited user can reject invite",
       do {
          my $creator = local_user_fixture();
          $creator, inviteonly_room_fixture( creator => $creator );
-      }
+      },
+	  qw ( deprecated_endpoints )
    ],
    do => \&invited_user_can_reject_invite;
 
@@ -104,7 +106,8 @@ test "Invited user can reject invite over federation",
       do {
          my $creator = local_user_fixture();
          $creator, inviteonly_room_fixture( creator => $creator );
-      }
+      },
+	  qw ( deprecated_endpoints )
    ],
    do => \&invited_user_can_reject_invite;
 
@@ -114,7 +117,8 @@ test "Invited user can reject invite over federation several times",
       do {
          my $creator = local_user_fixture();
          $creator, inviteonly_room_fixture( creator => $creator );
-      }
+      },
+	  qw ( deprecated_endpoints )
    ],
    do => sub {
       my ( $invitee, $creator, $room_id ) = @_;
@@ -169,7 +173,8 @@ test "Invited user can reject invite for empty room",
       do {
          my $creator = local_user_fixture();
          $creator, inviteonly_room_fixture( creator => $creator );
-      }
+      },
+	  qw ( deprecated_endpoints )
    ],
    do => \&invited_user_can_reject_invite_for_empty_room;
 
@@ -178,7 +183,8 @@ test "Invited user can reject invite over federation for empty room",
       do {
          my $creator = local_user_fixture();
          $creator, inviteonly_room_fixture( creator => $creator );
-      }
+      },
+	  qw ( deprecated_endpoints )
    ],
    do => \&invited_user_can_reject_invite_for_empty_room;
 
@@ -210,7 +216,8 @@ test "Invited user can reject local invite after originator leaves",
       do {
          my $creator = local_user_fixture();
          $creator, inviteonly_room_fixture( creator => $creator );
-      }
+      },
+	  qw ( deprecated_endpoints )
    ],
    do => sub {
       my ( $invitee, $creator, $room_id ) = @_;

--- a/tests/30rooms/06invite.pl
+++ b/tests/30rooms/06invite.pl
@@ -75,7 +75,7 @@ multi_test "Can invite users to invite-only rooms",
 test "Uninvited users cannot join the room",
    # TODO: deprecated endpoint used in this test
    requires => [ local_user_fixture(),
-                 inviteonly_room_fixture( creator => local_user_fixture() )],
+                 inviteonly_room_fixture( creator => local_user_fixture() ) ],
 
    check => sub {
       my ( $uninvited, $room_id ) = @_;

--- a/tests/30rooms/06invite.pl
+++ b/tests/30rooms/06invite.pl
@@ -35,6 +35,7 @@ sub inviteonly_room_fixture
 }
 
 multi_test "Can invite users to invite-only rooms",
+   # TODO: deprecated endpoint used in this test
    requires => do {
       my $creator_fixture = local_user_fixture();
 
@@ -42,7 +43,7 @@ multi_test "Can invite users to invite-only rooms",
          $creator_fixture,
          local_user_fixture(),
          inviteonly_room_fixture( creator => $creator_fixture ),
-         qw( can_invite_room deprecated_endpoints ),
+         qw( can_invite_room ),
       ];
    },
 
@@ -78,9 +79,9 @@ multi_test "Can invite users to invite-only rooms",
    };
 
 test "Uninvited users cannot join the room",
+   # TODO: deprecated endpoint used in this test
    requires => [ local_user_fixture(),
-                 inviteonly_room_fixture( creator => local_user_fixture() ),
-				 qw ( deprecated_endpoints ) ],
+                 inviteonly_room_fixture( creator => local_user_fixture() )],
 
    check => sub {
       my ( $uninvited, $room_id ) = @_;
@@ -92,33 +93,33 @@ test "Uninvited users cannot join the room",
 my $other_local_user_fixture = local_user_fixture();
 
 test "Invited user can reject invite",
+   # TODO: deprecated endpoint used in this test
    requires => [ local_user_fixture(),
       do {
          my $creator = local_user_fixture();
          $creator, inviteonly_room_fixture( creator => $creator );
-      },
-	  qw ( deprecated_endpoints )
+      }
    ],
    do => \&invited_user_can_reject_invite;
 
 test "Invited user can reject invite over federation",
+   # TODO: deprecated endpoint used in this test
    requires => [ remote_user_fixture(),
       do {
          my $creator = local_user_fixture();
          $creator, inviteonly_room_fixture( creator => $creator );
-      },
-	  qw ( deprecated_endpoints )
+      }
    ],
    do => \&invited_user_can_reject_invite;
 
 test "Invited user can reject invite over federation several times",
+   # TODO: deprecated endpoint used in this test
    # https://github.com/matrix-org/synapse/issues/1987
    requires => [ remote_user_fixture(),
       do {
          my $creator = local_user_fixture();
          $creator, inviteonly_room_fixture( creator => $creator );
-      },
-	  qw ( deprecated_endpoints )
+      }
    ],
    do => sub {
       my ( $invitee, $creator, $room_id ) = @_;
@@ -169,22 +170,22 @@ sub invited_user_can_reject_invite
 }
 
 test "Invited user can reject invite for empty room",
+   # TODO: deprecated endpoint used in this test
    requires => [ local_user_fixture(),
       do {
          my $creator = local_user_fixture();
          $creator, inviteonly_room_fixture( creator => $creator );
-      },
-	  qw ( deprecated_endpoints )
+      }
    ],
    do => \&invited_user_can_reject_invite_for_empty_room;
 
 test "Invited user can reject invite over federation for empty room",
+   # TODO: deprecated endpoint used in this test
    requires => [ remote_user_fixture(),
       do {
          my $creator = local_user_fixture();
          $creator, inviteonly_room_fixture( creator => $creator );
-      },
-	  qw ( deprecated_endpoints )
+      }
    ],
    do => \&invited_user_can_reject_invite_for_empty_room;
 
@@ -212,12 +213,12 @@ sub invited_user_can_reject_invite_for_empty_room
 }
 
 test "Invited user can reject local invite after originator leaves",
+   # TODO: deprecated endpoint used in this test
    requires => [ local_user_fixture(),
       do {
          my $creator = local_user_fixture();
          $creator, inviteonly_room_fixture( creator => $creator );
-      },
-	  qw ( deprecated_endpoints )
+      }
    ],
    do => sub {
       my ( $invitee, $creator, $room_id ) = @_;

--- a/tests/30rooms/11leaving.pl
+++ b/tests/30rooms/11leaving.pl
@@ -64,7 +64,8 @@ my $room_fixture = fixture(
 );
 
 test "A departed room is still included in /initialSync (SPEC-216)",
-    requires => [ $left_user_fixture, $room_fixture, qw ( deprecated_endpoints ) ],
+    deprecated_endpoints => 1,
+    requires => [ $left_user_fixture, $room_fixture ],
 
     check => sub {
         my ( $user, $room_id ) = @_;
@@ -97,7 +98,8 @@ test "A departed room is still included in /initialSync (SPEC-216)",
     };
 
 test "Can get rooms/{roomId}/initialSync for a departed room (SPEC-216)",
-    requires => [ $left_user_fixture, $room_fixture, qw ( deprecated_endpoints ) ],
+    deprecated_endpoints => 1,
+    requires => [ $left_user_fixture, $room_fixture ) ],
 
     check => sub {
         my ( $user, $room_id ) = @_;

--- a/tests/30rooms/11leaving.pl
+++ b/tests/30rooms/11leaving.pl
@@ -64,7 +64,7 @@ my $room_fixture = fixture(
 );
 
 test "A departed room is still included in /initialSync (SPEC-216)",
-    requires => [ $left_user_fixture, $room_fixture ],
+    requires => [ $left_user_fixture, $room_fixture, qw ( deprecated_endpoints ) ],
 
     check => sub {
         my ( $user, $room_id ) = @_;
@@ -97,7 +97,7 @@ test "A departed room is still included in /initialSync (SPEC-216)",
     };
 
 test "Can get rooms/{roomId}/initialSync for a departed room (SPEC-216)",
-    requires => [ $left_user_fixture, $room_fixture ],
+    requires => [ $left_user_fixture, $room_fixture, qw ( deprecated_endpoints ) ],
 
     check => sub {
         my ( $user, $room_id ) = @_;

--- a/tests/30rooms/11leaving.pl
+++ b/tests/30rooms/11leaving.pl
@@ -99,7 +99,7 @@ test "A departed room is still included in /initialSync (SPEC-216)",
 
 test "Can get rooms/{roomId}/initialSync for a departed room (SPEC-216)",
     deprecated_endpoints => 1,
-    requires => [ $left_user_fixture, $room_fixture ) ],
+    requires => [ $left_user_fixture, $room_fixture ],
 
     check => sub {
         my ( $user, $room_id ) = @_;

--- a/tests/30rooms/13guestaccess.pl
+++ b/tests/30rooms/13guestaccess.pl
@@ -2,7 +2,8 @@ use List::Util qw( first );
 use Future::Utils qw( repeat );
 
 test "Guest user cannot call /events globally",
-   requires => [ guest_user_fixture(), qw ( deprecated_endpoints ) ],
+   deprecated_endpoints => 1,
+   requires => [ guest_user_fixture() ],
 
    do => sub {
       my ( $guest_user ) = @_;
@@ -73,7 +74,8 @@ test "Guest users can send messages to guest_access rooms if joined",
    };
 
 test "Guest user calling /events doesn't tightloop",
-   requires => [ guest_user_fixture(), local_user_fixture(), qw ( deprecated_endpoints ) ],
+   deprecated_endpoints => 1,
+   requires => [ guest_user_fixture(), local_user_fixture() ],
 
    do => sub {
       my ( $guest_user, $user ) = @_;

--- a/tests/30rooms/13guestaccess.pl
+++ b/tests/30rooms/13guestaccess.pl
@@ -2,7 +2,7 @@ use List::Util qw( first );
 use Future::Utils qw( repeat );
 
 test "Guest user cannot call /events globally",
-   requires => [ guest_user_fixture() ],
+   requires => [ guest_user_fixture(), qw ( deprecated_endpoints ) ],
 
    do => sub {
       my ( $guest_user ) = @_;
@@ -73,7 +73,7 @@ test "Guest users can send messages to guest_access rooms if joined",
    };
 
 test "Guest user calling /events doesn't tightloop",
-   requires => [ guest_user_fixture(), local_user_fixture() ],
+   requires => [ guest_user_fixture(), local_user_fixture(), qw ( deprecated_endpoints ) ],
 
    do => sub {
       my ( $guest_user, $user ) = @_;

--- a/tests/30rooms/21receipts.pl
+++ b/tests/30rooms/21receipts.pl
@@ -33,7 +33,7 @@ sub find_receipt
 
 multi_test "Read receipts are visible to /initialSync",
    requires => [ local_user_and_room_fixtures(),
-                 qw( can_post_room_receipts )],
+                 qw( can_post_room_receipts deprecated_endpoints )],
 
    do => sub {
       my ( $user, $room_id ) = @_;

--- a/tests/30rooms/21receipts.pl
+++ b/tests/30rooms/21receipts.pl
@@ -32,8 +32,9 @@ sub find_receipt
 }
 
 multi_test "Read receipts are visible to /initialSync",
+   deprecated_endpoints => 1,
    requires => [ local_user_and_room_fixtures(),
-                 qw( can_post_room_receipts deprecated_endpoints )],
+                 qw( can_post_room_receipts )],
 
    do => sub {
       my ( $user, $room_id ) = @_;

--- a/tests/30rooms/30history-visibility.pl
+++ b/tests/30rooms/30history-visibility.pl
@@ -112,8 +112,9 @@ foreach my $i (
    foreach my $visibility (qw( shared invited joined default )) {
       test(
          "$name non-joined user cannot call /events on $visibility room",
-
-         requires => [ $fixture->(), local_user_and_room_fixtures(), qw ( deprecated_endpoints ) ],
+   
+         deprecated_endpoints => 1,
+         requires => [ $fixture->(), local_user_and_room_fixtures() ],
 
          do => sub {
             my ( $nonjoined_user, $creator_user, $room_id ) = @_;
@@ -131,7 +132,8 @@ foreach my $i (
    test(
       "$name non-joined user can call /events on world_readable room",
 
-      requires => [ $fixture->(), local_user_fixture( with_events => 1 ), local_user_fixture( with_events => 1 ), qw ( deprecated_endpoints ) ],
+      deprecated_endpoints => 1,
+      requires => [ $fixture->(), local_user_fixture( with_events => 1 ), local_user_fixture( with_events => 1 ) ],
 
       do => sub {
          my ( $nonjoined_user, $user, $user_not_in_room ) = @_;
@@ -286,7 +288,8 @@ foreach my $i (
    test(
       "$name non-joined users cannot room initalSync for non-world_readable rooms",
 
-      requires => [ guest_user_fixture(), local_user_fixture(), qw ( deprecated_endpoints ) ],
+      deprecated_endpoints => 1,
+      requires => [ guest_user_fixture(), local_user_fixture() ],
 
       do => sub {
          my ( $non_joined_user, $creating_user ) = @_;
@@ -308,7 +311,8 @@ foreach my $i (
    test(
       "$name non-joined users can room initialSync for world_readable rooms",
 
-      requires => [ guest_user_fixture( with_events => 1 ), local_user_fixture( with_events => 1 ), qw ( deprecated_endpoints ) ],
+      deprecated_endpoints => 1,
+      requires => [ guest_user_fixture( with_events => 1 ), local_user_fixture( with_events => 1 ) ],
 
       do => sub {
          my ( $syncing_user, $creating_user ) = @_;

--- a/tests/30rooms/30history-visibility.pl
+++ b/tests/30rooms/30history-visibility.pl
@@ -112,7 +112,7 @@ foreach my $i (
    foreach my $visibility (qw( shared invited joined default )) {
       test(
          "$name non-joined user cannot call /events on $visibility room",
-   
+
          deprecated_endpoints => 1,
          requires => [ $fixture->(), local_user_and_room_fixtures() ],
 

--- a/tests/30rooms/30history-visibility.pl
+++ b/tests/30rooms/30history-visibility.pl
@@ -113,7 +113,7 @@ foreach my $i (
       test(
          "$name non-joined user cannot call /events on $visibility room",
 
-         requires => [ $fixture->(), local_user_and_room_fixtures() ],
+         requires => [ $fixture->(), local_user_and_room_fixtures(), qw ( deprecated_endpoints ) ],
 
          do => sub {
             my ( $nonjoined_user, $creator_user, $room_id ) = @_;
@@ -131,7 +131,7 @@ foreach my $i (
    test(
       "$name non-joined user can call /events on world_readable room",
 
-      requires => [ $fixture->(), local_user_fixture( with_events => 1 ), local_user_fixture( with_events => 1 ) ],
+      requires => [ $fixture->(), local_user_fixture( with_events => 1 ), local_user_fixture( with_events => 1 ), qw ( deprecated_endpoints ) ],
 
       do => sub {
          my ( $nonjoined_user, $user, $user_not_in_room ) = @_;
@@ -286,7 +286,7 @@ foreach my $i (
    test(
       "$name non-joined users cannot room initalSync for non-world_readable rooms",
 
-      requires => [ guest_user_fixture(), local_user_fixture() ],
+      requires => [ guest_user_fixture(), local_user_fixture(), qw ( deprecated_endpoints ) ],
 
       do => sub {
          my ( $non_joined_user, $creating_user ) = @_;
@@ -308,7 +308,7 @@ foreach my $i (
    test(
       "$name non-joined users can room initialSync for world_readable rooms",
 
-      requires => [ guest_user_fixture( with_events => 1 ), local_user_fixture( with_events => 1 ) ],
+      requires => [ guest_user_fixture( with_events => 1 ), local_user_fixture( with_events => 1 ), qw ( deprecated_endpoints ) ],
 
       do => sub {
          my ( $syncing_user, $creating_user ) = @_;

--- a/tests/40presence.pl
+++ b/tests/40presence.pl
@@ -122,7 +122,7 @@ test "Presence changes to UNAVAILABLE are reported to remote room members",
 
 test "Newly created users see their own presence in /initialSync (SYT-34)",
    requires => [ local_user_fixture(),
-                 qw( can_initial_sync )],
+                 qw( can_initial_sync deprecated_endpoints )],
 
    do => sub {
       my ( $user ) = @_;

--- a/tests/40presence.pl
+++ b/tests/40presence.pl
@@ -121,8 +121,9 @@ test "Presence changes to UNAVAILABLE are reported to remote room members",
    };
 
 test "Newly created users see their own presence in /initialSync (SYT-34)",
+   deprecated_endpoints => 1,
    requires => [ local_user_fixture(),
-                 qw( can_initial_sync deprecated_endpoints )],
+                 qw( can_initial_sync )],
 
    do => sub {
       my ( $user ) = @_;

--- a/tests/42tags.pl
+++ b/tests/42tags.pl
@@ -259,8 +259,9 @@ test "Tags appear in the v1 /initalSync",
 
 
 test "Tags appear in the v1 room initial sync",
+   deprecated_endpoints => 1,
    requires => [ local_user_fixture( with_events => 0 ),
-                 qw( can_add_tag can_remove_tag deprecated_endpoints )],
+                 qw( can_add_tag can_remove_tag )],
 
    do => sub {
       my ( $user ) = @_;

--- a/tests/42tags.pl
+++ b/tests/42tags.pl
@@ -260,7 +260,7 @@ test "Tags appear in the v1 /initalSync",
 
 test "Tags appear in the v1 room initial sync",
    requires => [ local_user_fixture( with_events => 0 ),
-                 qw( can_add_tag can_remove_tag )],
+                 qw( can_add_tag can_remove_tag deprecated_endpoints )],
 
    do => sub {
       my ( $user ) = @_;

--- a/tests/44account_data.pl
+++ b/tests/44account_data.pl
@@ -102,7 +102,7 @@ test "Can get room account data without syncing",
 
 
 test "Latest account data comes down in /initialSync",
-   requires => [ local_user_and_room_fixtures() ],
+   requires => [ local_user_and_room_fixtures(), qw ( deprecated_endpoints ) ],
 
    check => sub {
       my ( $user, $room_id ) = @_;
@@ -126,7 +126,7 @@ test "Latest account data comes down in /initialSync",
 
 
 test "Latest account data comes down in room initialSync",
-   requires => [ local_user_and_room_fixtures() ],
+   requires => [ local_user_and_room_fixtures(), qw ( deprecated_endpoints ) ],
 
    check => sub {
       my ( $user, $room_id ) = @_;

--- a/tests/44account_data.pl
+++ b/tests/44account_data.pl
@@ -102,7 +102,8 @@ test "Can get room account data without syncing",
 
 
 test "Latest account data comes down in /initialSync",
-   requires => [ local_user_and_room_fixtures(), qw ( deprecated_endpoints ) ],
+   deprecated_endpoints => 1,
+   requires => [ local_user_and_room_fixtures() ],
 
    check => sub {
       my ( $user, $room_id ) = @_;
@@ -126,7 +127,8 @@ test "Latest account data comes down in /initialSync",
 
 
 test "Latest account data comes down in room initialSync",
-   requires => [ local_user_and_room_fixtures(), qw ( deprecated_endpoints ) ],
+   deprecated_endpoints => 1,
+   requires => [ local_user_and_room_fixtures() ],
 
    check => sub {
       my ( $user, $room_id ) = @_;

--- a/tests/80torture/03events.pl
+++ b/tests/80torture/03events.pl
@@ -1,6 +1,6 @@
 test "GET /initialSync with non-numeric 'limit'",
    requires => [ $main::SPYGLASS_USER,
-                 qw( can_initial_sync )],
+                 qw( can_initial_sync deprecated_endpoints )],
 
    check => sub {
       my ( $user ) = @_;

--- a/tests/80torture/03events.pl
+++ b/tests/80torture/03events.pl
@@ -1,6 +1,7 @@
 test "GET /initialSync with non-numeric 'limit'",
+   deprecated_endpoints => 1,
    requires => [ $main::SPYGLASS_USER,
-                 qw( can_initial_sync deprecated_endpoints )],
+                 qw( can_initial_sync )],
 
    check => sub {
       my ( $user ) = @_;

--- a/tests/90jira/SYN-115.pl
+++ b/tests/90jira/SYN-115.pl
@@ -1,8 +1,9 @@
 use Future::Utils qw( repeat );
 
 multi_test "New federated private chats get full presence information (SYN-115)",
+   # TODO: deprecated endpoint used in this test
    requires => [ local_user_fixture(), remote_user_fixture( with_events => 1 ),
-                 qw( can_create_private_room deprecated_endpoints )],
+                 qw( can_create_private_room )],
 
    do => sub {
       my ( $alice, $bob ) = @_;

--- a/tests/90jira/SYN-115.pl
+++ b/tests/90jira/SYN-115.pl
@@ -2,7 +2,7 @@ use Future::Utils qw( repeat );
 
 multi_test "New federated private chats get full presence information (SYN-115)",
    requires => [ local_user_fixture(), remote_user_fixture( with_events => 1 ),
-                 qw( can_create_private_room )],
+                 qw( can_create_private_room deprecated_endpoints )],
 
    do => sub {
       my ( $alice, $bob ) = @_;

--- a/tests/90jira/SYN-606.pl
+++ b/tests/90jira/SYN-606.pl
@@ -6,7 +6,7 @@ foreach my $i (
 
    test(
       "$name user can call /events on another world_readable room (SYN-606)",
-      requires => [ $fixture->(),  local_user_fixture() ],
+      requires => [ $fixture->(),  local_user_fixture(), qw ( deprecated_endpoints ) ],
 
       do => sub {
          my ( $nonjoined_user, $user ) = @_;

--- a/tests/90jira/SYN-606.pl
+++ b/tests/90jira/SYN-606.pl
@@ -6,7 +6,8 @@ foreach my $i (
 
    test(
       "$name user can call /events on another world_readable room (SYN-606)",
-      requires => [ $fixture->(),  local_user_fixture(), qw ( deprecated_endpoints ) ],
+      deprecated_endpoints => 1,
+      requires => [ $fixture->(),  local_user_fixture() ],
 
       do => sub {
          my ( $nonjoined_user, $user ) = @_;


### PR DESCRIPTION
This adds a new `deprecated_endpoints` qw to `require`, and adds a command-line flag `--exclude-deprecated`. The idea is that we can not bother running tests at all that test endpoints that we know are deprecated, e.g. in Dendrite we will never implement `/initialSync`. 