### PR TITLE
Wait for pushers to become active before proceeding

### DIFF
--- a/lib/SyTest/Federation/Server.pm
+++ b/lib/SyTest/Federation/Server.pm
@@ -490,8 +490,6 @@ sub on_request_federation_v1_send
       }
 
       next if $self->on_event( $event );
-
-      warn "TODO: Unhandled incoming event of type '$event->{type}'";
    }
 
    Future->done( json => {} );


### PR DESCRIPTION
Hopefully, this will make the pusher tests less flaky when running in a
redis worker setup. Wait for the pusher to respond before we proceed.