### PR TITLE
Rename serverkeyapi to signingkeyserver

### DIFF
--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -197,11 +197,11 @@ sub _get_config
          },
       },
 
-      server_key_api => {
+      signing_key_server => {
          database => {
             connection_string => 
                ( ! defined $ENV{'POSTGRES'} || $ENV{'POSTGRES'} == '0') ?
-               "file:$self->{hs_dir}/server_key_api.db" : $db_uri,
+               "file:$self->{hs_dir}/signingkeyserver.db" : $db_uri,
          },
       },
 


### PR DESCRIPTION
According to https://github.com/matrix-org/dendrite/commit/bf7e85848bce3ec9ef89e485699d1c5fc6b34e6b

Signed-off-by: Bohdan Horbeshko <bodqhrohro@gmail.com>