### PR TITLE
Rename sytest-synapse:py38 to :py39

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -8,5 +8,5 @@ docker build --pull ../ -f base.Dockerfile --build-arg DEBIAN_VERSION=buster -t 
 docker build --pull ../ -f base.Dockerfile --build-arg DEBIAN_VERSION=bullseye -t matrixdotorg/sytest:bullseye
 docker build ../ -f synapse.Dockerfile --build-arg DEBIAN_VERSION=stretch -t matrixdotorg/sytest-synapse:py35
 docker build ../ -f synapse.Dockerfile --build-arg DEBIAN_VERSION=buster -t matrixdotorg/sytest-synapse:py37
-docker build ../ -f synapse.Dockerfile --build-arg DEBIAN_VERSION=bullseye -t matrixdotorg/sytest-synapse:py38
+docker build ../ -f synapse.Dockerfile --build-arg DEBIAN_VERSION=bullseye -t matrixdotorg/sytest-synapse:py39
 docker build ../ -f dendrite.Dockerfile --build-arg DEBIAN_VERSION=stretch -t matrixdotorg/sytest-dendrite:go113 -t matrixdotorg/sytest-dendrite:latest

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -9,4 +9,4 @@ docker push matrixdotorg/sytest:buster
 docker push matrixdotorg/sytest:bullseye
 docker push matrixdotorg/sytest-synapse:py35
 docker push matrixdotorg/sytest-synapse:py37
-docker push matrixdotorg/sytest-synapse:py38
+docker push matrixdotorg/sytest-synapse:py39


### PR DESCRIPTION
These are based on Debian Bullseye.

As of last month, Bullseye ships Python 3.9:

  https://packages.debian.org/bullseye/python3

  https://tracker.debian.org/news/1199188/python3-defaults-390-4-migrated-to-testing/

Signed-off-by: Dan Callahan <danc@element.io>