### PR TITLE
Use the standardized form for SSO login via user interactive auth.

### DIFF
--- a/tests/10apidoc/13ui-auth.pl
+++ b/tests/10apidoc/13ui-auth.pl
@@ -80,8 +80,8 @@ test "Interactive authentication types include SSO",
          assert_json_list $body->{flows};
 
          # Note that this uses the unstable value.
-         die "org.matrix.login.sso was not listed" unless
-            any { $_->{stages}[0] eq "org.matrix.login.sso" } @{ $body->{flows} };
+         die "m.login.sso was not listed" unless
+            any { $_->{stages}[0] eq "m.login.sso" } @{ $body->{flows} };
 
          Future->done( 1 );
       });


### PR DESCRIPTION
r0.6.1 of the client-server spec includes `m.login.sso` as the standardized version for single sign-on login for user-interactive authentication. We should be using that instead.