### PR TITLE
Abide by the spec when making /keys/query requests

### DIFF
--- a/tests/50federation/40devicelists.pl
+++ b/tests/50federation/40devicelists.pl
@@ -577,7 +577,7 @@ test "Device list doesn't change if remote server is down",
             uri     => "/r0/keys/query",
             content => {
                device_keys => {
-                  $outbound_client_user => {}
+                  $outbound_client_user => []
                }
             }
          )
@@ -608,7 +608,7 @@ test "Device list doesn't change if remote server is down",
             uri     => "/r0/keys/query",
             content => {
                device_keys => {
-                  $outbound_client_user => {}
+                  $outbound_client_user => []
                }
             }
          )


### PR DESCRIPTION
Using `{}` is not valid and Dendrite will 400 the request. Only `[]`
is valid.