### PR TITLE
Remove pydron from dockerfile

### DIFF
--- a/docker/synapse.Dockerfile
+++ b/docker/synapse.Dockerfile
@@ -20,6 +20,4 @@ RUN /venv/bin/pip install -q --no-cache-dir lxml psycopg2 coverage codecov
 # and test
 RUN /venv/bin/pip uninstall -q --no-cache-dir -y matrix-synapse
 
-ADD docker/pydron.py /pydron.py
-
 ENTRYPOINT [ "/bin/bash", "/bootstrap.sh", "synapse" ]


### PR DESCRIPTION
#945 removed the pydron script, but apparently failed to remove it from the dockerfile.