### PR TITLE
Merge mainline release v1.14.0 into dinsic

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,11 @@ SyTest requires a number of dependencies that are easiest installed from CPAN.
    Synapse does not need to be installed, as SyTest will run it directly from
    its source code directory.
 
+Additionally, a number of native dependencies are required. To install these
+dependencies on an Ubuntu/Debian-derived Linux distribution, run the following::
+
+    sudo apt install libpq-dev build-essential
+
 Installing on OS X
 ------------------
 Dependencies can be installed on OS X in the same manner, except that packages

--- a/docker/README.md
+++ b/docker/README.md
@@ -55,9 +55,42 @@ Synapse:
  * `BLACKLIST`: set non-empty to change the default blacklist file to the
    specified path relative to the Synapse directory
 
+Some examples of running Synapse in different configurations:
+
+* Running Synapse in worker mode using
+[TCP-replication](https://github.com/matrix-org/synapse/blob/master/docs/tcp_replication.md):
+
+  ```
+  docker run --rm -it -e POSTGRES=1 -e WORKERS=1 -v /path/to/synapse\:/src:ro \
+      -v /path/to/where/you/want/logs\:/logs matrixdotorg/sytest-synapse:py35
+  ```
+
+* Running Synapse in worker mode using redis:
+
+  ```
+  docker network create testfoobar
+  docker run --network testfoobar --name testredis -d redis:5.0
+  docker run --network testfoobar --rm -it -e POSTGRES=1 -e WORKERS=1 \
+       -v /path/to/synapse\:/src:ro \
+       -v /path/to/where/you/want/logs\:/logs \
+       matrixdotorg/sytest-synapse:py35 --redis-host testredis
+  # Use `docker start/stop testredis` if you want to explicitly kill redis or start it again after reboot
+  ```
+
 Dendrite:
 
 Dendrite does not currently make use of any environment variables.
+
+## Using the local checkout of Sytest
+
+If you would like to run tests with a custom checkout of Sytest, add a volume
+to the docker command mounting the checkout to the `/sytest` folder in the
+container:
+
+```
+docker run --rm -it /path/to/synapse\:/src:ro -v /path/to/where/you/want/logs\:/logs \
+    -v /path/to/code/sytest\:/sytest:ro matrixdotorg/sytest-synapse:py35
+```
 
 ## Building the containers
 

--- a/docs/dendrite-setup.md
+++ b/docs/dendrite-setup.md
@@ -41,14 +41,18 @@ SyTest will expect Dendrite to be at `../dendrite` relative to Sytest's root dir
 Simply run the following to execute tests:
 
 ```
-./run-tests.pl -I Dendrite::Monolith -W ../dendrite/testfile
+./run-tests.pl -I Dendrite::Monolith -W ../dendrite/sytest-whitelist -B ../dendrite/sytest-blacklist
 ```
 
 ## Useful flags
 
 * `-W` applies a test whitelist file, one of which is currently kept up to date
   with what sytests Dendrite passes
-  [here](https://github.com/matrix-org/dendrite/blob/master/testfile)
+  [here](https://github.com/matrix-org/dendrite/blob/master/sytest-whitelist)
+
+* `-B` applies a test blacklist file, one of which is currently kept up to date
+  with what sytests are currently flaky (fail *sometimes*) with Dendrite
+  [here](https://github.com/matrix-org/dendrite/blob/master/sytest-blacklist)
 
 * `-d` lets you set the path to Dendrite's `bin/` directory, in case it's
   somewhere other than `../dendrite/bin`

--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -282,10 +282,15 @@ sub _start_monolith
       '--tls-key', $self->{paths}{tls_key},
    );
 
+   push(@command, '-api') if $ENV{'API'} == '1';
+   $output->diag( "Starting Dendrite with: @command" );
+
    return $self->_start_process_and_await_connectable(
       setup => [
          env => {
             LOG_DIR => $self->{hs_dir},
+            DENDRITE_TRACE_SQL => $ENV{'DENDRITE_TRACE_SQL'},
+            DENDRITE_TRACE_HTTP => $ENV{'DENDRITE_TRACE_HTTP'},
          },
       ],
       command => [ @command ],

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -33,6 +33,7 @@ sub _init
 
    $self->{paths} = {};
    $self->{dendron} = '';
+   $self->{redis_host} = '';
 
    $self->SUPER::_init( $args );
 
@@ -290,6 +291,11 @@ sub start
         # feature with worker mode.
         limit_usage_by_mau => "true",
         max_mau_value => 50000000,
+
+        redis => {
+           enabled => $self->{redis_host} ne '',
+           host    => $self->{redis_host},
+        },
 
         map {
            defined $self->{$_} ? ( $_ => $self->{$_} ) : ()
@@ -662,6 +668,7 @@ sub _init
    $self->SUPER::_init( @_ );
 
    $self->{dendron} = delete $args->{dendron_binary};
+   $self->{redis_host} = delete $args->{redis_host};
 
    if( my $level = delete $args->{torture_replication} ) {
       # torture the replication protocol a bit, to replicate bugs.

--- a/lib/SyTest/HomeserverFactory/Synapse.pm
+++ b/lib/SyTest/HomeserverFactory/Synapse.pm
@@ -101,6 +101,7 @@ sub _init
    $self->{impl} = "SyTest::Homeserver::Synapse::ViaDendron";
    $self->{args}{dendron_binary} = "";
    $self->{args}{torture_replication} = 0;
+   $self->{args}{redis_host} = "";
 }
 
 sub get_options
@@ -108,8 +109,9 @@ sub get_options
    my $self = shift;
 
    return (
-      'dendron-binary=s' => \$self->{args}{dendron_binary},
+      'dendron-binary=s'       => \$self->{args}{dendron_binary},
       'torture-replication:50' => \$self->{args}{torture_replication},
+      'redis-host=s'           => \$self->{args}{redis_host},
       $self->SUPER::get_options(),
    );
 }
@@ -125,6 +127,8 @@ sub print_usage
        --dendron-binary PATH    - path to the 'dendron' binary
 
        --torture-replication[=LEVEL] - enable torturing of the replication protocol
+
+       --redis-host HOST 	- if set then use redis for replication
 EOF
 }
 

--- a/scripts/synapse_sytest.sh
+++ b/scripts/synapse_sytest.sh
@@ -114,14 +114,15 @@ if [ -n "$OFFLINE" ]; then
     # if we're in offline mode, just put synapse into the virtualenv, and
     # hope that the deps are up-to-date.
     #
-    # (`pip install -e` likes to reinstall setuptools even if it's already installed,
-    # so we just run setup.py explicitly.)
-    #
-    (cd /src && /venv/bin/python setup.py -q develop)
+    # --no-use-pep517 works around what appears to be a pip issue
+    # (https://github.com/pypa/pip/issues/5402 possibly) where pip wants
+    # to reinstall any requirements for the build system, even if they are
+    # already installed.
+    /venv/bin/pip install --no-index --no-use-pep517 /src
 else
     # We've already created the virtualenv, but lets double check we have all
     # deps.
-    /venv/bin/pip install -q --upgrade --no-cache-dir /src
+    /venv/bin/pip install -q --upgrade --no-cache-dir /src[redis]
     /venv/bin/pip install -q --upgrade --no-cache-dir \
         lxml psycopg2 coverage codecov tap.py coverage_enable_subprocess
 

--- a/scripts/synapse_sytest.sh
+++ b/scripts/synapse_sytest.sh
@@ -9,7 +9,7 @@
 
 # Run the sytests.
 
-set -ex
+set -e
 
 cd "$(dirname $0)/.."
 
@@ -25,11 +25,6 @@ if [ -n "$MULTI_POSTGRES" ] || [ -n "$POSTGRES" ]; then
 
     # Start the database
     su -c 'eatmydata /usr/lib/postgresql/*/bin/pg_ctl -w -D $PGDATA start' postgres
-
-    su -c psql postgres <<< "show config_file"
-    su -c psql postgres <<< "show max_connections"
-    su -c psql postgres <<< "show full_page_writes"
-    su -c psql postgres <<< "show fsync"
 fi
 
 # Now create the databases
@@ -110,6 +105,24 @@ elif [ -n "$POSTGRES" ]; then
 
 fi
 
+# default value for SYNAPSE_SOURCE
+: ${SYNAPSE_SOURCE:=/src}
+
+# if we're running against a source directory, turn it into a tarball.  pip
+# will then unpack it to a temporary location, and build it.  (As of pip 20.1,
+# it will otherwise try to build it in-tree, which means writing changes to the
+# source volume outside the container.)
+#
+if [ -d "$SYNAPSE_SOURCE" ]; then
+    echo "Creating tarball from synapse source"
+    tar -C "$SYNAPSE_SOURCE" -czf /tmp/synapse.tar.gz \
+        synapse scripts setup.py README.rst synctl MANIFEST.in
+    SYNAPSE_SOURCE="/tmp/synapse.tar.gz"
+elif [ ! -r "$SYNAPSE_SOURCE" ]; then
+    echo "Unable to read synapse source at $SYNAPSE_SOURCE" >&2
+    exit 1
+fi
+
 if [ -n "$OFFLINE" ]; then
     # if we're in offline mode, just put synapse into the virtualenv, and
     # hope that the deps are up-to-date.
@@ -118,11 +131,11 @@ if [ -n "$OFFLINE" ]; then
     # (https://github.com/pypa/pip/issues/5402 possibly) where pip wants
     # to reinstall any requirements for the build system, even if they are
     # already installed.
-    /venv/bin/pip install --no-index --no-use-pep517 /src
+    /venv/bin/pip install --no-index --no-use-pep517 "$SYNAPSE_SOURCE"
 else
     # We've already created the virtualenv, but lets double check we have all
     # deps.
-    /venv/bin/pip install -q --upgrade --no-cache-dir /src[redis]
+    /venv/bin/pip install -q --upgrade --no-cache-dir "$SYNAPSE_SOURCE"[redis]
     /venv/bin/pip install -q --upgrade --no-cache-dir \
         lxml psycopg2 coverage codecov tap.py coverage_enable_subprocess
 

--- a/tests/10apidoc/02login.pl
+++ b/tests/10apidoc/02login.pl
@@ -82,7 +82,10 @@ test "POST /login can log in as a user",
 
          content => {
             type     => "m.login.password",
-            user     => $user_id,
+            identifier => {
+               type => "m.id.user",
+               user => $user_id,
+            },
             password => $password,
          },
       )->then( sub {
@@ -114,7 +117,10 @@ test "POST /login returns the same device_id as that in the request",
 
          content => {
             type     => "m.login.password",
-            user     => $user_id,
+            identifier => {
+               type => "m.id.user",
+               user => $user_id,
+            },
             password => $password,
             device_id => $device_id,
          },
@@ -146,7 +152,10 @@ test "POST /login can log in as a user with just the local part of the id",
 
          content => {
             type     => "m.login.password",
-            user     => $user_localpart,
+            identifier => {
+               type => "m.id.user",
+               user => $user_localpart,
+            },
             password => $password,
          },
       )->then( sub {
@@ -174,7 +183,10 @@ test "POST /login as non-existing user is rejected",
 
          content => {
             type     => "m.login.password",
-            user     => "i-ought-not-to-exist",
+            identifier => {
+               type => "m.id.user",
+               user => "i-ought-not-to-exist",
+            },
             password => "XXX",
          },
       )->main::expect_http_403;
@@ -193,7 +205,10 @@ test "POST /login wrong password is rejected",
 
          content => {
             type     => "m.login.password",
-            user     => $user_id,
+            identifier => {
+               type => "m.id.user",
+               user => $user_id,
+            },
             password => "${password}wrong",
          },
       )->main::expect_http_403->then( sub {
@@ -225,7 +240,10 @@ sub matrix_login_again_with_user
       uri     => "/r0/login",
       content  => {
          type     => "m.login.password",
-         user     => $user->user_id,
+         identifier => {
+            type => "m.id.user",
+            user => $user->user_id,
+         },
          password => $user->password,
          %args,
       },

--- a/tests/10apidoc/12device_management.pl
+++ b/tests/10apidoc/12device_management.pl
@@ -37,7 +37,7 @@ sub matrix_delete_device {
 }
 
 test "GET /device/{deviceId}",
-   requires => [ local_user_fixture( with_events => 0 ) ],
+   requires => [ local_user_fixture() ],
 
    do => sub {
       my ( $user ) = @_;
@@ -64,7 +64,7 @@ test "GET /device/{deviceId}",
    };
 
 test "GET /device/{deviceId} gives a 404 for unknown devices",
-   requires => [ local_user_fixture( with_events => 0 ) ],
+   requires => [ local_user_fixture() ],
 
    do => sub {
       my ( $user ) = @_;
@@ -78,7 +78,7 @@ test "GET /device/{deviceId} gives a 404 for unknown devices",
 
 
 test "GET /devices",
-   requires => [ local_user_fixture( with_events => 0 ) ],
+   requires => [ local_user_fixture() ],
 
    do => sub {
       my ( $user ) = @_;
@@ -136,7 +136,7 @@ test "GET /devices",
    };
 
 test "PUT /device/{deviceId} updates device fields",
-   requires => [ local_user_fixture( with_events => 0 ) ],
+   requires => [ local_user_fixture() ],
 
    do => sub {
       my ( $user ) = @_;
@@ -172,7 +172,7 @@ test "PUT /device/{deviceId} updates device fields",
    };
 
 test "PUT /device/{deviceId} gives a 404 for unknown devices",
-   requires => [ local_user_fixture( with_events => 0 ) ],
+   requires => [ local_user_fixture() ],
 
    do => sub {
       my ( $user ) = @_;
@@ -188,7 +188,7 @@ test "PUT /device/{deviceId} gives a 404 for unknown devices",
    };
 
 test "DELETE /device/{deviceId}",
-   requires => [ local_user_fixture( with_events => 0 ) ],
+   requires => [ local_user_fixture() ],
 
    do => sub {
       my ( $user ) = @_;
@@ -273,8 +273,8 @@ test "DELETE /device/{deviceId}",
 #
 test "DELETE /device/{deviceId} requires UI auth user to match device owner",
    requires => [
-      local_user_fixture( with_events => 0 ),
-      local_user_fixture( with_events => 0 ),
+      local_user_fixture(),
+      local_user_fixture(),
    ],
 
    do => sub {
@@ -317,7 +317,7 @@ test "DELETE /device/{deviceId} requires UI auth user to match device owner",
 
 
 test "DELETE /device/{deviceId} with no body gives a 401",
-   requires => [ local_user_fixture( with_events => 0 ) ],
+   requires => [ local_user_fixture() ],
 
    do => sub {
       my ( $user ) = @_;

--- a/tests/10apidoc/13ui-auth.pl
+++ b/tests/10apidoc/13ui-auth.pl
@@ -1,0 +1,274 @@
+use JSON qw( decode_json );
+use URI::Escape;
+
+our @EXPORT = qw( wait_for_cas_request );
+
+# A convenience function which wraps await_http_request. It returns a successful
+# CAS response when queried for a particular path.
+#
+# This takes two parameters:
+#  * The expected path of the request the homeserver makes to the CAS server.
+#  * A hash of parameters with the following (optional) keys:
+#    * response: The HTTP response body to return to the homeserver request.
+sub wait_for_cas_request
+{
+   my ( $expected_path, %params ) = @_;
+
+   await_http_request( $expected_path, sub {
+      return 1;
+   })->then( sub {
+      my ( $request ) = @_;
+
+      my $response = HTTP::Response->new( 200 );
+      $response->add_content( $params{response} // "" );
+      $response->content_type( "text/plain" );
+      $response->content_length( length $response->content );
+      $request->respond( $response );
+
+      Future->done( $request );
+   });
+}
+
+# Generate a ticket-submission request from the client to the homeserver.
+#
+# Waits for the validation request from the homeserver, and returns the given response.
+sub make_ticket_request
+{
+   my ( $http, $homeserver_info, $session, $ticket, $response ) = @_;
+
+   # Note that we skip almost all of the CAS flow since it isn't important
+   # for this test. The user just needs to end up back at the homeserver
+   # with a valid ticket (and the original UI Auth session ID).
+   my $login_uri = $homeserver_info->client_location . "/_matrix/client/r0/login/cas/ticket?session=$session&ticket=$ticket";
+
+   Future->needs_all(
+      wait_for_cas_request(
+         "/cas/proxyValidate",
+         response => $response,
+      ),
+      $http->do_request_json(
+         method   => "GET",
+         full_uri => $login_uri,
+         max_redirects => 0, # don't follow the redirect
+      ),
+   );
+}
+
+test "Interactive authentication types include SSO",
+   requires => [ local_user_fixture() ],
+
+   do => sub {
+      my ( $user ) = @_;
+
+      my $DEVICE_ID = "login_device";
+
+      matrix_login_again_with_user(
+         $user,
+         device_id => $DEVICE_ID,
+         initial_device_display_name => "device display",
+      )->then( sub {
+         # Initiate the interactive authentication session.
+         matrix_delete_device( $user, $DEVICE_ID, {} );
+      })->main::expect_http_401->then( sub {
+         my ($resp) = @_;
+
+         my $body = decode_json $resp->content;
+
+         log_if_fail "Response to empty body", $body;
+
+         assert_json_keys($body, qw(session params flows));
+         assert_json_list $body->{flows};
+
+         # Note that this uses the unstable value.
+         die "org.matrix.login.sso was not listed" unless
+            any { $_->{stages}[0] eq "org.matrix.login.sso" } @{ $body->{flows} };
+
+         Future->done( 1 );
+      });
+   };
+
+test "Can perform interactive authentication with SSO",
+   requires => [
+      local_user_fixture(),
+      $main::API_CLIENTS[0],
+      $main::HOMESERVER_INFO[0],
+   ],
+
+   do => sub {
+      my ( $user, $http, $homeserver_info ) = @_;
+
+      my $DEVICE_ID = "login_device";
+
+      my ($user_localpart) = $user->user_id =~ m/@([^:]*):/;
+      my $CAS_SUCCESS = <<"EOF";
+<cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
+    <cas:authenticationSuccess>
+         <cas:user>$user_localpart</cas:user>
+         <cas:attributes></cas:attributes>
+    </cas:authenticationSuccess>
+</cas:serviceResponse>
+EOF
+
+      # the ticket our mocked-up CAS server "generates"
+      my $CAS_TICKET = "goldenticket";
+      my $session;
+
+      # Create a device.
+      matrix_login_again_with_user(
+         $user,
+         device_id => $DEVICE_ID,
+         initial_device_display_name => "device display",
+      )->then( sub {
+         # Initiate the interactive authentication session via device deletion.
+         matrix_delete_device( $user, $DEVICE_ID, {} );
+      })->main::expect_http_401->then( sub {
+         my ( $resp ) = @_;
+
+         my $body = decode_json $resp->content;
+
+         log_if_fail "Response to empty body", $body;
+
+         assert_json_keys( $body, qw( session params flows ));
+
+         $session = $body->{session};
+
+         make_ticket_request( $http, $homeserver_info, $session, $CAS_TICKET, $CAS_SUCCESS );
+      })->then( sub {
+         # Repeat the device deletion, which should now complete.
+         matrix_delete_device( $user, $DEVICE_ID, {
+            auth => {
+               session => $session,
+            },
+         });
+      })->then( sub {
+         # the device should be deleted.
+         matrix_get_device( $user, $DEVICE_ID )->main::expect_http_404;
+      });
+   };
+
+test "The user must be consistent through an interactive authentication session with SSO",
+   requires => [
+      local_user_fixture(),
+      $main::API_CLIENTS[0],
+      $main::HOMESERVER_INFO[0],
+   ],
+
+   do => sub {
+      my ( $user, $http, $homeserver_info ) = @_;
+
+      my $DEVICE_ID = "login_device";
+
+      # The user below is what is returned from SSO and does not match the user
+      # being logged into the homeserver.
+      my $CAS_SUCCESS = <<'EOF';
+<cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
+    <cas:authenticationSuccess>
+         <cas:user>cas_user</cas:user>
+         <cas:attributes></cas:attributes>
+    </cas:authenticationSuccess>
+</cas:serviceResponse>
+EOF
+
+      # the ticket our mocked-up CAS server "generates"
+      my $CAS_TICKET = "goldenticket";
+      my $session;
+
+      # Create a device.
+      matrix_login_again_with_user(
+         $user,
+         device_id => $DEVICE_ID,
+         initial_device_display_name => "device display",
+      )->then( sub {
+         # Initiate the interactive authentication session via device deletion.
+         matrix_delete_device( $user, $DEVICE_ID, {} );
+      })->main::expect_http_401->then( sub {
+         my ( $resp ) = @_;
+
+         my $body = decode_json $resp->content;
+
+         log_if_fail "Response to empty body", $body;
+
+         assert_json_keys( $body, qw( session params flows ));
+
+         $session = $body->{session};
+
+         make_ticket_request( $http, $homeserver_info, $session, $CAS_TICKET, $CAS_SUCCESS );
+      })->then( sub {
+         # Repeat the device deletion, which should now give an auth error.
+         matrix_delete_device( $user, $DEVICE_ID, {
+            auth => {
+               session => $session,
+            },
+         })->main::expect_http_403;
+      })->then( sub {
+         # The device delete was rejected (the device should still exist).
+         matrix_get_device( $user, $DEVICE_ID );
+      })->then( sub {
+         my ( $device ) = @_;
+         assert_json_keys(
+            $device,
+            qw( device_id user_id display_name ),
+         );
+         assert_eq( $device->{device_id}, $DEVICE_ID );
+         assert_eq( $device->{display_name}, "device display" );
+         Future->done( 1 );
+      });
+   };
+
+
+test "The operation must be consistent through an interactive authentication session",
+   requires => [ local_user_fixture() ],
+
+   do => sub {
+      my ( $user ) = @_;
+
+      my $DEVICE_ID = "login_device";
+      my $SECOND_DEVICE_ID = "second_device";
+
+      # Create two devices.
+      matrix_login_again_with_user(
+         $user,
+         device_id => $DEVICE_ID,
+         initial_device_display_name => "device display",
+      )->then( sub {
+         matrix_login_again_with_user(
+            $user,
+            device_id => $SECOND_DEVICE_ID,
+            initial_device_display_name => "device display",
+         )
+      })->then( sub {
+         # Initiate the interactive authentication session with the first device.
+         matrix_delete_device( $user, $DEVICE_ID, {} );
+      })->main::expect_http_401->then( sub {
+         my ( $resp ) = @_;
+
+         my $body = decode_json $resp->content;
+
+         log_if_fail "Response to empty body", $body;
+
+         assert_json_keys( $body, qw( session params flows ));
+
+         # Continue the interactive authentication session (by providing
+         # credentials), but attempt to delete the second device.
+         matrix_delete_device( $user, $SECOND_DEVICE_ID, {
+             auth => {
+                type     => "m.login.password",
+                user     => $user->user_id,
+                password => $user->password,
+                session  => $body->{session},
+             }
+         })->main::expect_http_403;
+      })->then( sub {
+         # The device delete was rejected (the device should still exist).
+         matrix_get_device( $user, $SECOND_DEVICE_ID );
+      })->then( sub {
+         my ( $device ) = @_;
+         assert_json_keys(
+            $device,
+            qw( device_id user_id display_name ),
+         );
+         assert_eq( $device->{device_id}, $SECOND_DEVICE_ID );
+         assert_eq( $device->{display_name}, "device display" );
+         Future->done( 1 );
+      });
+   };

--- a/tests/10apidoc/30room-create.pl
+++ b/tests/10apidoc/30room-create.pl
@@ -318,7 +318,7 @@ sub matrix_create_room
    });
 }
 
-push @EXPORT, qw( room_alias_name_fixture room_alias_fixture matrix_create_room_synced );
+push @EXPORT, qw( room_alias_name_fixture room_alias_fixture remote_room_alias_fixture matrix_create_room_synced );
 
 my $next_alias_name = 0;
 
@@ -356,7 +356,7 @@ sub room_alias_name_fixture
 
 =head2 room_alias_fixture
 
-   $fixture = room_alias_fixture( prefix => $prefix )
+   $fixture = room_alias_fixture( prefix => $prefix, remote => 0 )
 
 Returns a new Fixture, which when provisioned will allocate a name for a new
 room alias on the first homeserver, and return it as a string. Note that this
@@ -366,6 +366,9 @@ new unique name for one.
 An optional prefix string can be provided, which will be prepended onto the
 alias name.
 
+An optional remote boolean can be supplied, which will generate an alias for
+the second homeserver instead.
+
 =cut
 
 sub room_alias_fixture
@@ -374,7 +377,8 @@ sub room_alias_fixture
 
    return fixture(
       requires => [
-         room_alias_name_fixture( prefix => $args{prefix} ), $main::HOMESERVER_INFO[0],
+         room_alias_name_fixture( prefix => $args{prefix} ),
+         $args{remote} ? $main::HOMESERVER_INFO[1] : $main::HOMESERVER_INFO[0],
       ],
 
       setup => sub {
@@ -383,6 +387,27 @@ sub room_alias_fixture
          Future->done( sprintf "#%s:%s", $alias_name, $info->server_name );
       },
    );
+}
+
+=head2 remote_room_alias_fixture
+
+   $fixture = remote_room_alias_fixture( prefix => $prefix )
+
+Returns a new Fixture, which when provisioned will allocate a name for a new
+room alias on the second homeserver, and return it as a string. Note that this
+does not actually create the alias on the server itself, it simply suggests a
+new unique name for one.
+
+An optional prefix string can be provided, which will be prepended onto the
+alias name.
+
+=cut
+
+sub remote_room_alias_fixture
+{
+   my %args = @_;
+
+   return room_alias_fixture( prefix => $args{prefix}, remote => 1 );
 }
 
 

--- a/tests/10apidoc/33room-members.pl
+++ b/tests/10apidoc/33room-members.pl
@@ -512,6 +512,11 @@ server and return the room id.
 C<$user_fixture> should be a Fixture which will provide a User when
 provisioned.
 
+C<opts> can contain a boolean key called C<synced>, which determines whether to
+perform a user /sync request after creating the room. This involves inserting
+and checking for a 'm.room.test' event in the room state, which may be
+undesirable in some cases. Defaults to 1.
+
 Any other options are passed into C<matrix_create_room>, whence they are passed
 on to the server.
 
@@ -531,7 +536,16 @@ sub room_fixture
       setup => sub {
          my ( $user ) = @_;
 
-         matrix_create_room( $user, %args )->then( sub {
+         # Determine whether to create room synced or not. Default is synced
+         #
+         # This will insert a m.room.test event into room state which
+         # some tests may not want
+         my $sync = 1;
+         if ( exists( $args{synced} ) && $args{synced} == 0 ) {
+            $sync = 0;
+         }
+
+         ( $sync ? matrix_create_room_synced( $user, %args ) : matrix_create_room( $user, %args ) )->then( sub {
             my ( $room_id ) = @_;
             # matrix_create_room returns the room_id and the room_alias if
             #  one was set. However we only want to return the room_id
@@ -611,7 +625,7 @@ through to C<setup_user>.
 
 =item room_opts => HASH
 
-Options to use when creating the room. Thes are passed into into
+Options to use when creating the room. These are passed into
 C<matrix_create_room>, whence they are passed on to the server.
 
 =back

--- a/tests/14account/02deactivate.pl
+++ b/tests/14account/02deactivate.pl
@@ -67,7 +67,10 @@ test "After deactivating account, can't log in with password",
             uri     => "/r0/login",
             content => {
                type     => "m.login.password",
-               user     => $user->user_id,
+               identifier => {
+                  type => "m.id.user",
+                  user => $user->user_id,
+               },
                password => $user->password,
             }
          # We don't mandate the exact failure code here

--- a/tests/30rooms/01state.pl
+++ b/tests/30rooms/01state.pl
@@ -263,7 +263,9 @@ sub set_test_state
 }
 
 test "Setting state twice is idempotent",
-   requires => [ local_user_and_room_fixtures() ],
+   # Setting synced to 1 inserts a m.room.test object into the
+   # timeline which this test does not expect
+   requires => [ local_user_and_room_fixtures( room_opts => { synced => 0 } ) ],
 
    check => sub {
       my ( $user, $room_id ) = @_;

--- a/tests/30rooms/03members-remote.pl
+++ b/tests/30rooms/03members-remote.pl
@@ -70,13 +70,12 @@ test "New room members see their own join event",
    do => sub {
       my ( $user, $room_id, $room_alias ) = @_;
 
-      await_event_for( $user, filter => sub {
+      await_sync_timeline_contains( $user, $room_id, check => sub {
          my ( $event ) = @_;
          return unless $event->{type} eq "m.room.member";
 
-         assert_json_keys( $event, qw( type room_id user_id ));
-         return unless $event->{room_id} eq $room_id;
-         return unless $event->{user_id} eq $user->user_id;
+         assert_json_keys( $event, qw( type sender ));
+         return unless $event->{sender} eq $user->user_id;
 
          assert_json_keys( my $content = $event->{content}, qw( membership displayname avatar_url ));
 
@@ -124,12 +123,11 @@ test "Existing members see new members' join events",
    do => sub {
       my ( $first_user, $user, $room_id, $room_alias ) = @_;
 
-      await_event_for( $first_user, filter => sub {
+      await_sync_timeline_contains( $first_user, $room_id, check => sub {
          my ( $event ) = @_;
          return unless $event->{type} eq "m.room.member";
-         assert_json_keys( $event, qw( type room_id user_id ));
-         return unless $event->{room_id} eq $room_id;
-         return unless $event->{user_id} eq $user->user_id;
+         assert_json_keys( $event, qw( type sender ));
+         return unless $event->{sender} eq $user->user_id;
 
          assert_json_keys( my $content = $event->{content}, qw( membership displayname avatar_url ));
 

--- a/tests/30rooms/04messages.pl
+++ b/tests/30rooms/04messages.pl
@@ -215,6 +215,15 @@ test "Message history can be paginated",
             body => "Message number $_[0]"
          )
       } foreach => [ 1 .. 20 ] )->then( sub {
+         await_sync_timeline_contains(
+            $user, $room_id, check => sub {
+               any {
+                  $_->{type} eq "m.room.message"
+                  && $_->{content}{body} eq "Message number 20"
+               } @_;
+            },
+         );
+      })->then( sub {
          matrix_get_room_messages( $user, $room_id, limit => 5 )
       })->then( sub {
          my ( $body ) = @_;

--- a/tests/30rooms/05aliases.pl
+++ b/tests/30rooms/05aliases.pl
@@ -144,7 +144,7 @@ multi_test "Canonical alias can include alt_aliases",
                alias => $room_alias,
                alt_aliases => [ $bad_alias ],
             }
-         )->main::expect_matrix_error( 404, "M_NOT_FOUND" )
+         )->main::expect_matrix_error( 400, "M_BAD_ALIAS" )
             ->SyTest::pass_on_done( "m.room.canonical_alias rejects missing aliases" );
       })->then( sub {
          # Create an invalid alias name (starts with % instead of #).
@@ -345,7 +345,7 @@ test "Users with sufficient power-level can delete other's aliases",
    };
 
 test "Can delete canonical alias",
-   requires => [ local_user_fixture( with_events => 0 ), room_alias_fixture(),
+   requires => [ local_user_fixture(), room_alias_fixture(),
                  qw( can_create_room_alias )],
 
    do => sub {

--- a/tests/30rooms/12thirdpartyinvite.pl
+++ b/tests/30rooms/12thirdpartyinvite.pl
@@ -190,7 +190,7 @@ test "Can invite unbound 3pid over federation with no ops into a private room",
       matrix_create_and_join_room(
          [ $creator, $inviter ],
          visibility => "private",
-         preset => "private_chat",
+         preset => "private_chat",  # Allow default PL users to invite others
          with_invite => 1,
       )->then( sub {
          my ( $room_id ) = @_;

--- a/tests/30rooms/13guestaccess.pl
+++ b/tests/30rooms/13guestaccess.pl
@@ -172,13 +172,19 @@ test "Guest user can set display names",
                displayname => "creeper",
             },
       )})->then( sub {
+         my $iter = 0;
+
          retry_until_success {
+            $iter++;
+
             Future->needs_all(
                do_request_json_for( $guest_user,
                   method => "GET",
                   uri    => $displayname_uri,
                )->then( sub {
                   my ( $body ) = @_;
+                  log_if_fail "Iteration $iter: /displayname result", $body;
+
                   assert_eq( $body->{displayname}, "creeper", "Profile displayname" );
 
                   Future->done(1);
@@ -188,6 +194,8 @@ test "Guest user can set display names",
                   uri    => "/r0/rooms/$room_id/state/m.room.member/:user_id",
                )->then( sub {
                   my ( $body ) = @_;
+                  log_if_fail "Iteration $iter: /state result", $body;
+
                   assert_eq( $body->{displayname}, "creeper", "Room displayname" );
 
                   Future->done(1);

--- a/tests/30rooms/13guestaccess.pl
+++ b/tests/30rooms/13guestaccess.pl
@@ -34,7 +34,11 @@ test "Guest users can send messages to guest_access rooms if joined",
 
       matrix_set_room_guest_access( $user, $room_id, "can_join" )
       ->then( sub {
-         matrix_join_room( $guest_user, $room_id )
+         # we use join_room_synced as a proxy for ensuring that the join event
+         # has propagated to the workers, otherwise the worker that receives
+         # the event send request might not know that we are in the room.
+         # (see https://github.com/matrix-org/sytest/issues/836)
+         matrix_join_room_synced( $guest_user, $room_id );
       })->then( sub {
          matrix_send_room_text_message( $guest_user, $room_id, body => "sup" );
       })->then( sub {
@@ -125,7 +129,7 @@ test "Guest users are kicked from guest_access rooms on revocation of guest_acce
 
       matrix_set_room_guest_access( $user, $room_id, "can_join" )
       ->then( sub {
-         matrix_join_room( $guest_user, $room_id );
+         matrix_join_room_synced( $guest_user, $room_id );
       })->then( sub {
          matrix_get_room_membership( $user, $room_id, $guest_user );
       })->then( sub {
@@ -154,7 +158,11 @@ test "Guest user can set display names",
       my $displayname_uri = "/r0/profile/:user_id/displayname";
 
       matrix_set_room_guest_access( $user, $room_id, "can_join" )->then( sub {
-         matrix_join_room( $guest_user, $room_id );
+         # we use join_room_synced as a proxy for ensuring that the join event
+         # has propagated to the workers, otherwise the worker that receives
+         # the profile request might not know that we are in the room.
+         # (see https://github.com/matrix-org/sytest/issues/836)
+         matrix_join_room_synced( $guest_user, $room_id );
       })->then( sub {
          do_request_json_for( $guest_user,
             method => "GET",
@@ -225,7 +233,7 @@ test "Guest users are kicked from guest_access rooms on revocation of guest_acce
          })->then( sub {
             matrix_join_room( $remote_user, $room_id );
          })->then( sub {
-            matrix_join_room( $guest_user, $room_id );
+            matrix_join_room_synced( $guest_user, $room_id );
          })->then( sub {
             matrix_get_room_membership( $local_user, $room_id, $guest_user );
          })->then( sub {

--- a/tests/41end-to-end-keys/06-device-lists.pl
+++ b/tests/41end-to-end-keys/06-device-lists.pl
@@ -731,8 +731,7 @@ test "If user leaves room, remote user changes device and rejoins we see update 
 
       matrix_create_room( $creator,
          invite => [ $remote_user->user_id ],
-         # Allow default PL users to invite others
-         preset => "private_chat",
+         preset => "private_chat",  # Allow default PL users to invite others
       )->then( sub {
          ( $room_id ) = @_;
 

--- a/tests/50federation/31room-send.pl
+++ b/tests/50federation/31room-send.pl
@@ -81,10 +81,9 @@ test "Inbound federation can receive events",
             destination => $first_home_server,
          );
       })->then( sub {
-         await_event_for( $creator, filter => sub {
+         await_sync_timeline_contains( $creator, $room_id, check => sub {
             my ( $event ) = @_;
             return unless $event->{type} eq "m.room.message";
-            return unless $event->{room_id} eq $room_id;
 
             assert_eq( $event->{sender}, $user_id,
                'event sender' );
@@ -132,10 +131,9 @@ test "Inbound federation can receive redacted events",
             destination => $first_home_server,
          );
       })->then( sub {
-         await_event_for( $creator, filter => sub {
+         await_sync_timeline_contains( $creator, $room_id, check => sub {
             my ( $event ) = @_;
             return unless $event->{type} eq "m.room.message";
-            return unless $event->{room_id} eq $room_id;
 
             assert_eq( $event->{sender}, $user_id,
                'event sender' );

--- a/tests/50federation/33room-get-missing-events.pl
+++ b/tests/50federation/33room-get-missing-events.pl
@@ -94,11 +94,14 @@ test "Outbound federation can request missing events",
          );
       })->then( sub {
          # creator user should eventually receive the missing event
-         await_event_for( $creator, filter => sub {
-            my ( $event ) = @_;
-            return $event->{type} eq "m.room.message" &&
-                   $event->{event_id} eq $missing_event->{event_id};
-         });
+         await_sync_timeline_contains(
+            $creator, $room_id,
+            check => sub {
+               my ( $event ) = @_;
+               $event->{type} eq "m.room.message" &&
+               $event->{event_id} eq $missing_event->{event_id};
+            },
+         );
       });
    };
 

--- a/tests/50federation/33room-get-missing-events.pl
+++ b/tests/50federation/33room-get-missing-events.pl
@@ -105,7 +105,9 @@ test "Outbound federation can request missing events",
 foreach my $vis (qw( world_readable shared invite joined )) {
    test "Inbound federation can return missing events for $vis visibility",
       requires => [ $main::OUTBOUND_CLIENT,
-                    local_user_and_room_fixtures(),
+                    # Setting synced to 1 inserts a m.room.test object into the
+                    # timeline which this test does not expect
+                    local_user_and_room_fixtures( room_opts => { synced => 0 } ),
                     federation_user_id_fixture() ],
 
       do => sub {


### PR DESCRIPTION
Does what it says on the tin.

Synapse PR: https://github.com/matrix-org/synapse-dinsic/pull/45

TODO:

- [x] ~~The CI is currently failing because sytest is looking for `dinsic-release-v1.14.x` on synapse, not synapse-dinsic. This can be fixed in a separate PR before merging this one.~~ The problem actually resides in Sytest's [pipeline downloading the Synapse branch](https://github.com/matrix-org/pipelines/blob/fafea2f5f35c7f9084fab27ccd4a742430ca6ae8/sytest/pipeline.yml#L45) from the main repo. This would need to be moved into a codebase so that we could differentiate by branch.

For now the CI on the Synapse PR says this passes, so we can just use that.