### PR TITLE
Add redis support to synapse docker image

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -50,7 +50,9 @@ Synapse:
 
  * `POSTGRES`: set non-empty to test against a PostgreSQL database instead of sqlite.
  * `WORKERS`: set non-empty to test a worker-mode deployment rather than a
-   monolith.
+   monolith. Requires `POSTGRES`.
+ * `REDIS`: set non-empty to use redis replication rather than old
+   TCP. Requires `WORKERS`.
  * `OFFLINE`: set non-empty to avoid updating the python or perl dependencies.
  * `BLACKLIST`: set non-empty to change the default blacklist file to the
    specified path relative to the Synapse directory
@@ -68,13 +70,10 @@ Some examples of running Synapse in different configurations:
 * Running Synapse in worker mode using redis:
 
   ```
-  docker network create testfoobar
-  docker run --network testfoobar --name testredis -d redis:5.0
-  docker run --network testfoobar --rm -it -e POSTGRES=1 -e WORKERS=1 \
+  docker run --rm -it -e POSTGRES=1 -e WORKERS=1 -e REDIS=1 \
        -v /path/to/synapse\:/src:ro \
        -v /path/to/where/you/want/logs\:/logs \
-       matrixdotorg/sytest-synapse:py35 --redis-host testredis
-  # Use `docker start/stop testredis` if you want to explicitly kill redis or start it again after reboot
+       matrixdotorg/sytest-synapse:py35
   ```
 
 Dendrite:

--- a/docker/synapse.Dockerfile
+++ b/docker/synapse.Dockerfile
@@ -3,7 +3,8 @@ ARG DEBIAN_VERSION=buster
 FROM matrixdotorg/sytest:${DEBIAN_VERSION}
 
 RUN apt-get -qq update && apt-get -qq install -y \
-    python3 python3-dev python3-virtualenv eatmydata
+    python3 python3-dev python3-virtualenv eatmydata \
+    redis-server
 
 ENV PYTHON=python3
 

--- a/scripts/synapse_sytest.sh
+++ b/scripts/synapse_sytest.sh
@@ -15,6 +15,11 @@ cd "$(dirname $0)/.."
 
 mkdir /work
 
+# start the redis server, if desired
+if [ -n "$REDIS" ]; then
+    /usr/bin/redis-server /etc/redis/redis.conf
+fi
+
 # PostgreSQL setup
 if [ -n "$MULTI_POSTGRES" ] || [ -n "$POSTGRES" ]; then
     # We increase the max connections as we have more databases.
@@ -162,6 +167,10 @@ if [ -n "$WORKERS" ]; then
     RUN_TESTS+=(-I Synapse::ViaHaproxy --dendron-binary=/pydron.py)
 else
     RUN_TESTS+=(-I Synapse)
+fi
+
+if [ -n "$REDIS" ]; then
+    RUN_TESTS+=(--redis-host=localhost)
 fi
 
 mkdir -p /logs


### PR DESCRIPTION
... because I kept forgetting how to do the networking foo to get redis
running, and because it seems to make sense now that TCP replication is
deprecated.