### PR TITLE
Use true not 1 when setting typing

### DIFF
--- a/tests/10apidoc/35room-typing.pl
+++ b/tests/10apidoc/35room-typing.pl
@@ -10,7 +10,7 @@ test "PUT /rooms/:room_id/typing/:user_id sets typing notification",
          method => "PUT",
          uri    => "/r0/rooms/$room_id/typing/:user_id",
 
-         content => { typing => 1 },
+         content => { typing => JSON::true },
       )->then( sub {
          my ( $body ) = @_;
 


### PR DESCRIPTION
Dendrite is more strict and follows the specificaiton. Make the tests
follow the spec.