### PR TITLE
Fix /send server ACL test to match spec

### DIFF
--- a/tests/50federation/50server-acl-endpoints.pl
+++ b/tests/50federation/50server-acl-endpoints.pl
@@ -53,9 +53,7 @@ sub can_send_event {
       my $pdu_result = $body->{pdus}->{$event_id};
 
       if( $params{expect_ban} ) {
-         assert_json_keys( $pdu_result, qw( errcode ));
-         assert_eq( $pdu_result->{errcode}, 'M_FORBIDDEN',
-                    "error code for forbidden /send" );
+         assert_json_keys( $pdu_result, qw( error ));
       } else {
          assert_deeply_eq( $pdu_result, {}, "result for permitted /send" );
       }


### PR DESCRIPTION
The test was looking for `errcode`, which Synapse returns but is not specced.

The test now looks for `error`, which is specced!