### PR TITLE
Allow redact to run on the event_creator.

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -1240,6 +1240,7 @@ sub generate_haproxy_map
 
 ^/_matrix/client/(r0|unstable|v2_alpha)/user_directory/    user_dir
 
+^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/redact                               event_creator
 ^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/send                                 event_creator
 ^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/(join|invite|leave|ban|unban|kick)$  event_creator
 ^/_matrix/client/(api/v1|r0|unstable)/join/                                         event_creator


### PR DESCRIPTION
Corresponds to the changes in matrix-org/synapse#8994.