### PR TITLE
Unflake "Server correctly resyncs when server leaves and rejoins a room"

### DIFF
--- a/tests/50federation/40devicelists.pl
+++ b/tests/50federation/40devicelists.pl
@@ -325,9 +325,11 @@ test "Server correctly resyncs when server leaves and rejoins a room",
 
          matrix_leave_room( $user, $room->room_id )
       })->then( sub {
-         matrix_join_room( $user, $room->room_id,
-            server_name => $inbound_server->server_name,
-         )
+         retry_until_success {
+            matrix_join_room( $user, $room->room_id,
+               server_name => $inbound_server->server_name,
+            )
+         }
       })->then( sub {
          Future->needs_all(
             $inbound_server->await_request_user_devices( $federated_user_id )


### PR DESCRIPTION
This test flaked on me [here](https://buildkite.com/matrix-dot-org/synapse/builds/9370#57f1c19a-b92b-4a90-b0f2-3a0e3a37ad78) with the following sytest output:

```

# Started: 2020-06-02 16:11:09.325
# Ended: 2020-06-02 16:11:10.785
# HTTP Request failed ( 404 Not Found https://localhost:8831/_matrix/client/r0/join/!PkvlNjehVHBRXtsZBJ:localhost:8831?server_name=localhost%3A44489&access_token=MDAxY2xvY2F0aW9uIGxvY2FsaG9zdDo4ODMxCjAwMTNpZGVudGlmaWVyIGtleQowMDEwY2lkIGdlbiA9IDEKMDAzYmNpZCB1c2VyX2lkID0gQGFub24tMjAyMDA2MDJfMTU1NjM1LTc0Mzpsb2NhbGhvc3Q6ODgzMQowMDE2Y2lkIHR5cGUgPSBhY2Nlc3MKMDAyMWNpZCBub25jZSA9ID1EaCs2bUh0SEhRWThTQnMKMDAyZnNpZ25hdHVyZSCKQJ7oXgJRqAE6WliaMy8nk7YBCL8U_xChZStw-JPdxAo ) from POST https://localhost:8831/_matrix/client/r0/join/!PkvlNjehVHBRXtsZBJ:localhost:8831?...
# {"errcode":"M_NOT_FOUND","error":"Unknown room !PkvlNjehVHBRXtsZBJ:localhost:8831"}
# 0.106658: Registered new user @anon-20200602_155635-743:localhost:8831
# 0.922439: Joined room 1: !PkvlNjehVHBRXtsZBJ:localhost:8831
# 1.007631: first query response
# {
#   device_keys       => {
#                          "\@__ANON__-64:localhost:44489" => { random_device_id1 => { device_keys => {} } },
#                        },
#   failures          => {},
#   master_keys       => {},
#   self_signing_keys => {},
#   user_signing_keys => {},
# }
```

Looks like it was due to the room join not completing before we try to manipulate the room. Add `retry_until_success` to ensure we join the room before continuing further.