### PR TITLE
Mark "Read receipts are sent as events" as deprecated

### DIFF
--- a/tests/30rooms/21receipts.pl
+++ b/tests/30rooms/21receipts.pl
@@ -118,6 +118,7 @@ multi_test "Read receipts are visible to /initialSync",
    };
 
 test "Read receipts are sent as events",
+   deprecated_endpoints => 1,
    requires => [ local_user_and_room_fixtures( user_opts => { with_events => 1 }),
                  qw( can_post_room_receipts )],
 


### PR DESCRIPTION
The `Read receipts are sent as events` test uses `/events`, which is deprecated, and there are already other tests which check the same functionality using non-deprecated endpoints:

- `Read receipts appear in initial v2 /sync`
- `New read receipts appear in incremental v2 /sync`