### PR TITLE
Ignore generated files when running on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,9 @@
 /synapse
 /test-server
 /var
+*.db
 \#*
 .vscode
 .coverage*
 .idea
+.DS_Store


### PR DESCRIPTION
Ignore generated files when running on macOS

 - Ignore `.DS_Store` from macOS
 - Ignore `*.db` files that can get generated from running (like `signingkeyserver.db`)