### PR TITLE
to_device.events is not required in the spec

### DIFF
--- a/tests/46direct/01directmessage.pl
+++ b/tests/46direct/01directmessage.pl
@@ -70,7 +70,9 @@ sub matrix_recv_device_message
       return 1 if $f->failure;
       my $resp = $f->get;
       log_if_fail "Sync response", $resp;
-      return scalar @{ $resp->{to_device}{events} };
+      if( exists $resp->{to_device}{events} ) {
+        return scalar @{ $resp->{to_device}{events} };
+      }
    };
 
    $f->then( sub {


### PR DESCRIPTION
It's incorrect to expect this key to exist if there are no send-to-device updates when the spec does not list it as a required field.