### PR TITLE
Make typing tests use /sync not /events

### DIFF
--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -45,7 +45,6 @@ TEST_STATUS=0
 mkdir -p /logs
 ./run-tests.pl -I Dendrite::Monolith -d $GOBIN -W /src/sytest-whitelist -O tap --all \
     --work-directory="/work" \
-    tests/30rooms/20typing.pl \
     "$@" > /logs/results.tap || TEST_STATUS=$?
 
 if [ $TEST_STATUS -ne 0 ]; then

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -45,6 +45,7 @@ TEST_STATUS=0
 mkdir -p /logs
 ./run-tests.pl -I Dendrite::Monolith -d $GOBIN -W /src/sytest-whitelist -O tap --all \
     --work-directory="/work" \
+    tests/30rooms/20typing.pl \
     "$@" > /logs/results.tap || TEST_STATUS=$?
 
 if [ $TEST_STATUS -ne 0 ]; then

--- a/tests/10apidoc/09synced.pl
+++ b/tests/10apidoc/09synced.pl
@@ -6,6 +6,7 @@ push our @EXPORT, qw(
    sync_timeline_contains
    await_sync
    await_sync_timeline_contains
+   await_sync_ephemeral_contains
    await_sync_timeline_or_state_contains
    await_sync_presence_contains
 );
@@ -92,6 +93,13 @@ sub sync_timeline_contains
    my ( $sync_body, $room_id, $check ) = @_;
 
    sync_room_contains( $sync_body, $room_id, "timeline", $check );
+}
+
+sub sync_ephemeral_contains
+{
+   my ( $sync_body, $room_id, $check ) = @_;
+
+   sync_room_contains( $sync_body, $room_id, "ephemeral", $check );
 }
 
 sub sync_presence_contains
@@ -184,6 +192,21 @@ sub await_sync_timeline_contains {
          my ( $body ) = @_;
 
          return sync_timeline_contains( $body, $room_id, $check ) ? $body : 0;
+      },
+      %params,
+   )
+}
+
+sub await_sync_ephemeral_contains {
+   my ( $user, $room_id, %params ) = @_;
+
+   my $check = delete $params{check} or die "Must supply a 'check' param";
+
+   return await_sync( $user,
+      check => sub {
+         my ( $body ) = @_;
+
+         return sync_ephemeral_contains( $body, $room_id, $check ) ? $body : 0;
       },
       %params,
    )

--- a/tests/10apidoc/09synced.pl
+++ b/tests/10apidoc/09synced.pl
@@ -197,6 +197,24 @@ sub await_sync_timeline_contains {
    )
 }
 
+=head2 await_sync_ephemeral_contains
+
+    $sync_body = await_sync_ephemeral_contains( $user, $room_id,
+        check => sub {
+            my ( $event ) = @_;
+            return true_if_event_matches();
+        },
+    )->get();
+
+Waits for something to appear in a the ephemeral section of a particular room.
+Returns the sync body.
+
+The C<check> function gets given individual events.
+
+See L</await_sync> for details of the C<since> parameter.
+
+=cut
+
 sub await_sync_ephemeral_contains {
    my ( $user, $room_id, %params ) = @_;
 

--- a/tests/30rooms/20typing.pl
+++ b/tests/30rooms/20typing.pl
@@ -119,8 +119,7 @@ test "Typing can be explicitly stopped",
                   assert_json_keys( my $content = $event->{content}, qw( user_ids ));
                   assert_json_list( my $users = $content->{user_ids} );
 
-                  scalar @$users and
-                     die "Expected 0 members to be typing";
+                  return unless scalar @$users == 1;
 
                   return 1;
                },

--- a/tests/30rooms/20typing.pl
+++ b/tests/30rooms/20typing.pl
@@ -43,31 +43,29 @@ test "Typing notification sent to local room members",
       my ( $typinguser, $local_user, $room_id ) = @_;
 
       matrix_typing( $typinguser, $room_id,
-         typing => 1,
+         typing => JSON::true,
          timeout => 30000, # msec
       )->then( sub {
          Future->needs_all( map {
             my $recvuser = $_;
 
-            await_event_for( $recvuser, filter => sub {
-               my ( $event ) = @_;
+            await_sync_ephemeral_contains($recvuser, $room_id,
+               check => sub {
+                  my ( $event ) = @_;
+                  return unless $event->{type} eq "m.typing";
 
-               return unless $event->{type} eq "m.typing";
+                  assert_json_keys( $event, qw( type content ));
+                  assert_json_keys( my $content = $event->{content}, qw( user_ids ));
+                  assert_json_list( my $users = $content->{user_ids} );
 
-               assert_json_keys( $event, qw( type room_id content ));
-               assert_json_keys( my $content = $event->{content}, qw( user_ids ));
+                  scalar @$users == 1 or
+                     die "Expected 1 member to be typing";
+                  $users->[0] eq $typinguser->user_id or
+                     die "Expected ${\ $typinguser->user_id } to be typing";
 
-               return unless $event->{room_id} eq $room_id;
-
-               assert_json_list( my $users = $content->{user_ids} );
-
-               scalar @$users == 1 or
-                  die "Expected 1 member to be typing";
-               $users->[0] eq $typinguser->user_id or
-                  die "Expected ${\ $typinguser->user_id } to be typing";
-
-               return 1;
-            })
+                  return 1;
+               },
+            )
          } $typinguser, $local_user );
       });
    };
