### PR TITLE
Run worker apps as the generic worker.

### DIFF
--- a/docker/pydron.py
+++ b/docker/pydron.py
@@ -64,8 +64,7 @@ try:
 
         base = (
             args["--synapse-python"]
-            + " -m synapse.app."
-            + appname
+            + " -m synapse.app.generic_worker"
             + " -D --config-path="
             + args["--synapse-config"]
             + " --config-path="


### PR DESCRIPTION
Synapse workers are now supposed to be run as `synapse.app.generic_worker` instead of the specific app.

This is a smaller bit of #958, but merging it will let me keep working on that locally until I'm sure that things work. 😄 

I think that the Docker container needs to be rebuilt to actually test this?