### PR TITLE
Unflake "Outbound federation will ignore a missing event with bad JSON for room version 6"

### DIFF
--- a/lib/SyTest/Assertions.pm
+++ b/lib/SyTest/Assertions.pm
@@ -24,7 +24,6 @@ our @EXPORT_OK = qw(
    assert_json_boolean
 
    assert_base64_unpadded
-   assert_in_list
 );
 
 use Data::Dump 'pp';
@@ -298,25 +297,6 @@ sub assert_base64_unpadded
       die "String contains invalid base64 characters";
    $str =~ m(=) and
       die "String contains trailing padding";
-}
-
-=head2 assert_in_list
-
-   assert_in_list( $obj, @list )
-
-Fails the test if C<$obj> is not found in C<@list>.
-
-=cut
-
-sub assert_in_list
-{
-   my ( $obj, @list ) = @_;
-   foreach ( @list ) {
-      if ($obj eq $_) {
-         return;
-      }
-   }
-   croak "$obj not found in list";
 }
 
 1;

--- a/lib/SyTest/Assertions.pm
+++ b/lib/SyTest/Assertions.pm
@@ -24,6 +24,7 @@ our @EXPORT_OK = qw(
    assert_json_boolean
 
    assert_base64_unpadded
+   assert_in_list
 );
 
 use Data::Dump 'pp';
@@ -297,6 +298,25 @@ sub assert_base64_unpadded
       die "String contains invalid base64 characters";
    $str =~ m(=) and
       die "String contains trailing padding";
+}
+
+=head2 assert_in_list
+
+   assert_in_list( $obj, @list )
+
+Fails the test if C<$obj> is not found in C<@list>.
+
+=cut
+
+sub assert_in_list
+{
+   my ( $obj, @list ) = @_;
+   foreach ( @list ) {
+      if ($obj eq $_) {
+         return;
+      }
+   }
+   croak "$obj not found in list";
 }
 
 1;

--- a/tests/50federation/33room-get-missing-events.pl
+++ b/tests/50federation/33room-get-missing-events.pl
@@ -452,8 +452,8 @@ test "Outbound federation will ignore a missing event with bad JSON for room ver
 
       log_if_fail "Missing event", $missing_event;
 
-      # Generate another one and do send it so it will refer to the
-      # previous in its prev_events field
+      # Generate another event which will be sent. It will refer to the missing
+      # event in its prev_events field.
       my $sent_event = $room->create_and_insert_event(
          type => "m.room.message",
 

--- a/tests/50federation/33room-get-missing-events.pl
+++ b/tests/50federation/33room-get-missing-events.pl
@@ -489,7 +489,8 @@ test "Outbound federation will ignore a missing event with bad JSON for room ver
             # so also allow any of that event's previous events.
             my @expected = @{$latest_event->{prev_events}};
             push( @expected, $room->id_for_event( $latest_event ) );
-            assert_in_list( $earliest->[0], @expected, 'earliest_events[0]' );
+            assert_ok( any { $earliest->[0] eq $_ } @expected,
+               "'earliest_events' did not match" );
 
             assert_json_list( my $latest = $body->{latest_events} );
             @$latest == 1 or

--- a/tests/50federation/33room-get-missing-events.pl
+++ b/tests/50federation/33room-get-missing-events.pl
@@ -484,8 +484,12 @@ test "Outbound federation will ignore a missing event with bad JSON for room ver
             assert_json_list( my $earliest = $body->{earliest_events} );
             @$earliest == 1 or
                die "Expected a single 'earliest_event' ID";
-            assert_eq( $earliest->[0], $room->id_for_event( $latest_event ),
-               'earliest_events[0]' );
+            # It is expected that the earliest event is the m.room.member event,
+            # but it is possible that the caches have not yet been invalidated
+            # so also allow any of that event's previous events.
+            my @expected = @{$latest_event->{prev_events}};
+            push( @expected, $room->id_for_event( $latest_event ) );
+            assert_in_list( $earliest->[0], @expected, 'earliest_events[0]' );
 
             assert_json_list( my $latest = $body->{latest_events} );
             @$latest == 1 or


### PR DESCRIPTION
Fixes #885, I think see https://github.com/matrix-org/sytest/issues/885#issuecomment-647506143 and the subsequent comment for what's happening here, but this uses option 3 to solve it: allow the event we're expecting or previous events as the "earliest event".