### PR TITLE
Make retry_until_success log the reason for failure

### DIFF
--- a/run-tests.pl
+++ b/run-tests.pl
@@ -413,20 +413,24 @@ sub delay
 }
 
 # Handy utility wrapper around Future::Utils::try_repeat_until_success which
-# includes a delay on retry
+# includes a delay on retry (and logs the reason for failure)
 sub retry_until_success(&)
 {
    my ( $code ) = @_;
 
    my $delay = 0.1;
+   my $iter = 0;
 
    try_repeat {
-      my $prev_f = shift;
-
-      ( $prev_f ?
+      ( $iter++ ?
             delay( $delay *= 1.5 ) :
             Future->done )
-         ->then( $code );
+         ->then( $code )
+         ->on_fail( sub {
+            my ( $exc ) = @_;
+            chomp $exc;
+            log_if_fail("Iteration $iter: not ready yet: $exc");
+         });
    }  until => sub { !$_[0]->failure };
 }
 

--- a/tests/30rooms/04messages.pl
+++ b/tests/30rooms/04messages.pl
@@ -400,10 +400,6 @@ test "Ephemeral messages received from clients are correctly expired",
                assert_deeply_eq( $chunk->[0]{content}, {}, 'chunk[0] content size' );
 
                Future->done(1);
-            })->on_fail( sub {
-               my ( $exc ) = @_;
-               chomp $exc;
-               log_if_fail "Iteration $iter: not ready yet: $exc";
             });
          }
       });

--- a/tests/30rooms/13guestaccess.pl
+++ b/tests/30rooms/13guestaccess.pl
@@ -413,10 +413,6 @@ test "GET /publicRooms lists rooms",
                }
 
                Future->done( 1 );
-            })->on_fail( sub {
-               my ( $exc ) = @_;
-               chomp $exc;
-               log_if_fail "Iteration $iter: not ready yet: $exc";
             });
          };
       })

--- a/tests/30rooms/70publicroomslist.pl
+++ b/tests/30rooms/70publicroomslist.pl
@@ -103,10 +103,6 @@ test "Name/topic keys are correct",
                }
 
                Future->done( 1 );
-            })->on_fail( sub {
-               my ( $exc ) = @_;
-               chomp $exc;
-               log_if_fail "Iteration $iter: not ready yet: $exc";
             });
          };
       });

--- a/tests/50federation/31room-send.pl
+++ b/tests/50federation/31room-send.pl
@@ -192,10 +192,6 @@ test "Ephemeral messages received from servers are correctly expired",
                assert_deeply_eq( $chunk->[0]{content}, {}, 'chunk[0] content size' );
 
                Future->done(1);
-            })->on_fail( sub {
-               my ( $exc ) = @_;
-               chomp $exc;
-               log_if_fail "Iteration $iter: not ready yet: $exc";
             });
          }
       });

--- a/tests/50federation/40publicroomlist.pl
+++ b/tests/50federation/40publicroomlist.pl
@@ -97,10 +97,6 @@ test "Name/topic keys are correct",
                }
 
                Future->done(1);
-            })->on_fail(sub {
-               my ($exc) = @_;
-               chomp $exc;
-               log_if_fail "Iteration $iter: not ready yet: $exc";
             });
          };
       })


### PR DESCRIPTION
otherwise it gets swallowed.

That means we can remove the same pattern from all the other places we have it.