### PR TITLE
Set Dendrite loglevel to trace

### DIFF
--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -148,7 +148,7 @@ sub _get_config
 
       logging => [{
          type => 'file',
-         level => 'debug',
+         level => 'trace',
          params => {
             path => "$self->{hs_dir}/dendrite-logs",
          },


### PR DESCRIPTION
This runs Dendrite under Sytest at the `trace` loglevel. 

Associated with matrix-org/dendrite#1244.