### PR TITLE
Disable rate limiting on Dendrite

### DIFF
--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -144,6 +144,10 @@ sub _get_config
             recaptcha_public_key     => $self->{recaptcha_config}->{public_key},
             recaptcha_private_key    => $self->{recaptcha_config}->{private_key},
          ) : (),
+
+         rate_limiting => {
+            enabled => $JSON::false,
+         },
       },
 
       current_state_server => {


### PR DESCRIPTION
This disables the new rate limiting on Dendrite so that we don't fail tests accidentally.

matrix-org/dendrite#1385