### PR TITLE
Run multiple event persisters when using Redis

### DIFF
--- a/tests/30rooms/60version_upgrade.pl
+++ b/tests/30rooms/60version_upgrade.pl
@@ -1070,6 +1070,8 @@ test "Local and remote users' homeservers remove a room from their public direct
             $remote_joiner, $new_room_id, ( server_name => $creator->server_name, )
          );
       })->then(sub {
+         # The room list can be updated asynchrounously, so we retry if it
+         # doesn't match what we expect.
          retry_until_success {
             do_request_json_for( $creator,
                method => "GET",
@@ -1093,6 +1095,8 @@ test "Local and remote users' homeservers remove a room from their public direct
             })
          }
       })->then(sub {
+         # The room list can be updated asynchrounously, so we retry if it
+         # doesn't match what we expect.
          retry_until_success {
             do_request_json_for( $remote_joiner,
                method => "GET",

--- a/tests/30rooms/60version_upgrade.pl
+++ b/tests/30rooms/60version_upgrade.pl
@@ -1070,7 +1070,7 @@ test "Local and remote users' homeservers remove a room from their public direct
             $remote_joiner, $new_room_id, ( server_name => $creator->server_name, )
          );
       })->then(sub {
-         # The room list can be updated asynchrounously, so we retry if it
+         # The room list can be updated asynchronously, so we retry if it
          # doesn't match what we expect.
          retry_until_success {
             do_request_json_for( $creator,
@@ -1095,7 +1095,7 @@ test "Local and remote users' homeservers remove a room from their public direct
             })
          }
       })->then(sub {
-         # The room list can be updated asynchrounously, so we retry if it
+         # The room list can be updated asynchronously, so we retry if it
          # doesn't match what we expect.
          retry_until_success {
             do_request_json_for( $remote_joiner,


### PR DESCRIPTION
This makes SyTest test Synapse's sharded event persister set up.

Requires https://github.com/matrix-org/synapse/pull/8499