### PR TITLE
Use matrix_invite_user_to_room_synced on remote invite tests

### DIFF
--- a/tests/30rooms/06invite.pl
+++ b/tests/30rooms/06invite.pl
@@ -129,7 +129,7 @@ sub invited_user_can_reject_invite
 {
    my ( $invitee, $creator, $room_id ) = @_;
 
-   matrix_invite_user_to_room( $creator, $invitee, $room_id )
+   matrix_invite_user_to_room_synced( $creator, $invitee, $room_id )
    ->then( sub {
       matrix_leave_room_synced( $invitee, $room_id )
    })->then( sub {
@@ -315,7 +315,7 @@ test "Remote invited user can see room metadata",
             content => { url => "http://something" },
          ),
       )->then( sub {
-         matrix_invite_user_to_room( $creator, $invitee, $room_id );
+         matrix_invite_user_to_room_synced( $creator, $invitee, $room_id );
       })->then( sub {
          await_sync( $invitee, check => sub {
             my ( $body ) = @_;


### PR DESCRIPTION
Dendrite will return 200 OK to `/invite` after the invite event has
been enqueued to the `federationsender` but before it has made its way
through all the components. Previously, this test would immediately hit
`GET /state/m.room.member/userID` which would sometimes 404 as the state
had not reached that component. This PR modifies this behaviour to wait
for the event to come down `/sync`, which serves as a good proxy for
having reached all dendrite components, then do the GET.