### PR TITLE
Ensure that SSO users are registered before trying to UI auth them.

### DIFF
--- a/tests/10apidoc/13ui-auth.pl
+++ b/tests/10apidoc/13ui-auth.pl
@@ -117,8 +117,7 @@ sub matrix_login_with_cas
       ),
    )->then( sub {
       my ( $cas_request, $_cas_response ) = @_;
-      log_if_fail( "Initial CAS request query:",
-                   $cas_request->query_string );
+      log_if_fail "Initial CAS request query:", $cas_request->query_string;
 
       assert_eq( $cas_request->method, "GET", "CAS request method" );
 
@@ -132,7 +131,7 @@ sub matrix_login_with_cas
       #
       # The URI that CAS redirects back to is the value of the 'service'
       # param we gave it, with an additional "ticket" query-param:
-      my $login_uri = $service . "&ticket=$CAS_TICKET";
+      my $login_uri = "$service&ticket=$CAS_TICKET";;
 
       # step 5: synapse receives ticket number from client, and makes a
       # request to CAS to validate the ticket.
@@ -165,8 +164,8 @@ sub matrix_login_with_cas
                  "Login token provided in the /ticket response" );
       my $login_token = $1;
 
-      log_if_fail( "Ticket response:", $ticket_response );
-      log_if_fail( "Login token:", $login_token );
+      log_if_fail "Ticket response:", $ticket_response;
+      log_if_fail "Login token:", $login_token;
 
       # step 7: the client uses the loginToken via the /login API.
       $http->do_request_json(
@@ -182,7 +181,7 @@ sub matrix_login_with_cas
    })->then( sub {
       my ( $body ) = @_;
 
-      log_if_fail( "Response from /login", $body );
+      log_if_fail "Response from /login", $body;
 
       assert_json_keys( $body, qw( access_token home_server user_id device_id ));
 

--- a/tests/10apidoc/13ui-auth.pl
+++ b/tests/10apidoc/13ui-auth.pl
@@ -3,6 +3,46 @@ use URI::Escape;
 
 our @EXPORT = qw( wait_for_cas_request );
 
+my $cas_login_fixture = fixture(
+   requires => [ $main::API_CLIENTS[0] ],
+
+   setup => sub {
+      my ( $http ) = @_;
+
+      $http->do_request_json(
+         method => "GET",
+         uri => "/r0/login",
+      )->then( sub {
+         my ( $body ) = @_;
+
+         assert_json_keys( $body, qw( flows ));
+         assert_json_list $body->{flows};
+
+         die "SKIP: no m.login.cas" unless
+            any { $_->{type} eq "m.login.cas" } @{ $body->{flows} };
+
+         Future->done( 1 );
+      });
+   },
+);
+
+sub generate_cas_response
+{
+   my ( $user_id ) = @_;
+
+   my ($user_localpart) = $user_id =~ m/@([^:]*):/;
+   my $cas_success = <<"EOF";
+<cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
+    <cas:authenticationSuccess>
+         <cas:user>$user_localpart</cas:user>
+         <cas:attributes></cas:attributes>
+    </cas:authenticationSuccess>
+</cas:serviceResponse>
+EOF
+
+   return $cas_success
+}
+
 # A convenience function which wraps await_http_request. It returns a successful
 # CAS response when queried for a particular path.
 #
@@ -26,6 +66,110 @@ sub wait_for_cas_request
       $request->respond( $response );
 
       Future->done( $request );
+   });
+}
+
+# Log into Synapse via CAS.
+sub matrix_login_with_cas
+{
+   my ( $user_id, $cas_ticket, $http, $homeserver_info, %params ) = @_;
+
+   # the redirectUrl we send to /login/sso/redirect, which is where we
+   # hope to get redirected back to
+   my $REDIRECT_URL = "https://client?p=http%3A%2F%2Fserver";
+
+   my $HS_URI = $homeserver_info->client_location . "/_matrix/client/r0/login/cas/ticket?redirectUrl=" . uri_escape($REDIRECT_URL);
+
+   my $CAS_SUCCESS = generate_cas_response( $user_id );
+
+   # step 1: client sends request to /login/sso/redirect
+   # step 2: synapse should redirect to the cas server.
+   Future->needs_all(
+      wait_for_cas_request( "/cas/login" ),
+      $http->do_request(
+         method => "GET",
+         uri    => "/r0/login/sso/redirect",
+         params => {
+            redirectUrl => $REDIRECT_URL,
+         },
+      ),
+   )->then( sub {
+      my ( $cas_request, $cas_response ) = @_;
+      log_if_fail( "Initial CAS request query:",
+                   $cas_request->query_string );
+
+      assert_eq( $cas_request->method, "GET", "CAS request method" );
+
+      my $service = $cas_request->query_param( "service" );
+
+      # step 3: client sends credentials to CAS server
+      # step 4: CAS redirects, with a ticket number, back to synapse.
+      #
+      # For this test, we skip this bit, as it's nothing to do with synapse,
+      # really.
+      #
+      # The URI that CAS redirects back to is the value of the 'service'
+      # param we gave it, with an additional "ticket" query-param:
+      my $login_uri = $service . "&ticket=$cas_ticket";
+
+      # step 5: synapse receives ticket number from client, and makes a
+      # request to CAS to validate the ticket.
+      # step 6: synapse sends a redirect back to the browser, with a
+      # 'loginToken' parameter
+      Future->needs_all(
+         wait_for_cas_request(
+            "/cas/proxyValidate",
+            response => $CAS_SUCCESS,
+         ),
+         $http->do_request_json(
+            method   => "GET",
+            full_uri => $login_uri,
+            max_redirects => 0, # don't follow the redirect
+         ),
+      );
+   })->then( sub {
+      my ( $cas_validate_request, $ticket_response ) = @_;
+
+      assert_eq( $cas_validate_request->method, "GET",
+                 "/cas/proxyValidate request method" );
+      assert_eq( $cas_validate_request->query_param( "ticket" ),
+                 $cas_ticket,
+                 "Ticket supplied to /cas/proxyValidate" );
+      assert_eq( $cas_validate_request->query_param( "service" ),
+                 $HS_URI,
+                 "Service supplied to /cas/proxyValidate" );
+
+      assert_ok( $ticket_response =~ "loginToken=([^\"&]+)",
+                 "Login token provided in the /ticket response" );
+      my $login_token = $1;
+
+      log_if_fail( "Ticket response:", $ticket_response );
+      log_if_fail( "Login token:", $login_token );
+
+      # step 7: the client uses the loginToken via the /login API.
+      $http->do_request_json(
+         method => "POST",
+         uri    => "/r0/login",
+
+         content => {
+            type     => "m.login.token",
+            token    => $login_token,
+            %params,
+         }
+      );
+   })->then( sub {
+      my ( $body ) = @_;
+
+      log_if_fail( "Response from /login", $body );
+
+      assert_json_keys( $body, qw( access_token home_server user_id device_id ));
+
+      assert_eq( $body->{home_server}, $http->server_name,
+                 'home_server in /login response' );
+      assert_eq( $body->{user_id}, $user_id,
+                 'user_id in /login response' );
+
+      Future->done(1);
    });
 }
 
