### PR TITLE
Fix signal handling in scripts/synapse_sytest.sh

### DIFF
--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -45,7 +45,13 @@ TEST_STATUS=0
 mkdir -p /logs
 ./run-tests.pl -I Dendrite::Monolith -d $GOBIN -W /src/sytest-whitelist -O tap --all \
     --work-directory="/work" --exclude-deprecated \
-    "$@" > /logs/results.tap || TEST_STATUS=$?
+    "$@" > /logs/results.tap &
+pid=$!
+
+# make sure that we kill the test runner on SIGTERM, SIGINT, etc
+trap 'kill $pid' TERM INT
+wait $pid || TEST_STATUS=$?
+trap - TERM INT
 
 if [ $TEST_STATUS -ne 0 ]; then
     echo >&2 -e "run-tests \e[31mFAILED\e[0m: exit code $TEST_STATUS"

--- a/scripts/synapse_sytest.sh
+++ b/scripts/synapse_sytest.sh
@@ -182,7 +182,6 @@ pid=$!
 
 # make sure that we kill the test runner on SIGTERM, SIGINT, etc
 trap 'kill $pid' TERM INT
-
 wait $pid || TEST_STATUS=$?
 trap - TERM INT
 

--- a/scripts/synapse_sytest.sh
+++ b/scripts/synapse_sytest.sh
@@ -177,7 +177,14 @@ fi
 mkdir -p /logs
 
 TEST_STATUS=0
-"${RUN_TESTS[@]}" "$@" >/logs/results.tap || TEST_STATUS=$?
+"${RUN_TESTS[@]}" "$@" >/logs/results.tap &
+pid=$!
+
+# make sure that we kill the test runner on SIGTERM, SIGINT, etc
+trap 'kill $pid' TERM INT
+
+wait $pid || TEST_STATUS=$?
+trap - TERM INT
 
 if [ $TEST_STATUS -ne 0 ]; then
     echo >&2 -e "run-tests \e[31mFAILED\e[0m: exit code $TEST_STATUS"


### PR DESCRIPTION
make sure that we pass SIGINTs and SIGTERMs through to the perl process, so
that `docker stop` and ctrl-c actually stop the test runs.