### PR TITLE
Fix "Event with an invalid signature in the send_join response should not cause room join to fail"

### DIFF
--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -1091,14 +1091,14 @@ test "Event with an invalid signature in the send_join response should not cause
                die "Expected room_id to be $room_id";
          })->then(sub {
             await_sync_timeline_contains( $user, $room_id, check => sub {
-                my ( $event ) = @_;
+               my ( $event ) = @_;
                 
-                assert_json_keys( $event, qw( type sender ));
-                return unless $event->{type} eq "m.room.member";
-                assert_json_keys( $event->{content}, qw( membership ) );
-                return unless $event->{sender} eq $user->user_id;
+               assert_json_keys( $event, qw( type sender ));
+               return unless $event->{type} eq "m.room.member";
+               assert_json_keys( $event->{content}, qw( membership ) );
+               return unless $event->{sender} eq $user->user_id;
 
-                Future->done(1);
+               Future->done(1);
             });
          }),
       )

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -1017,7 +1017,7 @@ test "Event with an invalid signature in the send_join response should not cause
       my $room_id = $room->room_id;
 
       my $event = $room->create_and_insert_event(
-         sender      => "\@test:$local_server_name",
+         sender      => "$creator_id",
          type        => "test",
          room_id     => $room_id,
          state_key   => "",
@@ -1089,14 +1089,17 @@ test "Event with an invalid signature in the send_join response should not cause
 
             $body->{room_id} eq $room_id or
                die "Expected room_id to be $room_id";
+         })->then(sub {
+            await_sync_timeline_contains( $user, $room_id, check => sub {
+                my ( $event ) = @_;
+                
+                assert_json_keys( $event, qw( type sender ));
+                return unless $event->{type} eq "m.room.member";
+                assert_json_keys( $event->{content}, qw( membership ) );
+                return unless $event->{sender} eq $user->user_id;
 
-            matrix_get_my_member_event( $user, $room_id )
-         })->then( sub {
-            my ( $event ) = @_;
-
-            assert_json_keys( $event->{content}, qw( membership ) );
-
-            Future->done(1);
+                Future->done(1);
+            });
          }),
       )
    };


### PR DESCRIPTION
This makes two changes:

1. Waits for the membership to appear over `/sync`, instead of immediately hitting `/state`, since the roomserver might not know about that room yet
2. Crafts an event using a user that's *actually* in the room, such that the event won't fail auth checks