### PR TITLE
Mark "Read receipts are sent as events" as deprecated

### DIFF
--- a/tests/30rooms/21receipts.pl
+++ b/tests/30rooms/21receipts.pl
@@ -118,6 +118,7 @@ multi_test "Read receipts are visible to /initialSync",
    };
 
 test "Read receipts are sent as events",
+   deprecated_endpoints => 1,
    requires => [ local_user_and_room_fixtures( user_opts => { with_events => 1 }),
                  qw( can_post_room_receipts )],
 


### PR DESCRIPTION
As per the [Spec](https://matrix.org/docs/spec/client_server/r0.6.1#deprecated-get-matrix-client-r0-events) the endpoint `/_matrix/client/r0/events` is deprecated.