### PR TITLE
Update state idempotency tests to not use initialsync

### DIFF
--- a/tests/30rooms/01state.pl
+++ b/tests/30rooms/01state.pl
@@ -277,7 +277,6 @@ sub set_test_state
 }
 
 test "Setting state twice is idempotent",
-   # TODO: deprecated endpoint used in this test
    # Setting synced to 1 inserts a m.room.test object into the
    # timeline which this test does not expect
    requires => [ local_user_and_room_fixtures( room_opts => { synced => 0 } ) ],
@@ -302,7 +301,6 @@ test "Setting state twice is idempotent",
    };
 
 test "Joining room twice is idempotent",
-   # TODO: deprecated endpoint used in this test
    requires => [ local_user_and_room_fixtures() ],
 
    check => sub {


### PR DESCRIPTION
This updates the following tests so that they no longer use initialsync:
```
Setting state twice is idempotent
Joining room twice is idempotent
```

Closes matrix-org/dendrite#1311. 