### PR TITLE
Wait for synapse to start by using sd_notify.

### DIFF
--- a/lib/SyTest/Homeserver/ProcessManager.pm
+++ b/lib/SyTest/Homeserver/ProcessManager.pm
@@ -283,15 +283,7 @@ sub _start_process_and_await_notify
       $finished_future->without_cancel()->then_fail(
          "Process died without becoming connectable",
       ),
-   )->else_with_f( sub {
-      my ( $f ) = @_;
-
-      # We need to manually kill child procs here as we don't seem to have
-      # registered the on finish handler yet.
-      $self->kill_and_await_finish()->then( sub {
-         $f
-      })
-   } );
+   );
    return $fut;
 }
 
@@ -355,11 +347,7 @@ sub _await_ready_notification
       socktype => "dgram",
       path     => $path,
    } )->then( sub {
-      # We add a timeout so that we don't wait for ever if process wedges.
-      Future->wait_any(
-         $poke_fut,
-         $loop->timeout_future( after => 15 )
-      )
+      $poke_fut
    })
 }
 

--- a/lib/SyTest/Homeserver/ProcessManager.pm
+++ b/lib/SyTest/Homeserver/ProcessManager.pm
@@ -267,12 +267,12 @@ sub _start_process_and_await_notify
    my %setup_map = @$setup;  # Copy to a hash so we can pull out the env entry.
    my $env = $setup_map{env} // {};
    if ( not defined $setup_map{env} ) {
-      # There was no env entry, so we me need to add it to the setup array.
+      # There was no env entry, so we need to add it to the setup array.
       push @$setup, env => $env;
    }
 
    # We need to set this up *before* we start the process as we need to bind the
-   # socket before startin the process.
+   # socket before starting the process.
    my $await_fut = $self->_await_ready_notification( $env );
 
    my $proc = $self -> _start_process( %params );

--- a/lib/SyTest/Homeserver/ProcessManager.pm
+++ b/lib/SyTest/Homeserver/ProcessManager.pm
@@ -315,7 +315,9 @@ sub _await_ready_notification
 
    # We replace null byte with '@' to allow us to pass it in via env. (This is
    # as per the sd_notify spec).
-   $env->{"NOTIFY_SOCKET"} = $path =~ s/\0/\@/rg;
+   my $path_env = $path;
+   $path_env =~ s/\0/\@/rg;
+   $env->{"NOTIFY_SOCKET"} = $path_env;
 
    # Create a future that gets resolved when we receive a `READY=1`
    # notification.

--- a/lib/SyTest/Homeserver/ProcessManager.pm
+++ b/lib/SyTest/Homeserver/ProcessManager.pm
@@ -22,6 +22,7 @@ package SyTest::Homeserver::ProcessManager;
 use Future::Utils qw( fmap_void );
 use POSIX qw( WIFEXITED WEXITSTATUS );
 use Struct::Dumb;
+use IO::Async::Socket;
 
 =head1 NAME
 
@@ -237,5 +238,129 @@ sub _kill_process
    );
 }
 
-1;
+=head2 _start_process_and_await_notify
 
