### PR TITLE
Assert the pusher config instead of depending on a 404 from deleting.

### DIFF
--- a/tests/14account/01change-password.pl
+++ b/tests/14account/01change-password.pl
@@ -168,15 +168,17 @@ test "Pushers created with a different access token are deleted on password chan
          matrix_set_password( $user, $password, "my new password" );
       })->then( sub {
          do_request_json_for( $user,
-            method  => "POST",
-            uri     => "/r0/pushers/set",
-            content => {
-               kind    => JSON::null,
-               app_id  => "sytest",
-               pushkey => "a_push_key",
-            },
-         )->main::expect_http_404;
-      })->then_done(1);
+            method  => "GET",
+            uri     => "/r0/pushers",
+         );
+      })->then( sub {
+         my ( $body ) = @_;
+
+         assert_json_keys( $body, qw( pushers ) );
+         @{ $body->{pushers} } == 0 or die "Expected no pushers";
+
+         Future->done(1);
+      });
    };
 
 test "Pushers created with a the same access token are not deleted on password change",
@@ -204,13 +206,15 @@ test "Pushers created with a the same access token are not deleted on password c
          matrix_set_password( $user, $password, "my new password");
       })->then( sub {
          do_request_json_for( $user,
-            method  => "POST",
-            uri     => "/r0/pushers/set",
-            content => {
-               kind    => JSON::null,
-               app_id  => "sytest",
-               pushkey => "a_push_key",
-            },
+            method  => "GET",
+            uri     => "/r0/pushers",
          );
-      })->then_done(1);
+      })->then( sub {
+         my ( $body ) = @_;
+
+         assert_json_keys( $body, qw( pushers ) );
+         @{ $body->{pushers} } == 1 or die "Expected one pushers";
+
+         Future->done(1);
+      });
    };


### PR DESCRIPTION
As far as I can tell this was depending on deleting a pusher causing a 404 if that pusher didn't exist, which I don't think is specced behavior.

See matrix-org/synapse#9121.