### PR TITLE
Call matrix_get_e2e_keys correctly

### DIFF
--- a/tests/41end-to-end-keys/06-device-lists.pl
+++ b/tests/41end-to-end-keys/06-device-lists.pl
@@ -198,7 +198,7 @@ test "Can query remote device keys using POST after notification",
          sync_until_user_in_device_list( $user1, $user2 );
       })->then( sub {
          matrix_get_e2e_keys(
-            $user1, $user2->user_id => {}
+            $user1, $user2->user_id
          )
       })->then( sub {
          my ( $content ) = @_;


### PR DESCRIPTION
This makes the test pass in Dendrite (before it had unmarshal errors). In other places we do not use this syntax at all, so use the syntax we use everywhere else.