### PR TITLE
Drop --no-tls and clean up Homeserver object API

### DIFF
--- a/lib/SyTest/Homeserver.pm
+++ b/lib/SyTest/Homeserver.pm
@@ -129,13 +129,6 @@ This method should return the port number where the homeserver exposes a
 server-server API (over HTTPS). It may return undef if there is no known
 federation port.
 
-=head2 secure_port
-
-   $hs->secure_port
-
-This method should return the port number where the homeserver exposes a
-client-server API over HTTPS.
-
 =head2 public_baseurl
 
    $hs->public_baseurl

--- a/lib/SyTest/Homeserver.pm
+++ b/lib/SyTest/Homeserver.pm
@@ -116,10 +116,10 @@ Homeserver interface.
 This method should return the server_name for the server (ie, the 'domain' part
 of any Matrix IDs it generates).
 
-=head2 http_api_host
+=head2 federation_host
 
 This method should return the hostname where the homeserver exposes the
-client-server and server-server APIs.
+server-server API.
 
 =head2 federation_port
 

--- a/lib/SyTest/Homeserver.pm
+++ b/lib/SyTest/Homeserver.pm
@@ -143,6 +143,13 @@ client-server API over HTTPS.
 This method should return the port number where the homeserver exposes a
 client-server API over HTTP.
 
+=head2 public_baseurl
+
+   $hs->public_baseurl
+
+This method should returns the public base URL for the client-server API for
+this server.
+
 =cut
 
 sub _init

--- a/lib/SyTest/Homeserver.pm
+++ b/lib/SyTest/Homeserver.pm
@@ -173,7 +173,7 @@ sub configure
    my %params = @_;
 
    exists $params{$_} and $self->{$_} = delete $params{$_} for qw(
-      public_baseurl recaptcha_config cas_config smtp_server_config
+      recaptcha_config cas_config smtp_server_config
       app_service_config_files
    );
 

--- a/lib/SyTest/Homeserver.pm
+++ b/lib/SyTest/Homeserver.pm
@@ -136,13 +136,6 @@ federation port.
 This method should return the port number where the homeserver exposes a
 client-server API over HTTPS.
 
-=head2 unsecure_port
-
-   $hs->unsecure_port
-
-This method should return the port number where the homeserver exposes a
-client-server API over HTTP.
-
 =head2 public_baseurl
 
    $hs->public_baseurl

--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -332,13 +332,9 @@ sub unsecure_port
 
 sub public_baseurl
 {
-    my $self = shift;
-    # run-tests.pl defines whether TLS should be used or not.
-    my ( $want_tls ) = @_;
-    return $want_tls ?
-       "https://$self->{bind_host}:" . $self->secure_port() :
-       "http://$self->{bind_host}:" . $self->unsecure_port();
- }
+   my $self = shift;
+   return "https://$self->{bind_host}:" . $self->secure_port();
+}
 
 sub start
 {

--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -69,7 +69,7 @@ sub _check_db_config
    return $self->SUPER::_check_db_config( @_ );
 }
 
-sub http_api_host
+sub federation_host
 {
    my $self = shift;
    return $self->{bind_host};

--- a/lib/SyTest/Homeserver/Manual.pm
+++ b/lib/SyTest/Homeserver/Manual.pm
@@ -80,13 +80,12 @@ sub unsecure_port
 
 sub public_baseurl
 {
-    my $self = shift;
-    # run-tests.pl defines whether TLS should be used or not.
-    my ( $want_tls ) = @_;
-    return $want_tls ?
-       "https://$self->{bind_host}:" . $self->secure_port() :
-       "http://$self->{bind_host}:" . $self->unsecure_port();
- }
+   my $self = shift;
+
+   return defined $self->{secure_port} ?
+      "https://$self->{host}:" . $self->{secure_port} :
+      "http://$self->{host}:" . $self->{unsecure_port};
+}
 
 sub start
 {

--- a/lib/SyTest/Homeserver/Manual.pm
+++ b/lib/SyTest/Homeserver/Manual.pm
@@ -52,7 +52,7 @@ sub server_name
    return $self->{server_name};
 }
 
-sub http_api_host
+sub federation_host
 {
    my $self = shift;
    return $self->{host};

--- a/lib/SyTest/Homeserver/Manual.pm
+++ b/lib/SyTest/Homeserver/Manual.pm
@@ -71,13 +71,6 @@ sub secure_port
    return $self->{secure_port};
 }
 
-sub unsecure_port
-{
-   my $self = shift;
-
-   return $self->{unsecure_port};
-}
-
 sub public_baseurl
 {
    my $self = shift;

--- a/lib/SyTest/Homeserver/Manual.pm
+++ b/lib/SyTest/Homeserver/Manual.pm
@@ -61,13 +61,6 @@ sub federation_host
 sub federation_port
 {
    my $self = shift;
-   return $self->secure_port;
-}
-
-sub secure_port
-{
-   my $self = shift;
-
    return $self->{secure_port};
 }
 

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -587,12 +587,6 @@ sub secure_port
    return $self->{ports}{synapse};
 }
 
