### PR TITLE
Use a consistent public baseurl.

### DIFF
--- a/lib/SyTest/Homeserver.pm
+++ b/lib/SyTest/Homeserver.pm
@@ -166,7 +166,7 @@ sub configure
    my %params = @_;
 
    exists $params{$_} and $self->{$_} = delete $params{$_} for qw(
-      recaptcha_config cas_config smtp_server_config
+      public_baseurl recaptcha_config cas_config smtp_server_config
       app_service_config_files
    );
 

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -152,7 +152,12 @@ sub start
 
    my $listeners = [ $self->generate_listeners ];
    my $bind_host = $self->{bind_host};
-   my $secure_port = $self->secure_port;
+
+   # run-tests.pl defines whether TLS should be used or not.
+   our $WANT_TLS;
+   my $public_baseurl = $WANT_TLS ?
+      "https://${bind_host}:" . $self->secure_port() :
+      "http://${bind_host}:" . $self->unsecure_port();
 
    my $macaroon_secret_key = "secret_$port";
    my $registration_shared_secret = "reg_secret";
@@ -172,7 +177,7 @@ sub start
    my $config_path = $self->{paths}{config} = $self->write_yaml_file( "config.yaml" => {
         server_name => $self->server_name,
         log_config => $log_config_file,
-        public_baseurl => "https://${bind_host}:$secure_port",
+        public_baseurl => $public_baseurl,
 
         # We configure synapse to use a TLS cert which is signed by our dummy CA...
         tls_certificate_path => $self->{paths}{cert_file},

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -171,7 +171,7 @@ sub start
    my $config_path = $self->{paths}{config} = $self->write_yaml_file( "config.yaml" => {
         server_name => $self->server_name,
         log_config => $log_config_file,
-        public_baseurl => $self->public_baseurl,
+        public_baseurl => $self->{public_baseurl},
 
         # We configure synapse to use a TLS cert which is signed by our dummy CA...
         tls_certificate_path => $self->{paths}{cert_file},
@@ -597,8 +597,8 @@ sub public_baseurl
 {
    my $self = shift;
    # run-tests.pl defines whether TLS should be used or not.
-   our $WANT_TLS;
-   return $WANT_TLS ?
+   my ( $want_tls ) = @_;
+   return $want_tls ?
       "https://$self->{bind_host}:" . $self->secure_port() :
       "http://$self->{bind_host}:" . $self->unsecure_port();
 }

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -153,12 +153,6 @@ sub start
    my $listeners = [ $self->generate_listeners ];
    my $bind_host = $self->{bind_host};
 
-   # run-tests.pl defines whether TLS should be used or not.
-   our $WANT_TLS;
-   my $public_baseurl = $WANT_TLS ?
-      "https://${bind_host}:" . $self->secure_port() :
-      "http://${bind_host}:" . $self->unsecure_port();
-
    my $macaroon_secret_key = "secret_$port";
    my $registration_shared_secret = "reg_secret";
 
@@ -177,7 +171,7 @@ sub start
    my $config_path = $self->{paths}{config} = $self->write_yaml_file( "config.yaml" => {
         server_name => $self->server_name,
         log_config => $log_config_file,
-        public_baseurl => $public_baseurl,
+        public_baseurl => $self->public_baseurl,
 
         # We configure synapse to use a TLS cert which is signed by our dummy CA...
         tls_certificate_path => $self->{paths}{cert_file},
@@ -597,6 +591,16 @@ sub unsecure_port
 {
    my $self = shift;
    return $self->{ports}{synapse_unsecure};
+}
+
+sub public_baseurl
+{
+   my $self = shift;
+   # run-tests.pl defines whether TLS should be used or not.
+   our $WANT_TLS;
+   return $WANT_TLS ?
+      "https://$self->{bind_host}:" . $self->secure_port() :
+      "http://$self->{bind_host}:" . $self->unsecure_port();
 }
 
 package SyTest::Homeserver::Synapse::Direct;
@@ -1111,6 +1115,12 @@ sub unsecure_port
 {
    my $self = shift;
    die "haproxy does not have an unsecure port mode\n";
+}
+
+sub public_baseurl
+{
+   my $self = shift;
+   return "https://$self->{bind_host}:" . $self->secure_port();
 }
 
 sub start

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -152,7 +152,7 @@ sub start
 
    my $listeners = [ $self->generate_listeners ];
    my $bind_host = $self->{bind_host};
-   my $secure_port = $self->{ports}{synapse};
+   my $secure_port = $self->secure_port;
 
    my $macaroon_secret_key = "secret_$port";
    my $registration_shared_secret = "reg_secret";

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -152,7 +152,7 @@ sub start
 
    my $listeners = [ $self->generate_listeners ];
    my $bind_host = $self->{bind_host};
-   my $unsecure_port = $self->{ports}{synapse_unsecure};
+   my $secure_port = $self->{ports}{synapse};
 
    my $macaroon_secret_key = "secret_$port";
    my $registration_shared_secret = "reg_secret";
@@ -172,7 +172,7 @@ sub start
    my $config_path = $self->{paths}{config} = $self->write_yaml_file( "config.yaml" => {
         server_name => $self->server_name,
         log_config => $log_config_file,
-        public_baseurl => "http://${bind_host}:$unsecure_port",
+        public_baseurl => "https://${bind_host}:$secure_port",
 
         # We configure synapse to use a TLS cert which is signed by our dummy CA...
         tls_certificate_path => $self->{paths}{cert_file},

--- a/tests/05homeserver.pl
+++ b/tests/05homeserver.pl
@@ -53,15 +53,17 @@ our @HOMESERVER_INFO = map {
 
          my $api_host = $server->http_api_host;
 
-         my $location = $WANT_TLS ?
-            "https://$api_host:" . $server->secure_port :
-            "http://$api_host:" . $server->unsecure_port;
+         my $location = $server->public_baseurl($WANT_TLS);
 
          $server->configure(
             smtp_server_config => $mail_server_info,
          );
 
          $server->configure(
+            # Annoyingly we ask the homeserver object for public_baseurl and then
+            # pass it back into the configuration since this is the only location
+            # we have $WANT_TLS.
+            public_baseurl => $location,
             # Config for testing recaptcha. 90jira/SYT-8.pl
             recaptcha_config => {
                siteverify_api   => $test_server_info->client_location .

--- a/tests/05homeserver.pl
+++ b/tests/05homeserver.pl
@@ -70,7 +70,6 @@ our @HOMESERVER_INFO = map {
                private_key      => "sytest_recaptcha_private_key",
             }, cas_config    => {
                server_url       => $test_server_info->client_location . "/cas",
-               service_url      => $location,
             },
          );
 


### PR DESCRIPTION
This sets `public_baseurl` in the Synapse config to match what is provided via `ServerInfo`.

Note that the `cas_config.service_url` was deprecated in matrix-org/synapse#9199 so we don't need to provide it anymore.

Hopefully will fix the build issues in matrix-org/synapse#9313.