### PR TITLE
Fix a warning about referencing a scalar as an array.

### DIFF
--- a/tests/50federation/33room-get-missing-events.pl
+++ b/tests/50federation/33room-get-missing-events.pl
@@ -426,7 +426,7 @@ test "Outbound federation will ignore a missing event with bad JSON for room ver
    do => sub {
       my ( $outbound_client, $inbound_server, $creator, $user_id, @rooms ) = @_;
 
-      my $room = @rooms[0];
+      my $room = $rooms[0];
       my $room_id = $room->{room_id};
       my $first_home_server = $creator->server_name;
 


### PR DESCRIPTION
Removes a warning:
`** Scalar value @rooms[0] better written as $rooms[0] at tests/50federation/33room-get-missing-events.pl line 429.`