### PR TITLE
Switch `shutdown_room` to `delete` room API

### DIFF
--- a/tests/48admin.pl
+++ b/tests/48admin.pl
@@ -383,7 +383,11 @@ multi_test "Shutdown room",
          do_request_json_for( $admin,
             method   => "POST",
             full_uri => "/_synapse/admin/v1/rooms/$room_id/delete",
-            content  => { "new_room_user_id" => $dummy_user->user_id },
+            content  => {
+               new_room_user_id => $dummy_user->user_id,
+               block => JSON::true,
+               purge => JSON::false,
+            },
          );
       })->SyTest::pass_on_done( "Shutdown room returned success" )
       ->then( sub {

--- a/tests/48admin.pl
+++ b/tests/48admin.pl
@@ -382,7 +382,7 @@ multi_test "Shutdown room",
       })->then( sub {
          do_request_json_for( $admin,
             method   => "POST",
-            full_uri => "/_synapse/admin/v1/shutdown_room/$room_id",
+            full_uri => "/_synapse/admin/v1/rooms/$room_id/delete",
             content  => { "new_room_user_id" => $dummy_user->user_id },
          );
       })->SyTest::pass_on_done( "Shutdown room returned success" )


### PR DESCRIPTION
Remove old `shutdown_room` admin API

Switch from `/_synapse/admin/v1/shutdown_room/$room_id`
to `/_synapse/admin/v1/rooms/$room_id/delete`

Follow up: https://github.com/matrix-org/synapse/pull/8829
Required for: https://github.com/matrix-org/synapse/pull/8830