@@ -80,25 +78,24 @@ test "Typing notifications also sent to remote room members",
    do => sub {
       my ( $typinguser, $remote_user, $room_id ) = @_;
 
-      await_event_for( $remote_user, filter => sub {
-         my ( $event ) = @_;
+      await_sync_ephemeral_contains($remote_user, $room_id,
+         check => sub {
+            my ( $event ) = @_;
+            return unless $event->{type} eq "m.typing";
 
-         return unless $event->{type} eq "m.typing";
+            assert_json_keys( $event, qw( type content ));
+            assert_json_keys( my $content = $event->{content}, qw( user_ids ));
 
-         assert_json_keys( $event, qw( type room_id content ));
-         assert_json_keys( my $content = $event->{content}, qw( user_ids ));
+            assert_json_list( my $users = $content->{user_ids} );
 
-         return unless $event->{room_id} eq $room_id;
+            scalar @$users == 1 or
+               die "Expected 1 member to be typing";
+            $users->[0] eq $typinguser->user_id or
+               die "Expected ${\ $typinguser->user_id } to be typing";
 
-         assert_json_list( my $users = $content->{user_ids} );
-
-         scalar @$users == 1 or
-            die "Expected 1 member to be typing";
-         $users->[0] eq $typinguser->user_id or
-            die "Expected ${\ $typinguser->user_id } to be typing";
-
-         return 1;
-      })
+            return 1;
+         },
+      )
    };
 
 
@@ -109,27 +106,25 @@ test "Typing can be explicitly stopped",
    do => sub {
       my ( $typinguser, $local_user, $room_id ) = @_;
 
-      matrix_typing( $typinguser, $room_id, typing => 0 )->then( sub {
+      matrix_typing( $typinguser, $room_id, typing => JSON::false )->then( sub {
          Future->needs_all( map {
             my $recvuser = $_;
 
-            await_event_for( $recvuser, filter => sub {
-               my ( $event ) = @_;
+            await_sync_ephemeral_contains($recvuser, $room_id,
+               check => sub {
+                  my ( $event ) = @_;
+                  return unless $event->{type} eq "m.typing";
 
-               return unless $event->{type} eq "m.typing";
+                  assert_json_keys( $event, qw( type content ));
+                  assert_json_keys( my $content = $event->{content}, qw( user_ids ));
+                  assert_json_list( my $users = $content->{user_ids} );
 
-               assert_json_keys( $event, qw( type room_id content ));
-               assert_json_keys( my $content = $event->{content}, qw( user_ids ));
+                  scalar @$users and
+                     die "Expected 0 members to be typing";
 
-               return unless $event->{room_id} eq $room_id;
-
-               assert_json_list( my $users = $content->{user_ids} );
-
-               scalar @$users and
-                  die "Expected 0 members to be typing";
-
-               return 1;
-            })
+                  return 1;
+               },
+            )
          } $typinguser, $local_user );
       });
    };

--- a/tests/30rooms/20typing.pl
+++ b/tests/30rooms/20typing.pl
@@ -119,9 +119,7 @@ test "Typing can be explicitly stopped",
                   assert_json_keys( my $content = $event->{content}, qw( user_ids ));
                   assert_json_list( my $users = $content->{user_ids} );
 
-                  return unless scalar @$users == 1;
-
-                  return 1;
+                  return scalar @$users == 0;
                },
             )
          } $typinguser, $local_user );

--- a/tests/30rooms/20typing.pl
+++ b/tests/30rooms/20typing.pl
@@ -122,15 +122,15 @@ test "Typing can be explicitly stopped",
                   assert_json_keys( my $content = $event->{content}, qw( user_ids ));
                   assert_json_list( my $users = $content->{user_ids} );
 
-                  my $zero_users = scalar @$users == 0;
-                  if ( !$zero_users ) {
-                     log_if_fail "rejecting event because want zero users typing, but there are some";
-                     if ( $num_typing_events > 1) {
-                        # this is the second time we have seen a typing event with >0 typing users, bail out
-                        die "seen too many typing events with typing users";
-                     }
+                  return 1 if scalar @$users == 0;
+
+                  log_if_fail "rejecting event because want zero users typing, but there are some";
+
+                  if ( $num_typing_events > 1 ) {
+                     # this is the second time we have seen a typing event with >0 typing users, bail out
+                     die "seen too many typing events with typing users";
                   }
-                  return $zero_users;
+                  return 0;
                },
             )
          } $typinguser, $local_user );


### PR DESCRIPTION
This adds the helper function `await_sync_ephemeral_contains` which behaves the same as `await_sync_timeline_contains`. Also, make typing send true/false not 1/0 which Dendrite dislikes (and so does the spec!).

https://github.com/matrix-org/sytest/pull/896/files?diff=split&w=1 gives a nicer diff.