### PR TITLE
Implementation-specific tests

### DIFF
--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -57,7 +57,7 @@ is described in more detail in the following sections.
 
 ``implementation_specific``
     A string to specify that the test should only be run for certain homeserver
-    implementations, e.g. `"Synapse"`, `"Dendrite::Monolith"` etc. 
+    implementations, e.g. `"Synapse"`, `"Dendrite"` etc. 
 
 A call to ``test`` is a simplified version of ``multi_test`` which produces
 only a single line of test output indicating success or failure automatically.

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -55,6 +55,10 @@ is described in more detail in the following sections.
     deprecated in the spec. These tests will be ignored automatically if
     the ``--exclude-deprecated`` flag is provided to Sytest. 
 
+``implementation_specific``
+    A string to specify that the test should only be run for certain homeserver
+    implementations, e.g. `"Synapse"`, `"Dendrite::Monolith"` etc. 
+
 A call to ``test`` is a simplified version of ``multi_test`` which produces
 only a single line of test output indicating success or failure automatically.
 A call to ``multi_test`` can make use of additional functions within the body

--- a/lib/SyTest/HomeserverFactory.pm
+++ b/lib/SyTest/HomeserverFactory.pm
@@ -38,6 +38,14 @@ sub new
 
 sub _init {}
 
+# Returns the generic simple name of the implementation, e.g. "synapse",
+# "dendrite" etc. This is used when determining whether to run any
+# implementation-specific tests.
+sub implementation_name
+{
+    return "";
+}
+
 # returns a list of (name => action) pairs suitable for
 # inclusion in the GetOptions argument list
 sub get_options

--- a/lib/SyTest/HomeserverFactory/Dendrite.pm
+++ b/lib/SyTest/HomeserverFactory/Dendrite.pm
@@ -31,6 +31,11 @@ sub _init
    $self->SUPER::_init( @_ );
 }
 
+sub implementation_name
+{
+   return "dendrite";
+}
+
 sub get_options
 {
    my $self = shift;

--- a/lib/SyTest/HomeserverFactory/Dendrite.pm
+++ b/lib/SyTest/HomeserverFactory/Dendrite.pm
@@ -70,6 +70,11 @@ sub _init
    $self->SUPER::_init( @_ );
 }
 
+sub implementation_name
+{
+   return "dendrite";
+}
+
 sub create_server
 {
    my $self = shift;

--- a/lib/SyTest/HomeserverFactory/Dendrite.pm
+++ b/lib/SyTest/HomeserverFactory/Dendrite.pm
@@ -70,11 +70,6 @@ sub _init
    $self->SUPER::_init( @_ );
 }
 
-sub implementation_name
-{
-   return "dendrite";
-}
-
 sub create_server
 {
    my $self = shift;

--- a/lib/SyTest/HomeserverFactory/Manual.pm
+++ b/lib/SyTest/HomeserverFactory/Manual.pm
@@ -31,6 +31,11 @@ sub _init
    $self->SUPER::_init( @_ );
 }
 
+sub implementation_name
+{
+   return "manual";
+}
+
 sub get_options
 {
    my $self = shift;

--- a/lib/SyTest/HomeserverFactory/Synapse.pm
+++ b/lib/SyTest/HomeserverFactory/Synapse.pm
@@ -38,6 +38,11 @@ sub _init
    $self->SUPER::_init( @_ );
 }
 
+sub implementation_name
+{
+   return "synapse";
+}
+
 sub get_options
 {
    my $self = shift;

--- a/lib/SyTest/HomeserverFactory/Synapse.pm
+++ b/lib/SyTest/HomeserverFactory/Synapse.pm
@@ -108,11 +108,6 @@ sub _init
    $self->{args}{redis_host} = "";
 }
 
-sub implementation_name
-{
-   return "synapse";
-}
-
 sub get_options
 {
    my $self = shift;

--- a/lib/SyTest/HomeserverFactory/Synapse.pm
+++ b/lib/SyTest/HomeserverFactory/Synapse.pm
@@ -103,6 +103,11 @@ sub _init
    $self->{args}{redis_host} = "";
 }
 
