### PR TITLE
Bump the version of Future we're depending on

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -32,7 +32,9 @@ requires 'Email::MIME';
 requires 'File::Basename';
 requires 'File::Path';
 requires 'File::Slurper';
-requires 'Future', '>= 0.33';
+
+# Future 0.45 allows you to return immediate values from sequence functions.
+requires 'Future', '>= 0.45';
 requires 'Getopt::Long';
 requires 'IO::Async', '>= 0.69';
 requires 'IO::Async::SSL';


### PR DESCRIPTION
For the second time this week (#972 and #973), I've found myself wondering why
a test was failing and discovered that it is due to it relying on new
functionality in Future 0.45. I guess we may as well bump the dep as try to
keep our tests backwards-compatible, particularly given the CI uses the latest
version.