### PR TITLE
Add tests for allowed symbols in user identifiers

### DIFF
--- a/changelog.d/983.feature
+++ b/changelog.d/983.feature
@@ -1,0 +1,1 @@
+- Add tests for allowed symbols in user identifiers. Thanks to @bodqhrohro

--- a/changelog.d/983.feature
+++ b/changelog.d/983.feature
@@ -1,1 +1,0 @@
-- Add tests for allowed symbols in user identifiers. Thanks to @bodqhrohro

--- a/tests/10apidoc/01register.pl
+++ b/tests/10apidoc/01register.pl
@@ -183,6 +183,11 @@ foreach my $chr (split '', '!":?\@[]{|}£é' . "\n'" ) {
 
 foreach my $chr (split '', 'q3._=-/' ) {
    test "POST /register allows registration of usernames with '$chr'",
+      # Note: this test relies on somewhat implementation-specific details,
+      # in that it assumes that the `username` presented to `/register` maps
+      # directly onto an MXID. In reality, a server is free to accept or reject
+      # any `usernames` it wants, provided it maps those it accepts onto
+      # valid MXIDs.
       requires => [ $main::API_CLIENTS[0],
                     qw( can_register_dummy_flow ) ],
 

--- a/tests/10apidoc/01register.pl
+++ b/tests/10apidoc/01register.pl
@@ -180,6 +180,32 @@ foreach my $chr (split '', '!":?\@[]{|}£é' . "\n'" ) {
       };
 }
 
+
+foreach my $chr (split '', 'q3._=-/' ) {
+   test "POST /register allows registration of usernames with '$chr'",
+      requires => [ $main::API_CLIENTS[0],
+                    qw( can_register_dummy_flow ) ],
+
+      do => sub {
+         my ( $http ) = @_;
+
+         my $reqbody = {
+            auth => {
+               type => "m.login.dummy",
+            },
+            username => 'chrtestuser'.$chr,
+            password => "sUp3rs3kr1t",
+         };
+
+         $http->do_request_json(
+            method => "POST",
+            uri    => "/r0/register",
+
+            content => $reqbody,
+         );
+      };
+}
+
 push our @EXPORT, qw( localpart_fixture );
 
 my $next_anon_uid = 1;


### PR DESCRIPTION
https://matrix.org/docs/spec/appendices#user-identifiers

Signed-off-by: Bohdan Horbeshko bodqhrohro@gmail.com