+sub implementation_name
+{
+   return "synapse";
+}
+
 sub get_options
 {
    my $self = shift;

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -623,7 +623,7 @@ sub _push_test
    }
 
    if( exists $params{implementation_specific} ) {
-       if ( $params{implementation_specific} ne $SERVER_IMPL ) {
+       if ( (split /::/, $params{implementation_specific})[0] ne $SERVER_IMPL ) {
            return;
        }
    }

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -623,8 +623,7 @@ sub _push_test
    }
 
    if( exists $params{implementation_specific} ) {
-       my @tokens = split /::/, $SERVER_IMPL;
-       if ( $tokens[0] ne $params{implementation_specific} ) {
+       if ( $HS_FACTORY->implementation_name() ne $params{implementation_specific} ) {
            return;
        }
    }

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -624,7 +624,7 @@ sub _push_test
 
    if( exists $params{implementation_specific} ) {
        my @tokens = split /::/, $SERVER_IMPL;
-       if ( $tokens[0] ne $$params{implementation_specific} ) {
+       if ( $tokens[0] ne $params{implementation_specific} ) {
            return;
        }
    }

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -624,7 +624,7 @@ sub _push_test
 
    if( exists $params{implementation_specific} ) {
        my @tokens = split /::/, $params{implementation_specific};
-       if ( @tokens[0] ne $SERVER_IMPL ) {
+       if ( $tokens[0] ne $SERVER_IMPL ) {
            return;
        }
    }

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -623,7 +623,7 @@ sub _push_test
    }
 
    if( exists $params{implementation_specific} ) {
-       @tokens = split /::/, $params{implementation_specific};
+       my @tokens = split /::/, $params{implementation_specific};
        if ( @tokens[0] ne $SERVER_IMPL ) {
            return;
        }

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -623,7 +623,8 @@ sub _push_test
    }
 
    if( exists $params{implementation_specific} ) {
-       if ( (split /::/, $params{implementation_specific})[0] ne $SERVER_IMPL ) {
+       @tokens = split /::/, $params{implementation_specific};
+       if ( @tokens[0] ne $SERVER_IMPL ) {
            return;
        }
    }

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -623,8 +623,8 @@ sub _push_test
    }
 
    if( exists $params{implementation_specific} ) {
-       my @tokens = split /::/, $params{implementation_specific};
-       if ( $tokens[0] ne $SERVER_IMPL ) {
+       my @tokens = split /::/, $SERVER_IMPL;
+       if ( $tokens[0] ne $$params{implementation_specific} ) {
            return;
        }
    }

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -622,6 +622,12 @@ sub _push_test
        }
    }
 
+   if( exists $params{implementation_specific} ) {
+       if ( $params{implementation_specific} ne $SERVER_IMPL ) {
+           return;
+       }
+   }
+
    push @TESTS, Test( $filename, $name, $multi,
       @params{qw( expect_fail proves requires check do timeout )} );
 }

