### PR TITLE
Avoid swallowing stdout on errors

### DIFF
--- a/lib/SyTest/Homeserver.pm
+++ b/lib/SyTest/Homeserver.pm
@@ -556,12 +556,18 @@ sub _run_command
 
    my $on_output = sub {
       my ( $stream, $buffref, $eof) = @_;
+
+      # write each complete line in the buffer
       while ( $$buffref =~ s/^(.*)\n// ) {
          &$diag($1);
       }
+
+      # if this is the end of the output, and there is
+      # anything left in the buffer, print out the remainder.
       if( $eof && $$buffref ) {
          &$diag($$buffref);
       }
+
       return 0;
    };
 

--- a/lib/SyTest/Homeserver.pm
+++ b/lib/SyTest/Homeserver.pm
@@ -536,7 +536,9 @@ sub await_connectable
 This method runs a specified command and returns a future which will complete
 when the process exits.
 
-The parameters are passed to C<IO::Loop->run_child>.
+Any output from the command is written as diagnostics.
+
+The parameters are passed to C<IO::Async::Process::new>.
 
 =cut
 
@@ -546,16 +548,34 @@ sub _run_command
    my %params = @_;
 
    my $cmd = $params{command}[0];
+   my $output = $self->{output};
+
+   my $diag = sub {
+      $output->diag( "\e[1;35m[$cmd]\e[m: $_[0]" );
+   };
+
+   my $on_output = sub {
+      my ( $stream, $buffref, $eof) = @_;
+      while ( $$buffref =~ s/^(.*)\n// ) {
+         &$diag($1);
+      }
+      if( $eof && $$buffref ) {
+         &$diag($$buffref);
+      }
+      return 0;
+   };
 
    my $fut = $self->loop->new_future;
-   $self->loop->run_child(
-      %params,
 
+   my $proc = IO::Async::Process->new(
+      %params,
+      stdout => { on_read => $on_output },
+      stderr => { on_read => $on_output },
       on_finish => sub {
-         my ( $pid, $exitcode, $stdout, $stderr ) = @_;
+         my ( undef, $exitcode ) = @_;
 
          if( $exitcode == 0 ) {
-            $fut->done( $stdout );
+            $fut->done();
             return;
          }
 
@@ -566,13 +586,11 @@ sub _run_command
             $failure = "$cmd failed $exitcode";
          }
 
-         if( $stderr ) {
-            $failure .= ": $stderr";
-         }
          $fut->fail( $failure );
-      }
+      },
    );
 
+   $self->loop->add($proc);
    return $fut;
 }
 

--- a/lib/SyTest/Output/TAP.pm
+++ b/lib/SyTest/Output/TAP.pm
@@ -71,6 +71,11 @@ sub diagwarn
    shift;
    my ( $message ) = @_;
    print "#** $message\n";
+
+   # print warnings to stderr as well, because they only happen when something
+   # goes wrong and it's annoying to have to fish around in the TAP file for
+   # them.
+   print STDERR "WARN: $message\n";
 }
 
 sub status {}

--- a/tests/05homeserver.pl
+++ b/tests/05homeserver.pl
@@ -133,7 +133,7 @@ our @HOMESERVER_INFO = map {
 
             # if we can't start the first homeserver, we really might as well go home.
             if( $idx == 0 ) {
-               print STDERR "\nAborting test run due to failure to start test server\n";
+               warn( "Aborting test run due to failure to start test server" );
 
                # If we just exit then we need to call the AT_END functions
                # manually (if we don't we'll leak child processes).


### PR DESCRIPTION
Make sure that stderr and stdout get correctly caught and logged, to help diagnose mysterious "failed to start server" errors. Things written direct to stderr tend to get overwritten by other diagnostic output, so use the proper `Output::diag` method.

Previously, stderr was being caught and returned in the failure, which wasn't terribly clear, while stdout went to /dev/null.