### PR TITLE
Use an empty ip_range_blacklist to allow connecting to localhost.

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -252,6 +252,7 @@ sub start
 
         # We remove the ip range blacklist which by default blocks federation
         # connections to local homeservers, of which sytest uses extensively
+        ip_range_blacklist => [],
         federation_ip_range_blacklist => [],
 
         # If we're using workers we need to disable these things in the main


### PR DESCRIPTION
Corresponds to matrix-org/synapse#8870. Empties out the new `ip_range_blacklist` setting (similar to `federation_ip_range_blacklist`) so that connections to private IPs work OK.