-sub unsecure_port
-{
-   my $self = shift;
-   return $self->{ports}{synapse_unsecure};
-}
-
 sub public_baseurl
 {
    my $self = shift;
@@ -1105,12 +1099,6 @@ sub secure_port
 {
    my $self = shift;
    return $self->{ports}{haproxy};
-}
-
-sub unsecure_port
-{
-   my $self = shift;
-   die "haproxy does not have an unsecure port mode\n";
 }
 
 sub public_baseurl

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -596,11 +596,7 @@ sub unsecure_port
 sub public_baseurl
 {
    my $self = shift;
-   # run-tests.pl defines whether TLS should be used or not.
-   my ( $want_tls ) = @_;
-   return $want_tls ?
-      "https://$self->{bind_host}:" . $self->secure_port() :
-      "http://$self->{bind_host}:" . $self->unsecure_port();
+   return "https://$self->{bind_host}:" . $self->secure_port;
 }
 
 package SyTest::Homeserver::Synapse::Direct;

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -569,7 +569,7 @@ sub server_name
    return $self->{bind_host} . ":" . $self->secure_port;
 }
 
-sub http_api_host
+sub federation_host
 {
    my $self = shift;
    return $self->{bind_host};

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -171,7 +171,7 @@ sub start
    my $config_path = $self->{paths}{config} = $self->write_yaml_file( "config.yaml" => {
         server_name => $self->server_name,
         log_config => $log_config_file,
-        public_baseurl => $self->{public_baseurl},
+        public_baseurl => $self->public_baseurl,
 
         # We configure synapse to use a TLS cert which is signed by our dummy CA...
         tls_certificate_path => $self->{paths}{cert_file},

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -53,8 +53,6 @@ use Module::Pluggable
 
 binmode(STDOUT, ":utf8");
 
-our $WANT_TLS = 1;  # This is shared with the test scripts
-
 our $BIND_HOST = "localhost";
 
 # a unique ID for this test run. It is used in some tests to create user IDs
@@ -100,8 +98,6 @@ GetOptions(
    'w|wait-at-end' => \my $WAIT_AT_END,
 
    'v|verbose+' => \(my $VERBOSE = 0),
-
-   'n|no-tls' => sub { $WANT_TLS = 0 },
 
    'work-directory=s' => \$WORK_DIR,
 

--- a/tests/05homeserver.pl
+++ b/tests/05homeserver.pl
@@ -123,7 +123,7 @@ our @HOMESERVER_INFO = map {
             return Future->done( $info );
          })->on_fail( sub {
             my ( $exn, @details ) = @_;
-            warn( "Error starting server-$idx (on port ${\$server->secure_port}): $exn" );
+            warn( "Error starting server-$idx: $exn" );
 
             # if we can't start the first homeserver, we really might as well go home.
             if( $idx == 0 ) {

--- a/tests/05homeserver.pl
+++ b/tests/05homeserver.pl
@@ -51,8 +51,6 @@ our @HOMESERVER_INFO = map {
 
          $loop->add( $server );
 
-         my $api_host = $server->http_api_host;
-
          my $location = $server->public_baseurl($WANT_TLS);
 
          $server->configure(
@@ -75,8 +73,10 @@ our @HOMESERVER_INFO = map {
             },
          );
 
-         my $info = ServerInfo( $server->server_name, $location,
-                                $api_host, $server->federation_port );
+         my $info = ServerInfo(
+            $server->server_name, $location,
+            $server->federation_host, $server->federation_port,
+         );
 
          if( $idx == 0 ) {
             # Configure application services on first instance only

--- a/tests/05homeserver.pl
+++ b/tests/05homeserver.pl
@@ -51,17 +51,11 @@ our @HOMESERVER_INFO = map {
 
          $loop->add( $server );
 
-         my $location = $server->public_baseurl;
-
          $server->configure(
             smtp_server_config => $mail_server_info,
          );
 
          $server->configure(
-            # Annoyingly we ask the homeserver object for public_baseurl and then
-            # pass it back into the configuration since this is the only location
-            # we have $WANT_TLS.
-            public_baseurl => $location,
             # Config for testing recaptcha. 90jira/SYT-8.pl
             recaptcha_config => {
                siteverify_api   => $test_server_info->client_location .
@@ -74,7 +68,7 @@ our @HOMESERVER_INFO = map {
          );
 
          my $info = ServerInfo(
-            $server->server_name, $location,
+            $server->server_name, $server->public_baseurl,
             $server->federation_host, $server->federation_port,
          );
 

--- a/tests/05homeserver.pl
+++ b/tests/05homeserver.pl
@@ -51,7 +51,7 @@ our @HOMESERVER_INFO = map {
 
          $loop->add( $server );
 
-         my $location = $server->public_baseurl($WANT_TLS);
+         my $location = $server->public_baseurl;
 
          $server->configure(
             smtp_server_config => $mail_server_info,


### PR DESCRIPTION
This was getting to be a bit of a mess, with unused/duplicate functions, and undocumented methods named the same as undocumented fields with different functions. Clean it all up.

Commits should be reviewable independently.