### PR TITLE
Look for sender not user_id in various tests

### DIFF
--- a/tests/30rooms/04messages.pl
+++ b/tests/30rooms/04messages.pl
@@ -108,7 +108,7 @@ test "Local non-members don't see posted message events",
 
             return unless $event->{type} eq "m.room.message";
 
-            assert_json_keys( $event, qw( type content user_id ));
+            assert_json_keys( $event, qw( type content sender ));
 
             die "Nonmember received event about a room they're not a member of";
          }),

--- a/tests/30rooms/04messages.pl
+++ b/tests/30rooms/04messages.pl
@@ -140,7 +140,7 @@ test "Local room members can get room messages",
 
             my ( $event ) = @$chunk;
 
-            assert_json_keys( $event, qw( type room_id user_id content ));
+            assert_json_keys( $event, qw( type room_id sender content ));
 
             $event->{room_id} eq $room_id or
                die "Expected room_id to be $room_id";
@@ -193,7 +193,7 @@ test "Remote room members can get room messages",
 
          my ( $event ) = @$chunk;
 
-         assert_json_keys( $event, qw( type room_id user_id content ));
+         assert_json_keys( $event, qw( type room_id sender content ));
 
          $event->{room_id} eq $room_id or
             die "Expected room_id to be $room_id";

--- a/tests/30rooms/13guestaccess.pl
+++ b/tests/30rooms/13guestaccess.pl
@@ -59,10 +59,10 @@ test "Guest users can send messages to guest_access rooms if joined",
 
                my ( $event ) = @$chunk;
 
-               assert_json_keys( $event, qw( type room_id user_id content ));
+               assert_json_keys( $event, qw( type room_id sender content ));
 
-               $event->{user_id} eq $guest_user->user_id or
-                  die "expected user_id to be ".$guest_user->user_id;
+               $event->{sender} eq $guest_user->user_id or
+                  die "expected sender to be ".$guest_user->user_id;
 
                $event->{content}->{body} eq "sup" or
                   die "content to be sup";

--- a/tests/60app-services/02ghost.pl
+++ b/tests/60app-services/02ghost.pl
@@ -46,11 +46,11 @@ multi_test "AS-ghosted users can use rooms via AS",
 
                log_if_fail "AS event", $event;
 
-               assert_json_keys( $event, qw( room_id user_id ));
+               assert_json_keys( $event, qw( room_id sender ));
 
                $event->{room_id} eq $room_id or
                   die "Expected room_id to be $room_id";
-               $event->{user_id} eq $ghost->user_id or
+               $event->{sender} eq $ghost->user_id or
                   die "Expected sender user_id to be ${\$ghost->user_id}";
 
                Future->done;
@@ -123,11 +123,11 @@ multi_test "AS-ghosted users can use rooms themselves",
 
                log_if_fail "AS event", $event;
 
-               assert_json_keys( $event, qw( room_id user_id ));
+               assert_json_keys( $event, qw( room_id sender ));
 
                $event->{room_id} eq $room_id or
                   die "Expected room_id to be $room_id";
-               $event->{user_id} eq $ghost->user_id or
+               $event->{sender} eq $ghost->user_id or
                   die "Expected sender user_id to be ${\$ghost->user_id}";
 
                Future->done;

--- a/tests/60app-services/03passive.pl
+++ b/tests/60app-services/03passive.pl
@@ -29,7 +29,7 @@ test "Inviting an AS-hosted user asks the AS server",
 
             log_if_fail "Event", $event;
 
-            assert_json_keys( $event, qw( content room_id user_id ));
+            assert_json_keys( $event, qw( content room_id sender ));
 
             $event->{room_id} eq $room_id or
                die "Expected room_id to be $room_id";
@@ -77,10 +77,10 @@ multi_test "Accesing an AS-hosted room alias asks the AS server",
 
             log_if_fail "Event", $event;
 
-            assert_json_keys( $event, qw( content room_id user_id state_key ));
+            assert_json_keys( $event, qw( content room_id sender state_key ));
 
             assert_eq($event->{room_id}, $room_id, "Event room_id");
-            assert_eq($event->{user_id}, $local_user->user_id, "Event user_id");
+            assert_eq($event->{sender}, $local_user->user_id, "Event sender");
             assert_eq($event->{state_key}, $local_user->user_id, "Event state_key");
 
             assert_json_keys( $event->{content}, qw( membership ));
@@ -111,7 +111,7 @@ test "Events in rooms with AS-hosted room aliases are sent to AS server",
 
             log_if_fail "Event", $event;
 
-            assert_json_keys( $event, qw( content room_id user_id ));
+            assert_json_keys( $event, qw( content room_id sender ));
 
             $event->{room_id} eq $room_id or
                die "Expected room_id to be $room_id";


### PR DESCRIPTION
Fixes a few dendrite tests as a result.