### PR TITLE
Remove unused variables.

### DIFF
--- a/tests/30rooms/52members.pl
+++ b/tests/30rooms/52members.pl
@@ -83,7 +83,7 @@ test "Can filter rooms/{roomId}/members",
 
    check => sub {
       my ( $user1, $user2 ) = @_;
-      my ( $room_id, $event_id );
+      my $room_id;
 
       matrix_create_and_join_room( [ $user1, $user2 ] )->then( sub {
          ( $room_id ) = @_;
@@ -130,4 +130,3 @@ test "Can filter rooms/{roomId}/members",
          Future->done(1);
       })
    };
-

--- a/tests/30rooms/60version_upgrade.pl
+++ b/tests/30rooms/60version_upgrade.pl
@@ -973,7 +973,6 @@ test "/upgrade is rejected if the user can't send state events",
 
    do => sub {
       my ( $creator, $room_id, $joiner ) = @_;
-      my ( $replacement_room );
 
       matrix_join_room( $joiner, $room_id )->then( sub {
          upgrade_room(
@@ -989,7 +988,6 @@ test "/upgrade of a bogus room fails gracefully",
 
    do => sub {
       my ( $user ) = @_;
-      my ( $replacement_room );
 
       upgrade_room(
          $user, "!fail:unknown",

--- a/tests/30rooms/70publicroomslist.pl
+++ b/tests/30rooms/70publicroomslist.pl
@@ -242,10 +242,10 @@ test "Can paginate public room list",
    };
 
 test "Can search public room list",
-   requires => [ $main::HOMESERVER_INFO[0], local_user_fixture() ],
+   requires => [ local_user_fixture() ],
 
    check => sub {
-      my ( $info, $local_user ) = @_;
+      my ( $local_user ) = @_;
 
       my $room_id;
 

--- a/tests/41end-to-end-keys/08-cross-signing.pl
+++ b/tests/41end-to-end-keys/08-cross-signing.pl
@@ -417,10 +417,7 @@ test "can fetch self-signing keys over federation",
    do => sub {
       my ( $user1, $user2 ) = @_;
 
-      my $user1_id = $user1->user_id;
-      my $user1_device = $user1->device_id;
       my $user2_id = $user2->user_id;
-      my $user2_device = $user2->device_id;
 
       my ( $master_pubkey, $master_secret_key ) = $crypto_sign->keypair( decode_base64( "2lonYOM6xYKdEsO+6KrC766xBcHnYnim1x/4LFGF8B0" ) );
       my $self_signing_key = {
@@ -488,8 +485,6 @@ test "uploading self-signing key notifies over federation",
    do => sub {
       my ( $user1, $user2 ) = @_;
 
-      my $user1_id = $user1->user_id;
-      my $user1_device = $user1->device_id;
       my $user2_id = $user2->user_id;
       my $user2_device = $user2->device_id;
 
@@ -589,8 +584,6 @@ test "uploading signed devices gets propagated over federation",
    do => sub {
       my ( $user1, $user2 ) = @_;
 
-      my $user1_id = $user1->user_id;
-      my $user1_device = $user1->device_id;
       my $user2_id = $user2->user_id;
       my $user2_device = $user2->device_id;
 

--- a/tests/46direct/01directmessage.pl
+++ b/tests/46direct/01directmessage.pl
@@ -47,8 +47,6 @@ sub matrix_recv_device_message
 {
    my ( $user ) = @_;
 
-   my $next_batch;
-
    my $delay = 0;
 
    my $f = repeat {

--- a/tests/50federation/40devicelists.pl
+++ b/tests/50federation/40devicelists.pl
@@ -5,8 +5,6 @@ test "Local device key changes get to remote servers",
    check => sub {
       my ( $user, $inbound_server, $creator_id, $room_alias_name ) = @_;
 
-      my ( $room_id );
-
       my $local_server_name = $inbound_server->server_name;
       my $datastore         = $inbound_server->datastore;
 
@@ -14,7 +12,7 @@ test "Local device key changes get to remote servers",
 
       my $prev_stream_id;
 
-      my $room = $datastore->create_room(
+      $datastore->create_room(
          creator => $creator_id,
          alias   => $room_alias,
       );
@@ -70,8 +68,6 @@ test "Server correctly handles incoming m.device_list_update",
    check => sub {
       my ( $user, $inbound_server, $outbound_client, $creator_id, $room_alias_name ) = @_;
 
-      my ( $room_id );
-
       my $local_server_name = $user->server_name;
 
       my $remote_server_name = $inbound_server->server_name;
@@ -81,9 +77,7 @@ test "Server correctly handles incoming m.device_list_update",
 
       my $device_id = "random_device_id";
 
-      my $prev_stream_id;
-
-      my $room = $datastore->create_room(
+      $datastore->create_room(
          creator => $creator_id,
          alias   => $room_alias,
       );
@@ -387,8 +381,6 @@ test "Local device key changes get to remote servers with correct prev_id",
    check => sub {
       my ( $user1, $user2, $inbound_server, $creator_id, $room_alias_name ) = @_;
 
-      my ( $room_id );
-
       my $local_server_name = $inbound_server->server_name;
       my $datastore         = $inbound_server->datastore;
 
@@ -396,7 +388,7 @@ test "Local device key changes get to remote servers with correct prev_id",
 
       my $prev_stream_id;
 
-      my $room = $datastore->create_room(
+      $datastore->create_room(
          creator => $creator_id,
          alias   => $room_alias,
       );
@@ -625,8 +617,6 @@ test "If a device list update goes missing, the server resyncs on the next one",
    check => sub {
       my ( $user, $inbound_server, $outbound_client, $creator_id, $room_alias_name ) = @_;
 
-      my ( $room_id );
-
       my $local_server_name = $user->server_name;
 
       my $remote_server_name = $inbound_server->server_name;
@@ -636,9 +626,7 @@ test "If a device list update goes missing, the server resyncs on the next one",
 
       my $device_id = "random_device_id";
 
-      my $prev_stream_id;
-
-      my $room = $datastore->create_room(
+      $datastore->create_room(
          creator => $creator_id,
          alias   => $room_alias,
       );

--- a/tests/50federation/41power-levels.pl
+++ b/tests/50federation/41power-levels.pl
@@ -22,8 +22,6 @@ test "Remote servers cannot set power levels in rooms without existing powerleve
    do => sub {
       my ( $synapse_user, $inbound_server, $sytest_user_id_a) = @_;
 
-      my $synapse_server_name = $synapse_user->http->server_name;
-      my $outbound_client     = $inbound_server->client;
       my $sytest_server_name  = $inbound_server->server_name;
       my $datastore           = $inbound_server->datastore;
 
@@ -59,16 +57,14 @@ test "Remote servers cannot set power levels in rooms without existing powerleve
 
 test "Remote servers should reject attempts by non-creators to set the power levels",
 
-   requires => [ $main::OUTBOUND_CLIENT,
-                 $main::INBOUND_SERVER,
+   requires => [ $main::INBOUND_SERVER,
                  local_user_fixture(),
                  federation_user_id_fixture(),
                  federation_user_id_fixture(),
                 ],
 
    do => sub {
-      my ( $outbound_server, $inbound_server,
-           $synapse_user, $sytest_user_id_a, $sytest_user_id_b ) = @_;
+      my ( $inbound_server, $synapse_user, $sytest_user_id_a, $sytest_user_id_b ) = @_;
 
       my $synapse_server_name = $synapse_user->server_name;
       my $outbound_client     = $inbound_server->client;

--- a/tests/50federation/50no-deextrem-outliers.pl
+++ b/tests/50federation/50no-deextrem-outliers.pl
@@ -35,7 +35,7 @@ test "Forward extremities remain so even after the next events are populated as 
 
       my $fake_user_id = '@fake_user:' . $outbound_client->server_name;
       my $room_id = $room->room_id;
-      my ( $pl_event_b, $pl_event_b_id );
+      my $pl_event_b_id;
 
       # make sure that the sytest user has permission to alter the state
       Future->needs_all(

--- a/tests/53groups/05categories.pl
+++ b/tests/53groups/05categories.pl
@@ -4,7 +4,7 @@ test "Add group category",
    do => sub {
       my ( $user ) = @_;
 
-      my ( $group_id, $room_id );
+      my $group_id;
 
       matrix_create_group( $user )
       ->then( sub {
@@ -31,7 +31,7 @@ test "Remove group category",
    do => sub {
       my ( $user ) = @_;
 
-      my ( $group_id, $room_id );
+      my $group_id;
 
       matrix_create_group( $user )
       ->then( sub {
@@ -52,7 +52,7 @@ test "Get group categories",
    do => sub {
       my ( $user ) = @_;
 
-      my ( $group_id, $room_id );
+      my $group_id;
 
       matrix_create_group( $user )
       ->then( sub {

--- a/tests/53groups/05roles.pl
+++ b/tests/53groups/05roles.pl
@@ -4,7 +4,7 @@ test "Add group role",
    do => sub {
       my ( $user ) = @_;
 
-      my ( $group_id, $room_id );
+      my $group_id;
 
       matrix_create_group( $user )
       ->then( sub {
@@ -31,7 +31,7 @@ test "Remove group role",
    do => sub {
       my ( $user ) = @_;
 
-      my ( $group_id, $room_id );
+      my $group_id;
 
       matrix_create_group( $user )
       ->then( sub {
@@ -52,7 +52,7 @@ test "Get group roles",
    do => sub {
       my ( $user ) = @_;
 
-      my ( $group_id, $room_id );
+      my $group_id;
 
       matrix_create_group( $user )
       ->then( sub {

--- a/tests/53groups/06summaries.pl
+++ b/tests/53groups/06summaries.pl
@@ -377,7 +377,7 @@ test "Add user to group summary with role",
    do => sub {
       my ( $user, $viewer ) = @_;
 
-      my ( $group_id, $room_id );
+      my $group_id;
 
       matrix_create_group( $user,
          name => "Testing summaries",
@@ -418,7 +418,7 @@ test "Remove user from group summary with role",
    do => sub {
       my ( $user, $viewer ) = @_;
 
-      my ( $group_id, $room_id );
+      my $group_id;
 
       matrix_create_group( $user,
          name => "Testing summaries",

--- a/tests/54identity.pl
+++ b/tests/54identity.pl
@@ -76,10 +76,10 @@ test "Can bind and unbind 3PID via homeserver",
 
 
 test "Can unbind 3PID via homeserver when bound out of band",
-   requires => [ $main::HTTP_CLIENT, local_user_fixture(), id_server_fixture() ],
+   requires => [ local_user_fixture(), id_server_fixture() ],
 
    check => sub {
-      my ( $http, $user, $id_server ) = @_;
+      my ( $user, $id_server ) = @_;
 
       my $medium = "email";
       my $address = 'bob3@example.com';
@@ -107,10 +107,10 @@ test "Can unbind 3PID via homeserver when bound out of band",
 
 
 test "3PIDs are unbound after account deactivation",
-   requires => [ $main::HTTP_CLIENT, local_user_fixture(), id_server_fixture() ],
+   requires => [ local_user_fixture(), id_server_fixture() ],
 
    check => sub {
-      my ( $http, $user, $id_server ) = @_;
+      my ( $user, $id_server ) = @_;
 
       my $medium = "email";
       my $address = 'bob4@example.com';
@@ -132,10 +132,10 @@ test "3PIDs are unbound after account deactivation",
 
 
 test "Can bind and unbind 3PID via /unbind by specifying the identity server",
-   requires => [ $main::HTTP_CLIENT, local_user_fixture(), id_server_fixture() ],
+   requires => [ local_user_fixture(), id_server_fixture() ],
 
    check => sub {
-      my ( $http, $user, $id_server ) = @_;
+      my ( $user, $id_server ) = @_;
 
       my $medium = "email";
       my $address = 'bobby@example.com';
@@ -165,10 +165,10 @@ test "Can bind and unbind 3PID via /unbind by specifying the identity server",
 
 
 test "Can bind and unbind 3PID via /unbind without specifying the identity server",
-   requires => [ $main::HTTP_CLIENT, local_user_fixture(), id_server_fixture() ],
+   requires => [ local_user_fixture(), id_server_fixture() ],
 
    check => sub {
-      my ( $http, $user, $id_server ) = @_;
+      my ( $user, $id_server ) = @_;
 
       my $medium = "email";
       my $address = 'bobby2@example.com';

--- a/tests/60app-services/01as-create.pl
+++ b/tests/60app-services/01as-create.pl
@@ -3,10 +3,10 @@ my $user_fixture = local_user_fixture();
 my $room_fixture = room_fixture( $user_fixture );
 
 test "AS can create a user",
-   requires => [ $main::AS_USER[0], $room_fixture ],
+   requires => [ $main::AS_USER[0] ],
 
    do => sub {
-      my ( $as_user, $room_id ) = @_;
+      my ( $as_user ) = @_;
 
       do_request_json_for( $as_user,
          method => "POST",
@@ -27,10 +27,10 @@ test "AS can create a user",
    };
 
 test "AS can create a user with an underscore",
-   requires => [ $main::AS_USER[0], $room_fixture ],
+   requires => [ $main::AS_USER[0] ],
 
    do => sub {
-      my ( $as_user, $room_id ) = @_;
+      my ( $as_user ) = @_;
 
       do_request_json_for( $as_user,
          method => "POST",
@@ -52,10 +52,10 @@ test "AS can create a user with an underscore",
 
 
 test "AS can create a user with inhibit_login",
-   requires => [ $main::AS_USER[0], $room_fixture ],
+   requires => [ $main::AS_USER[0] ],
 
    do => sub {
-      my ( $as_user, $room_id ) = @_;
+      my ( $as_user ) = @_;
 
       do_request_json_for( $as_user,
          method => "POST",
@@ -107,13 +107,13 @@ test "Regular users cannot register within the AS namespace",
 
 test "AS can make room aliases",
    requires => [
-      $main::AS_USER[0], $main::APPSERV[0], $room_fixture,
+      $main::AS_USER[0], $room_fixture,
       room_alias_fixture( prefix => "astest-" ),
       qw( can_create_room_alias ),
    ],
 
    do => sub {
-      my ( $as_user, $appserv, $room_id, $room_alias ) = @_;
+      my ( $as_user, $room_id, $room_alias ) = @_;
 
       do_request_json_for( $as_user,
          method => "PUT",

--- a/tests/60app-services/04asuser.pl
+++ b/tests/60app-services/04asuser.pl
@@ -18,10 +18,10 @@ test "AS user (not ghost) can join room without registering",
 # TODO: Remove this test when the in-use ASes stop passing the user_id param
 # (or if we end up killing non-ghost AS users)
 test "AS user (not ghost) can join room without registering, with user_id query param",
-   requires => [ $main::AS_USER[0], local_user_fixture(), $main::HOMESERVER_INFO[0] ],
+   requires => [ $main::AS_USER[0], local_user_fixture() ],
 
    do => sub {
-      my ( $as_user, $user, $hs_info ) = @_;
+      my ( $as_user, $user ) = @_;
 
       my $room_id;
 

--- a/tests/61push/06_get_pusher.pl
+++ b/tests/61push/06_get_pusher.pl
@@ -38,7 +38,7 @@ test "Can fetch a user's pushers",
 
          log_if_fail "Get pusher response body", $body;
 
-         assert_json_keys( my $notification = $body, qw(pushers));
+         assert_json_keys( $body, qw(pushers) );
 
          assert_json_keys( my $pusher = $body->{pushers}[0], qw(
             profile_tag kind app_id app_display_name device_display_name


### PR DESCRIPTION
A bunch of the tests have unused variables, and some even have unused fixtures. These annoy much each time I poke at sytest, so I decided to remove them. I can't promise I found every instance...