@@ -55,15 +199,19 @@ sub make_ticket_request
 }
 
 test "Interactive authentication types include SSO",
-   requires => [ local_user_fixture() ],
+   requires => [ local_user_fixture(), $main::API_CLIENTS[0], $main::HOMESERVER_INFO[0], $cas_login_fixture, ],
 
    do => sub {
-      my ( $user ) = @_;
+      my ( $user, $http, $homeserver_info ) = @_;
 
       my $DEVICE_ID = "login_device";
+      my $CAS_TICKET = "goldenticket";
 
-      matrix_login_again_with_user(
-         $user,
+      matrix_login_with_cas(
+         $user->user_id,
+         $CAS_TICKET,
+         $http,
+         $homeserver_info,
          device_id => $DEVICE_ID,
          initial_device_display_name => "device display",
       )->then( sub {
@@ -92,6 +240,7 @@ test "Can perform interactive authentication with SSO",
       local_user_fixture(),
       $main::API_CLIENTS[0],
       $main::HOMESERVER_INFO[0],
+      $cas_login_fixture,
    ],
 
    do => sub {
@@ -99,23 +248,18 @@ test "Can perform interactive authentication with SSO",
 
       my $DEVICE_ID = "login_device";
 
-      my ($user_localpart) = $user->user_id =~ m/@([^:]*):/;
-      my $CAS_SUCCESS = <<"EOF";
-<cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
-    <cas:authenticationSuccess>
-         <cas:user>$user_localpart</cas:user>
-         <cas:attributes></cas:attributes>
-    </cas:authenticationSuccess>
-</cas:serviceResponse>
-EOF
+      my $CAS_SUCCESS = generate_cas_response( $user->user_id );
 
       # the ticket our mocked-up CAS server "generates"
       my $CAS_TICKET = "goldenticket";
       my $session;
 
       # Create a device.
-      matrix_login_again_with_user(
-         $user,
+      matrix_login_with_cas(
+         $user->user_id,
+         $CAS_TICKET,
+         $http,
+         $homeserver_info,
          device_id => $DEVICE_ID,
          initial_device_display_name => "device display",
       )->then( sub {
@@ -151,6 +295,7 @@ test "The user must be consistent through an interactive authentication session 
       local_user_fixture(),
       $main::API_CLIENTS[0],
       $main::HOMESERVER_INFO[0],
+      $cas_login_fixture,
    ],
 
    do => sub {
@@ -160,22 +305,18 @@ test "The user must be consistent through an interactive authentication session 
 
       # The user below is what is returned from SSO and does not match the user
       # being logged into the homeserver.
-      my $CAS_SUCCESS = <<'EOF';
-<cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
-    <cas:authenticationSuccess>
-         <cas:user>cas_user</cas:user>
-         <cas:attributes></cas:attributes>
-    </cas:authenticationSuccess>
-</cas:serviceResponse>
-EOF
+      my $CAS_SUCCESS = generate_cas_response( '@cas_user' . $http->server_name );
 
       # the ticket our mocked-up CAS server "generates"
       my $CAS_TICKET = "goldenticket";
       my $session;
 
       # Create a device.
-      matrix_login_again_with_user(
-         $user,
+      matrix_login_with_cas(
+         $user->user_id,
+         $CAS_TICKET,
+         $http,
+         $homeserver_info,
          device_id => $DEVICE_ID,
          initial_device_display_name => "device display",
       )->then( sub {

--- a/tests/12login/02cas.pl
+++ b/tests/12login/02cas.pl
@@ -25,33 +25,9 @@ test "login types include SSO",
    };
 
 
-my $cas_login_fixture = fixture(
-   requires => [ $main::API_CLIENTS[0] ],
-
-   setup => sub {
-      my ( $http ) = @_;
-
-      $http->do_request_json(
-         method => "GET",
-         uri => "/r0/login",
-      )->then( sub {
-         my ( $body ) = @_;
-
-         assert_json_keys( $body, qw( flows ));
-         assert_json_list $body->{flows};
-
-         die "SKIP: no m.login.cas" unless
-            any { $_->{type} eq "m.login.cas" } @{ $body->{flows} };
-
-         Future->done( 1 );
-      });
-   },
-);
-
-
 test "/login/cas/redirect redirects if the old m.login.cas login type is listed",
    requires => [
-      $main::TEST_SERVER_INFO, $main::API_CLIENTS[0], $cas_login_fixture,
+      $main::TEST_SERVER_INFO, $main::API_CLIENTS[0], cas_login_fixture(),
    ],
 
    do => sub {
@@ -85,13 +61,9 @@ test "Can login with new user via CAS",
    do => sub {
       my ( $http, $homeserver_info ) = @_;
 
-      # the ticket our mocked-up CAS server "generates"
-      my $CAS_TICKET = "goldenticket";
-
       # Ensure the base login works without issue.
       matrix_login_with_cas(
          '@cas_user=21:' . $http->server_name,
-         $CAS_TICKET,
          $http,
          $homeserver_info,
          $CAS_SUCCESS,

--- a/tests/12login/02cas.pl
+++ b/tests/12login/02cas.pl
@@ -1,13 +1,6 @@
 use URI::Escape;
 
-my $CAS_SUCCESS = <<'EOF';
-<cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
-    <cas:authenticationSuccess>
-         <cas:user>cas_user!</cas:user>
-         <cas:attributes></cas:attributes>
-    </cas:authenticationSuccess>
-</cas:serviceResponse>
-EOF
+my $CAS_SUCCESS = generate_cas_response( 'cas_user!' );
 
 test "login types include SSO",
    requires => [ $main::API_CLIENTS[0] ],
@@ -92,102 +85,15 @@ test "Can login with new user via CAS",
    do => sub {
       my ( $http, $homeserver_info ) = @_;
 
-      # the redirectUrl we send to /login/cas/redirect, which is where we
-      # hope to get redirected back to
-      my $REDIRECT_URL = "https://client?p=http%3A%2F%2Fserver";
-
-      my $HS_URI = $homeserver_info->client_location . "/_matrix/client/r0/login/cas/ticket?redirectUrl=" . uri_escape($REDIRECT_URL);
-
       # the ticket our mocked-up CAS server "generates"
       my $CAS_TICKET = "goldenticket";
 
-      # step 1: client sends request to /login/sso/redirect
-      # step 2: synapse should redirect to the cas server.
-      Future->needs_all(
-         wait_for_cas_request( "/cas/login" ),
-         $http->do_request(
-            method => "GET",
-            uri    => "/r0/login/sso/redirect",
-            params => {
-               redirectUrl => $REDIRECT_URL,
-            },
-         ),
-      )->then( sub {
-         my ( $cas_request, $cas_response ) = @_;
-         log_if_fail( "Initial CAS request query:",
-                      $cas_request->query_string );
-
-         assert_eq( $cas_request->method, "GET", "CAS request method" );
-
-         my $service = $cas_request->query_param( "service" );
-
-         # step 3: client sends credentials to CAS server
-         # step 4: CAS redirects, with a ticket number, back to synapse.
-         #
-         # For this test, we skip this bit, as it's nothing to do with synapse,
-         # really.
-         #
-         # The URI that CAS redirects back to is the value of the 'service'
-         # param we gave it, with an additional "ticket" query-param:
-         my $login_uri = $service . "&ticket=$CAS_TICKET";
-
-         # step 5: synapse receives ticket number from client, and makes a
-         # request to CAS to validate the ticket.
-         # step 6: synapse sends a redirect back to the browser, with a
-         # 'loginToken' parameter
-         Future->needs_all(
-            wait_for_cas_request(
-               "/cas/proxyValidate",
-               response => $CAS_SUCCESS,
-            ),
-            $http->do_request_json(
-               method   => "GET",
-               full_uri => $login_uri,
-               max_redirects => 0, # don't follow the redirect
-            ),
-         );
-      })->then( sub {
-         my ( $cas_validate_request, $ticket_response ) = @_;
-
-         assert_eq( $cas_validate_request->method, "GET",
-                    "/cas/proxyValidate request method" );
-         assert_eq( $cas_validate_request->query_param( "ticket" ),
-                    $CAS_TICKET,
-                    "Ticket supplied to /cas/proxyValidate" );
-         assert_eq( $cas_validate_request->query_param( "service" ),
-                    $HS_URI,
-                    "Service supplied to /cas/proxyValidate" );
-
-         assert_ok( $ticket_response =~ "loginToken=([^\"&]+)",
-                    "Login token provided in the /ticket response" );
-         my $login_token = $1;
-
-         log_if_fail( "Ticket response:", $ticket_response );
-         log_if_fail( "Login token:", $login_token );
-
-         # step 7: the client uses the loginToken via the /login API.
-         $http->do_request_json(
-            method => "POST",
-            uri    => "/r0/login",
-
-            content => {
-               type     => "m.login.token",
-               token    => $login_token,
-            }
-         );
-      })->then( sub {
-         my ( $body ) = @_;
-
-         log_if_fail( "Response from /login", $body );
-
-         assert_json_keys( $body, qw( access_token home_server user_id device_id ));
-
-         assert_eq( $body->{home_server}, $http->server_name,
-                    'home_server in /login response' );
-         assert_eq( $body->{user_id},
-                    '@cas_user=21:' . $http->server_name,
-                    'user_id in /login response' );
-
-         Future->done(1);
-      });
+      # Ensure the base login works without issue.
+      matrix_login_with_cas(
+         '@cas_user=21:' . $http->server_name,
+         $CAS_TICKET,
+         $http,
+         $homeserver_info,
+         $CAS_SUCCESS,
+      );
    };


### PR DESCRIPTION
We have some tests for UI auth + SSO, but they're performed with users who aren't actually logged in via SSO, so the resulting authentication flows don't really make sense.

This modifies the UI auth + SSO tests to log the users in via SSO, not via normal login. (This allows a homeserver to know that they're an SSO user, not user that logs in via a password.)

The diff here is pretty awful, but I pretty much abstracted the "Can login with new user via CAS" to a sub (`matrix_login_with_cas`) that then gets used in multiple places. It also pulls the `cas_login_fixture` into the UI auth tests as well and adds a new sub `generate_cas_response` instead of hard-coding the same XML in many places.