### PR TITLE
Add plugin support.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,12 +146,17 @@ synapse) and place it within the homeserver configuration directory
 
 .. _dictConfig: https://docs.python.org/2/library/logging.config.html#logging.config.dictConfig
 
+Plugins
+~~~~~~~
+
 Sytest supports plugins. Plugins follow the same project structure as sytest and can be placed
 in the ``plugins`` directory. They should contain the ``lib/SyTest/HomeserverFactory`` and
 ``lib/SyTest/Homeserver``, or ``lib/SyTest/Output`` directories, similar to the root of the sytest repository.
 The path of the plugins directory can be overridden via the ``SYTEST_PLUGINS`` environment variable.
 
 Currently only ``Homeserver`` and ``Output`` implementations are supported in plugins.
+
+See https://github.com/valkum/sytest_conduit for an example of a plugin.
 
 Developing
 ----------

--- a/README.rst
+++ b/README.rst
@@ -147,10 +147,11 @@ synapse) and place it within the homeserver configuration directory
 .. _dictConfig: https://docs.python.org/2/library/logging.config.html#logging.config.dictConfig
 
 Sytest supports plugins. Plugins follow the same project structure as sytest and can be placed
-in the `plugins` directory.
-To override the path of the plugins directory set the env var `SYTEST_PLUGINS` to another directory.
+in the ``plugins`` directory. They should contain the ``lib/SyTest/HomeserverFactory`` and
+``lib/SyTest/Homeserver``, or ``lib/SyTest/Output`` directories. Similar to the sytest repository.
+The path of the plugins directory can be overridden via the ``SYTEST_PLUGINS``environment variable.
 
-Currently only Homeserver and Output Implementations are supported in plugins.
+Currently only ``Homeserver`` and ``Output`` implementations are supported in plugins.
 
 Developing
 ----------

--- a/README.rst
+++ b/README.rst
@@ -146,6 +146,12 @@ synapse) and place it within the homeserver configuration directory
 
 .. _dictConfig: https://docs.python.org/2/library/logging.config.html#logging.config.dictConfig
 
+Sytest supports plugins. Plugins follow the same project structure as sytest and can be placed
+in the `plugins` directory.
+To override the path of the plugins directory set the env var `SYTEST_PLUGINS` to another directory.
+
+Currently only Homeserver and Output Implementations are supported in plugins.
+
 Developing
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -148,8 +148,8 @@ synapse) and place it within the homeserver configuration directory
 
 Sytest supports plugins. Plugins follow the same project structure as sytest and can be placed
 in the ``plugins`` directory. They should contain the ``lib/SyTest/HomeserverFactory`` and
-``lib/SyTest/Homeserver``, or ``lib/SyTest/Output`` directories. Similar to the sytest repository.
-The path of the plugins directory can be overridden via the ``SYTEST_PLUGINS``environment variable.
+``lib/SyTest/Homeserver``, or ``lib/SyTest/Output`` directories, similar to the root of the sytest repository.
+The path of the plugins directory can be overridden via the ``SYTEST_PLUGINS`` environment variable.
 
 Currently only ``Homeserver`` and ``Output`` implementations are supported in plugins.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -97,3 +97,15 @@ docker run --rm -it ... matrixdotorg/sytest-synapse:py37 tests/20profile-events.
 
 The containers are built by executing `./build.sh`. You will then have to push
 them up to Docker Hub with `./push.sh`.
+
+## Loading sytest plugins at start
+
+To utilize sytest plugins and automatically load them on start set the `PLUGINS` environment variable.
+This should be one or more URLs to tar.gz files separated by whitespaces.
+
+The bootstrap script will search for `${SYTEST_TARGET}_sytest.sh` in all plugins. This can be used to
+execute custom scripts like the ones in `/scripts/`
+
+```
+docker run --rm -it -e PLUGINS="https://host/path/to/hs_plugin.tar.gz https://host2/path/to/output_plugin.tar.gz"
+```

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -29,10 +29,10 @@ else
     fi
 
     # Try and fetch the branch
