### PR TITLE
Fix username field in AS tests

### DIFF
--- a/tests/60app-services/01as-create.pl
+++ b/tests/60app-services/01as-create.pl
@@ -13,7 +13,7 @@ test "AS can create a user",
          uri    => "/r0/register",
 
          content => {
-            user => "astest-01create-0-$TEST_RUN_ID",
+            username => "astest-01create-0-$TEST_RUN_ID",
          },
       )->then( sub {
          my ( $body ) = @_;
@@ -37,7 +37,7 @@ test "AS can create a user with an underscore",
          uri    => "/r0/register",
 
          content => {
-            user => "_astest-01create-0-$TEST_RUN_ID",
+            username => "_astest-01create-0-$TEST_RUN_ID",
          },
       )->then( sub {
          my ( $body ) = @_;
@@ -62,7 +62,7 @@ test "AS can create a user with inhibit_login",
          uri    => "/r0/register",
 
          content => {
-            user => "astest-01create-1-$TEST_RUN_ID",
+            username => "astest-01create-1-$TEST_RUN_ID",
             inhibit_login => 1,
          },
       )->then( sub {
@@ -90,7 +90,7 @@ test "AS cannot create users outside its own namespace",
          uri    => "/r0/register",
 
          content => {
-            user => "a-different-user",
+            username => "a-different-user",
          }
       )->main::expect_http_4xx;
    };
@@ -174,7 +174,7 @@ sub matrix_register_as_ghost
       uri    => "/r0/register",
 
       content => {
-         user => $user_id,
+         username => $user_id,
       }
    )->then( sub {
       my ( $body ) = @_;

--- a/tests/60app-services/02ghost.pl
+++ b/tests/60app-services/02ghost.pl
@@ -184,7 +184,7 @@ test "Ghost user must register before joining room",
          uri    => "/r0/register",
 
          content => {
-            user => $unregistered_as_user_localpart,
+            username => $unregistered_as_user_localpart,
          },
       );
    };


### PR DESCRIPTION
Apparently the `"user"` field is old non-spec-compliant behaviour and we should be using `"username"` now: https://matrix.org/docs/spec/client_server/r0.6.1#post-matrix-client-r0-register