### PR TITLE
Switch to YAML::XS for YAML serialisation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
 .git/
+server-0/
+server-1/

--- a/cpanfile
+++ b/cpanfile
@@ -51,4 +51,4 @@ requires 'Net::SSLeay', '>= 1.59';
 requires 'Protocol::Matrix', '>= 0.02';
 requires 'Struct::Dumb', '>= 0.04';
 requires 'URI::Escape';
-requires 'YAML';
+requires 'YAML::XS';

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -18,7 +18,7 @@ use File::Path qw( remove_tree );
 use List::Util qw( any );
 use POSIX qw( strftime WIFEXITED WEXITSTATUS );
 
-use YAML ();
+use JSON;
 
 use SyTest::SSL qw( ensure_ssl_key create_ssl_cert );
 
@@ -410,9 +410,8 @@ sub generate_listeners
          type         => "http",
          port         => $unsecure_port,
          bind_address => $bind_host,
-         tls          => 0,
          resources    => [{
-            names => [ "client", "federation", "replication", "metrics" ], compress => 0
+            names => [ "client", "federation", "replication", "metrics" ]
          }]
       }
    }
@@ -422,7 +421,6 @@ sub generate_listeners
          type         => "replication",
          port         => $replication_tcp_port,
          bind_address => $bind_host,
-         tls          => 0,
       }
    }
 
@@ -431,7 +429,6 @@ sub generate_listeners
          type         => "metrics",
          port         => $self->{ports}{synapse_metrics},
          bind_address => $bind_host,
-         tls          => 0,
       };
 }
 
@@ -643,9 +640,9 @@ sub generate_listeners
          type => "http",
          port => $self->{ports}{synapse},
          bind_address => $self->{bind_host},
-         tls => 1,
+         tls => JSON::true,
          resources => [{
-            names => [ "client", "federation", "replication", "metrics" ], compress => 0
+            names => [ "client", "federation", "replication", "metrics" ]
          }]
       },
       $self->SUPER::generate_listeners;

--- a/tests/04mail-server.pl
+++ b/tests/04mail-server.pl
@@ -44,7 +44,9 @@ our $MAIL_SERVER_INFO = fixture(
          $OUTPUT->diag( "Started test SMTP Server at $sockname" );
          Future->done({
             host => $BIND_HOST,
-            port => $sockport,
+            # +0 because otherwise this comes back as a string, and perl is
+            # awful
+            port => $sockport + 0,
          });
       });
    },

--- a/tests/05homeserver.pl
+++ b/tests/05homeserver.pl
@@ -93,11 +93,11 @@ our @HOMESERVER_INFO = map {
                   sender_localpart => $as_info->localpart,
                   namespaces => {
                      users => [
-                        { regex => '@_.*:' . $info->server_name, exclusive => "false" },
-                        map { { regex => $_, exclusive => "true" } } @{ $as_info->user_regexes },
+                        { regex => '@_.*:' . $info->server_name, exclusive => JSON::false },
+                        map { { regex => $_, exclusive => JSON::true } } @{ $as_info->user_regexes },
                      ],
                      aliases => [
-                        map { { regex => $_, exclusive => "true" } } @{ $as_info->alias_regexes },
+                        map { { regex => $_, exclusive => JSON::true } } @{ $as_info->alias_regexes },
                      ],
                      rooms => [],
                   },


### PR DESCRIPTION
it's better at understanding the difference between `1`, `true`, and
`"true"`. This leads to a few fixes around the codebase where it turned out we
were getting away with some sloppiness thanks to `YAML`'s idiosyncracies.