### PR TITLE
Allow filename= formatted Content-Disposition

### DIFF
--- a/tests/51media/01unicode.pl
+++ b/tests/51media/01unicode.pl
@@ -1,6 +1,7 @@
 use HTTP::Headers::Util qw( split_header_words );
 use URI::Escape qw( uri_escape );
 use SyTest::TCPProxy;
+use utf8;
 
 my $FILENAME = "\xf0\x9f\x90\x94";
 my $FILENAME_ENCODED = uc uri_escape( $FILENAME );
@@ -168,8 +169,12 @@ sub test_using_client
    get_media( $client, $content )->then( sub {
       my ( $cd_params ) = @_;
 
-      if (exists( $cd_params->{'filename'} )) {
-         assert_eq( $cd_params->{'filename'}, "utf-8\"$FILENAME\"", "filename" );
+      # The Content-Disposition header can take two formats - either:
+      #  * filename=utf-8"filename_here"
+      #  * filename*=utf-8''filename_here
+      # This checks the format of whichever one we were provided with. 
+      if (exists( $cd_params->{filename} )) {
+         assert_eq( $cd_params->{filename}, "utf-8\"$FILENAME\"", "filename" );
       } else {
          assert_eq( $cd_params->{'filename*'}, "utf-8''$FILENAME_ENCODED", "filename*" );
       }

--- a/tests/51media/01unicode.pl
+++ b/tests/51media/01unicode.pl
@@ -168,7 +168,7 @@ sub test_using_client
    get_media( $client, $content )->then( sub {
       my ( $cd_params ) = @_;
 
-      if (defined( $cd_params->{'filename'} )) {
+      if (exists( $cd_params->{'filename'} )) {
          assert_eq( $cd_params->{'filename'}, "utf-8\"$FILENAME\"", "filename" );
       } else {
          assert_eq( $cd_params->{'filename*'}, "utf-8''$FILENAME_ENCODED", "filename*" );

--- a/tests/51media/01unicode.pl
+++ b/tests/51media/01unicode.pl
@@ -212,6 +212,7 @@ test "Can download specifying a different Unicode file name",
    check => sub {
       my ( $http ) = @_;
 
+      my $alt_filename = "☕";
       my $alt_filename_encoded = "%E2%98%95";
 
       $http->do_request(
@@ -222,7 +223,7 @@ test "Can download specifying a different Unicode file name",
 
          my $disposition = $response->header( "Content-Disposition" );
          uc $disposition eq uc "inline; filename*=utf-8''$alt_filename_encoded" or
-            uc $disposition eq uc "inline; filename=utf-8\"$alt_filename_encoded\"" or
+            uc $disposition eq uc "inline; filename=utf-8\"$alt_filename\"" or
             die "Expected a UTF-8 filename parameter";
 
          Future->done(1);

--- a/tests/51media/01unicode.pl
+++ b/tests/51media/01unicode.pl
@@ -222,6 +222,7 @@ test "Can download specifying a different Unicode file name",
 
          my $disposition = $response->header( "Content-Disposition" );
          uc $disposition eq uc "inline; filename*=utf-8''$alt_filename_encoded" or
+            uc $disposition eq uc "inline; filename=utf-8\"$alt_filename_encoded\"" or
             die "Expected a UTF-8 filename parameter";
 
          Future->done(1);

--- a/tests/51media/01unicode.pl
+++ b/tests/51media/01unicode.pl
@@ -167,7 +167,13 @@ sub test_using_client
 
    get_media( $client, $content )->then( sub {
       my ( $cd_params ) = @_;
-      assert_eq( $cd_params->{'filename*'}, "utf-8''$FILENAME_ENCODED", "filename*" );
+
+      if (defined( $cd_params->{'filename'} )) {
+         assert_eq( $cd_params->{'filename'}, "utf-8\"$FILENAME\"", "filename" );
+      } else {
+         assert_eq( $cd_params->{'filename*'}, "utf-8''$FILENAME_ENCODED", "filename*" );
+      }
+
       Future->done(1);
    });
 }


### PR DESCRIPTION
In the `Content-Disposition` header, Synapse uses `inline; filename*=utf-8''foo` but Dendrite uses `inline; filename=utf-8\"foo\"`.

This updates the test to support both, rather than just the former.

Additional info in Synapse's own source code: https://github.com/matrix-org/synapse/blob/a3f11567d930b7da0db068c3b313f6f4abbf12a1/synapse/rest/media/v1/_base.py#L122-L140