### PR TITLE
Add signing_key_server entry to _get_config.

### DIFF
--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -205,6 +205,14 @@ sub _get_config
          },
       },
 
+      signing_key_server => {
+         database => {
+            connection_string =>
+               ( ! defined $ENV{'POSTGRES'} || $ENV{'POSTGRES'} == '0') ?
+               "file:$self->{hs_dir}/signing_key_server.db" : $db_uri,
+         },
+      },
+
       sync_api => {
          database => {
             connection_string => 


### PR DESCRIPTION
Without this, tests still work, unless you run with a readonly /sytest
directory. A default signingkeyserver.db will be created there.

That seems unfortunate however, better to add an entry for it. Also, the
docker/README.md instructions do say to mount /sytest readonly so they
do not work without this fix.

Signed-off-by: Per Johansson <per@morth.org>