### PR TITLE
Update "Event with an invalid signature in the send_join response should not cause room join to fail"

### DIFF
--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -1027,7 +1027,7 @@ test "Event with an invalid signature in the send_join response should not cause
       );
 
       # Modify the event (after the signature was generated) to invalidate the signature.
-      $event->{origin} = "other-server:12345";
+      $event->{state_key} = "something";
 
       my $await_request_send_join;
 


### PR DESCRIPTION
Changing the `origin` field seemingly triggers the `Event ID domain <-> Origin` and `Sender Domain <-> Origin` checks, which is not great.