-    wget -q https://github.com/valkum/sytest/archive/$branch_name.tar.gz -O sytest.tar.gz || {
+    wget -q https://github.com/matrix-org/sytest/archive/$branch_name.tar.gz -O sytest.tar.gz || {
         # Probably a 404, fall back to develop
         echo "Using develop instead..."
-        wget -q https://github.com/valkum/sytest/archive/develop.tar.gz -O sytest.tar.gz
+        wget -q https://github.com/matrix-org/sytest/archive/develop.tar.gz -O sytest.tar.gz
     }
 
     mkdir -p /sytest
@@ -61,10 +61,12 @@ if [ -x "/sytest/scripts/${SYTEST_TARGET}_sytest.sh" ]; then
 elif [ -x "/sytest/docker/${SYTEST_TARGET}_sytest.sh" ]; then
     # old branches of sytest used to put the sytest running script in the "/docker" directory
     exec "/sytest/docker/${SYTEST_TARGET}_sytest.sh" "$@"
+
 else
     PLUGIN_RUNNER=$(find /sytest/plugins/ -type f -exec test -x {} \; -name "${SYTEST_TARGET}_sytest.sh" -print)
     if [ -n PLUGIN_RUNNER ]; then
         exec ${PLUGIN_RUNNER} "$@"
+        
     else
         echo "sytest runner script for ${SYTEST_TARGET} not found" >&2
         exit 1

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -19,6 +19,7 @@ use IO::Async::Loop;
 
 use Data::Dump qw( pp );
 use File::Basename qw( basename );
+use File::Spec::Functions qw( catdir );
 use Getopt::Long qw( :config no_ignore_case gnu_getopt );
 use IO::Socket::SSL;
 use List::Util 1.33 qw( first all any maxstr max );
@@ -34,16 +35,21 @@ Data::Dump::Filtered::add_dump_filter( sub {
       : undef;
 });
 
+my $plugin_dir = $ENV{"SYTEST_PLUGINS"} || "plugins"; # Read plugin dir from env var SYTEST_PLUGINS or fallback to plugins
+my @plugins = grep { -d } glob(catdir($plugin_dir, "*", "*")); # Read all plugins/<author>/<plugin>
+my @lib_dirs = map { catdir($_, "lib") } @plugins;
+
 use Module::Pluggable
    sub_name    => "output_formats",
    search_path => [ "SyTest::Output" ],
+   search_dirs => \@lib_dirs,
    require     => 1;
 
 use Module::Pluggable
    sub_name    => "homeserver_factories",
    search_path => [ "SyTest::HomeserverFactory" ],
+   search_dirs => \@lib_dirs,
    require     => 1;
-
 
 binmode(STDOUT, ":utf8");
 

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -36,7 +36,7 @@ Data::Dump::Filtered::add_dump_filter( sub {
 });
 
 my $plugin_dir = $ENV{"SYTEST_PLUGINS"} || "plugins"; # Read plugin dir from env var SYTEST_PLUGINS or fallback to plugins
-my @plugins = grep { -d } glob(catdir($plugin_dir, "*", "*")); # Read all plugins/<author>/<plugin>
+my @plugins = grep { -d } glob(catdir($plugin_dir, "*")); # Read all plugins/<plugin>
 my @lib_dirs = map { catdir($_, "lib") } @plugins;
 
 use Module::Pluggable


### PR DESCRIPTION
This PR adds support for plugins in sytest. The bootstrap script will download given plugins and sytest will use them.

You can now pass the env var $PLUGIN with the format `PLUGINS="<owner>/<repo>[:<owner>/<repo>]"`
bootstrap.sh (when downloading sytest) will load `<owner>/<repo>` from github to `/sytest/plugins/<owner>/<repo>`
and will look if a matching runner script is found in one of the plugins.

Example:
```sh
$ PLUGIN="valkum/conduit_sytest" bootstrap.sh "conduit"
$ # Downloads https://github.com/valkum/conduit_sytest to /sytest/plugins/valkum/sytest 
$ # and executes /sytest/plugins/valkum/sytest/scrypts/conduit_sytest.sh
```
Sytest will look for Output and ServerImplementation plugins in the plugin dir.
Plugin dir is `/sytest/plugin` by default but can be overwritten by the env var `$SYTEST_PLUGINS`