--- a/tests/10apidoc/01register.pl
+++ b/tests/10apidoc/01register.pl
@@ -318,6 +318,7 @@ sub shared_secret_tests {
 
    test "POST $ep_name with shared secret",
       requires => [ $main::API_CLIENTS[0], localpart_fixture() ],
+      implementation_specific => "Synapse",
 
       proves => [qw( can_register_with_secret )],
 
@@ -334,6 +335,7 @@ sub shared_secret_tests {
 
    test "POST $ep_name admin with shared secret",
       requires => [ $main::API_CLIENTS[0], localpart_fixture() ],
+      implementation_specific => "Synapse",
 
       do => sub {
          my ( $http, $uid ) = @_;
@@ -349,6 +351,7 @@ sub shared_secret_tests {
 
    test "POST $ep_name with shared secret downcases capitals",
       requires => [ $main::API_CLIENTS[0], localpart_fixture() ],
+      implementation_specific => "Synapse",
 
       proves => [qw( can_register_with_secret )],
 
@@ -365,6 +368,7 @@ sub shared_secret_tests {
 
    test "POST $ep_name with shared secret disallows symbols",
       requires => [ $main::API_CLIENTS[0] ],
+      implementation_specific => "Synapse",
 
       proves => [qw( can_register_with_secret )],
 

--- a/tests/10apidoc/01register.pl
+++ b/tests/10apidoc/01register.pl
@@ -318,7 +318,7 @@ sub shared_secret_tests {
 
    test "POST $ep_name with shared secret",
       requires => [ $main::API_CLIENTS[0], localpart_fixture() ],
-      implementation_specific => "Synapse",
+      implementation_specific => "synapse",
 
       proves => [qw( can_register_with_secret )],
 
@@ -335,7 +335,7 @@ sub shared_secret_tests {
 
    test "POST $ep_name admin with shared secret",
       requires => [ $main::API_CLIENTS[0], localpart_fixture() ],
-      implementation_specific => "Synapse",
+      implementation_specific => "synapse",
 
       do => sub {
          my ( $http, $uid ) = @_;
@@ -351,7 +351,7 @@ sub shared_secret_tests {
 
    test "POST $ep_name with shared secret downcases capitals",
       requires => [ $main::API_CLIENTS[0], localpart_fixture() ],
-      implementation_specific => "Synapse",
+      implementation_specific => "synapse",
 
       proves => [qw( can_register_with_secret )],
 
@@ -368,7 +368,7 @@ sub shared_secret_tests {
 
    test "POST $ep_name with shared secret disallows symbols",
       requires => [ $main::API_CLIENTS[0] ],
-      implementation_specific => "Synapse",
+      implementation_specific => "synapse",
 
       proves => [qw( can_register_with_secret )],
 

--- a/tests/48admin.pl
+++ b/tests/48admin.pl
@@ -30,7 +30,7 @@ sub await_purge_complete {
 
 test "/whois",
    requires => [ $main::API_CLIENTS[0] ],
-   implementation_specific => "Synapse",
+   implementation_specific => "synapse",
 
    do => sub {
       my ( $http ) = @_;
@@ -70,7 +70,7 @@ test "/whois",
 
 test "/purge_history",
    requires => [ local_admin_fixture(), local_user_and_room_fixtures() ],
-   implementation_specific => "Synapse",
+   implementation_specific => "synapse",
 
    do => sub {
       my ( $admin, $user, $room_id ) = @_;
@@ -151,7 +151,7 @@ test "/purge_history",
 
 test "/purge_history by ts",
    requires => [ local_admin_fixture(), local_user_and_room_fixtures() ],
-   implementation_specific => "Synapse",
+   implementation_specific => "synapse",
 
    do => sub {
       my ( $admin, $user, $room_id ) = @_;
@@ -225,7 +225,7 @@ test "/purge_history by ts",
 test "Can backfill purged history",
    requires => [ local_admin_fixture(), local_user_and_room_fixtures(),
                  remote_user_fixture(), qw( can_paginate_room_remotely ) ],
-   implementation_specific => "Synapse",
+   implementation_specific => "synapse",
 
    # this test is a bit slow.
    timeout => 50,
@@ -362,7 +362,7 @@ test "Can backfill purged history",
 multi_test "Shutdown room",
    requires => [ local_admin_fixture(), local_user_fixtures( 2 ), remote_user_fixture(),
       room_alias_name_fixture() ],
-   implementation_specific => "Synapse",
+   implementation_specific => "synapse",
 
    do => sub {
       my ( $admin, $user, $dummy_user, $remote_user, $room_alias_name ) = @_;

--- a/tests/48admin.pl
+++ b/tests/48admin.pl
@@ -30,7 +30,6 @@ sub await_purge_complete {
 
 test "/whois",
    requires => [ $main::API_CLIENTS[0] ],
-   implementation_specific => "synapse",
 
    do => sub {
       my ( $http ) = @_;

--- a/tests/48admin.pl
+++ b/tests/48admin.pl
@@ -30,6 +30,7 @@ sub await_purge_complete {
 
 test "/whois",
    requires => [ $main::API_CLIENTS[0] ],
+   implementation_specific => "Synapse",
 
    do => sub {
       my ( $http ) = @_;
@@ -69,6 +70,7 @@ test "/whois",
 
 test "/purge_history",
    requires => [ local_admin_fixture(), local_user_and_room_fixtures() ],
+   implementation_specific => "Synapse",
 
    do => sub {
       my ( $admin, $user, $room_id ) = @_;
@@ -149,6 +151,7 @@ test "/purge_history",
 
 test "/purge_history by ts",
    requires => [ local_admin_fixture(), local_user_and_room_fixtures() ],
+   implementation_specific => "Synapse",
 
    do => sub {
       my ( $admin, $user, $room_id ) = @_;
@@ -222,6 +225,7 @@ test "/purge_history by ts",
 test "Can backfill purged history",
    requires => [ local_admin_fixture(), local_user_and_room_fixtures(),
                  remote_user_fixture(), qw( can_paginate_room_remotely ) ],
+   implementation_specific => "Synapse",
 
    # this test is a bit slow.
    timeout => 50,
@@ -358,6 +362,7 @@ test "Can backfill purged history",
 multi_test "Shutdown room",
    requires => [ local_admin_fixture(), local_user_fixtures( 2 ), remote_user_fixture(),
       room_alias_name_fixture() ],
+   implementation_specific => "Synapse",
 
    do => sub {
       my ( $admin, $user, $dummy_user, $remote_user, $room_alias_name ) = @_;


### PR DESCRIPTION
This PR adds a test parameter `implementation_specific`, which instructs Sytest to run a test for a specific implementation only. It also marks the admin tests as Synapse-specific.