### PR TITLE
Fix typing leak test to use /sync and true

### DIFF
--- a/tests/90jira/SYN-328.pl
+++ b/tests/90jira/SYN-328.pl
@@ -16,33 +16,34 @@ multi_test "Typing notifications don't leak",
             method => "PUT",
             uri    => "/r0/rooms/$room_id/typing/:user_id",
 
-            content => { typing => 1, timeout => 30000 }, # msec
+            content => { typing => JSON::true, timeout => 30000 }, # msec
          );
       })->then( sub {
          Future->needs_all( map {
             my $recvuser = $_;
 
-            await_event_for( $recvuser, filter => sub {
-               my ( $event ) = @_;
-               return unless $event->{type} eq "m.typing";
-               return unless $event->{room_id} eq $room_id;
-
-               return 1;
-            })
+            await_sync_ephemeral_contains($recvuser, $room_id,
+               check => sub {
+                  my ( $event ) = @_;
+                  return unless $event->{type} eq "m.typing";
+                  return 1;
+               },
+            )
          } $creator, $member )
             ->SyTest::pass_on_done( "Members received notification" )
       })->then( sub {
 
+         # Wait on a different user to see if we get a typing notification
          Future->wait_any(
             delay( 2 ),
 
-            await_event_for( $nonmember, filter => sub {
-               my ( $event ) = @_;
-               return unless $event->{type} eq "m.typing";
-               return unless $event->{room_id} eq $room_id;
-
-               return 1;
-            })->then_fail( "Received unexpected typing notification" ),
+            await_sync_ephemeral_contains($nonmember, $room_id,
+               check => sub {
+                  my ( $event ) = @_;
+                  return unless $event->{type} eq "m.typing";
+                  return 1;
+               },
+            )->then_fail( "Received unexpected typing notification" ),
          )->SyTest::pass_on_done( "Non-member did not receive it up to timeout" )
       })->then_done(1);
    };


### PR DESCRIPTION
- Use `/sync` not `/events`.
- Use `true` not `1` when setting typing.