+   $fut = $hs->_start_process_and_await_notify( %params )
+
+This method starts a new process, setting the `NOTIFY_SOCKET` env, and waits to
+receive a `READY=1` notification from the process on the socket.
+
+Parameters are passed on to C<IO::Async::Process::new>.
+
+=cut
+
+sub _start_process_and_await_notify
+{
+   my $self = shift;
+
+   my %params = @_;
+
+   # We now need to do some faffing to pull out any passed env hash so that we
+   # can then pass it to `_await_ready_notification`.
+   #
+   # The env is passed in as part of the `setup` param, which is an ordered map
+   # represented as an array.
+   $params{setup} //= [];
+
+   my $setup = $params{setup};
+
+   my %setup_map = @$setup;  # Copy to a hash so we can pull out the env entry.
+   my $env = $setup_map{env} // {};
+   if ( not defined $setup_map{env} ) {
+      # There was no env entry, so we me need to add it to the setup array.
+      push @$setup, env => $env;
+   }
+
+   # We need to set this up *before* we start the process as we need to bind the
+   # socket before startin the process.
+   my $await_fut = $self->_await_ready_notification( $env );
+
+   my $proc = $self -> _start_process( %params );
+   my $finished_future = $self->{proc_info}{$proc}->finished_future;
+
+   my $fut = Future->wait_any(
+      $await_fut,
+      $finished_future->without_cancel()->then_fail(
+         "Process died without becoming connectable",
+      ),
+   )->else_with_f( sub {
+      my ( $f ) = @_;
+
+      # We need to manually kill child procs here as we don't seem to have
+      # registered the on finish handler yet.
+      $self->kill_and_await_finish()->then( sub {
+         $f
+      })
+   } );
+   return $fut;
+}
+
+=head2 _await_ready_notification
+
+   $fut = $hs->_await_ready_notification( $env )
+
+This method binds a listener to a newly created unix socket and waits for a
+`READY=1` to be received. The socket address is added to the `env` map passed
+in under `NOTIFY_SOCKET`.
+
+This is basically a noddy implementation of the `sd_notify` mechanism.
+
+=cut
+
+sub _await_ready_notification
+{
+   my $self = shift;
+
+   my ( $env ) = @_;
+
+   my $loop = $self->loop;
+   my $output = $self->{output};
+
+   # Create a random abstract socket name. Abstract sockets start with a null
+   # byte.
+   my $random_id = join "", map { chr 65 + rand 25 } 1 .. 20;
+   my $path = "\0sytest-$random_id.sock";
+
+   # We replace null byte with '@' to allow us to pass it in via env. (This is
+   # as per the sd_notify spec).
+   $env->{"NOTIFY_SOCKET"} = $path =~ s/\0/\@/rg;
+
+   # Create a future that gets resolved when we receive a `READY=1`
+   # notification.
+   my $poke_fut = Future->new;
+
+   my $socket = IO::Async::Socket->new(
+      on_recv => sub {
+         my ( $self, $dgram, $addr ) = @_;
+
+         # Payloads are newline separated list of varalbe assignments.
+         foreach my $line ( split(/\n/, $dgram) ) {
+            $output->diag( "Received signal from process: $line" );
+            if ( $line eq "READY=1" ) {
+               $poke_fut->done;
+            }
+         }
+
+         $loop->stop;
+      },
+      on_recv_error => sub {
+         my ( $self, $errno ) = @_;
+         die "Cannot recv - $errno\n";
+      },
+   );
+   $loop->add( $socket );
+
+   $socket->bind( {
+      family   => "unix",
+      socktype => "dgram",
+      path     => $path,
+   } )->then( sub {
+      # We add a timeout so that we don't wait for ever if process wedges.
+      Future->wait_any(
+         $poke_fut,
+         $loop->timeout_future( after => 15 )
+      )
+   })
+}
+
+1;

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -375,9 +375,11 @@ sub start
            . join( " ", @command ),
       );
 
-      $self->_start_process_and_await_notify(
+      $self->_start_process_and_await_connectable(
          setup => [ env => $env ],
          command => \@command,
+         connect_host => $bind_host,
+         connect_port => $self->_start_await_port,
       );
    })->on_done( sub {
       $output->diag("Started synapse $hs_index");

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -375,11 +375,9 @@ sub start
            . join( " ", @command ),
       );
 
-      $self->_start_process_and_await_connectable(
+      $self->_start_process_and_await_notify(
          setup => [ env => $env ],
          command => \@command,
-         connect_host => $bind_host,
-         connect_port => $self->_start_await_port,
       );
    })->on_done( sub {
       $output->diag("Started synapse $hs_index");


### PR DESCRIPTION
Currently SyTest waits for synapse process to fully start by repeatedly
checking if it can connect to the HTTP socket. This won't work for
starting worker processest that do not listen on any HTTP socket.

Instead, we use the `sd_notify` mechanism. This works by SyTest binding
to a unix socket, passing the socket address to Synapse via env, and
waiting to receive a `READY=1` notification on the socket.