### PR TITLE
Remove Debian Stretch containers

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -6,14 +6,12 @@ are.
 
 Included currently is:
 
-- `matrixdotorg/sytest:stretch` and `matrixdotorg/sytest:buster`: base
-  containers with SyTest dependencies installed
-- `matrixdotorg/sytest-synapse:py35`: a container which will run SyTest against
-  Synapse on Python 3.5 + Stretch
-- `matrixdotorg/sytest-synapse:py37`: a container which will run SyTest against
-  Synapse on Python 3.7 + Buster
-- `matrixdotorg/sytest-dendrite:go113`: a container which will run SyTest
-  against Dendrite on Go 1.13 + Buster
+- `matrixdotorg/sytest` Base container with SyTest dependencies installed
+    - Tagged by underlying Debian image: `buster` or `testing`
+- `matrixdotorg/sytest-synapse`: Runs SyTest against Synapse
+    - Tagged by underlying Debian image: `buster` or `testing`
+- `matrixdotorg/sytest-dendrite:go113`: Runs SyTest against Dendrite on Go 1.13
+    - Currently uses Debian 10 (Buster) as its base image
 
 ## Target-specific details
 
@@ -26,7 +24,7 @@ it is useful to mount a volume there too.
 For example:
 
 ```
-docker run --rm -it -v /path/to/synapse\:/src:ro -v /path/to/where/you/want/logs\:/logs matrixdotorg/sytest-synapse:py37
+docker run --rm -it -v /path/to/synapse\:/src:ro -v /path/to/where/you/want/logs\:/logs matrixdotorg/sytest-synapse:buster
 ```
 
 The following environment variables can be set with `-e` to control the test run:
@@ -48,7 +46,7 @@ Some examples of running Synapse in different configurations:
 
   ```
   docker run --rm -it -e POSTGRES=1 -e WORKERS=1 -v /path/to/synapse\:/src:ro \
-      -v /path/to/where/you/want/logs\:/logs matrixdotorg/sytest-synapse:py37
+      -v /path/to/where/you/want/logs\:/logs matrixdotorg/sytest-synapse:buster
   ```
 
 * Running Synapse in worker mode using redis:
@@ -57,7 +55,7 @@ Some examples of running Synapse in different configurations:
   docker run --rm -it -e POSTGRES=1 -e WORKERS=1 -e REDIS=1 \
        -v /path/to/synapse\:/src:ro \
        -v /path/to/where/you/want/logs\:/logs \
-       matrixdotorg/sytest-synapse:py35
+       matrixdotorg/sytest-synapse:buster
   ```
 
 ### Dendrite
@@ -82,7 +80,7 @@ the container:
 
 ```
 docker run --rm -it -v /path/to/synapse\:/src:ro -v /path/to/where/you/want/logs\:/logs \
-    -v /path/to/code/sytest\:/sytest:ro matrixdotorg/sytest-synapse:py35
+    -v /path/to/code/sytest\:/sytest:ro matrixdotorg/sytest-synapse:buster
 ```
 
 ## Running a single test file, and other sytest commandline options
@@ -91,7 +89,7 @@ You can pass arguments to sytest by adding them at the end of the
 docker command. For example:
 
 ```
-docker run --rm -it ... matrixdotorg/sytest-synapse:py37 tests/20profile-events.pl
+docker run --rm -it ... matrixdotorg/sytest-synapse:buster tests/20profile-events.pl
 ```
 
 ## Building the containers

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -3,10 +3,12 @@
 set -ex
 
 cd $(dirname $0)
-docker build --pull ../ -f base.Dockerfile --build-arg DEBIAN_VERSION=stretch -t matrixdotorg/sytest:stretch
+
 docker build --pull ../ -f base.Dockerfile --build-arg DEBIAN_VERSION=buster -t matrixdotorg/sytest:buster
-docker build --pull ../ -f base.Dockerfile --build-arg DEBIAN_VERSION=bullseye -t matrixdotorg/sytest:bullseye
-docker build ../ -f synapse.Dockerfile --build-arg DEBIAN_VERSION=stretch -t matrixdotorg/sytest-synapse:py35
-docker build ../ -f synapse.Dockerfile --build-arg DEBIAN_VERSION=buster -t matrixdotorg/sytest-synapse:py37
-docker build ../ -f synapse.Dockerfile --build-arg DEBIAN_VERSION=bullseye -t matrixdotorg/sytest-synapse:py39
+docker build --pull ../ -f base.Dockerfile --build-arg DEBIAN_VERSION=testing -t matrixdotorg/sytest:testing
+
+# Note: If changing labels also update docker/push.sh and docker/README.md
+docker build ../ -f synapse.Dockerfile --build-arg DEBIAN_VERSION=buster -t matrixdotorg/sytest-synapse:buster
+docker build ../ -f synapse.Dockerfile --build-arg DEBIAN_VERSION=testing -t matrixdotorg/sytest-synapse:testing
+
 docker build ../ -f dendrite.Dockerfile --build-arg DEBIAN_VERSION=stretch -t matrixdotorg/sytest-dendrite:go113 -t matrixdotorg/sytest-dendrite:latest

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -4,9 +4,8 @@ set -ex
 
 cd $(dirname $0)
 
-docker push matrixdotorg/sytest:stretch
 docker push matrixdotorg/sytest:buster
-docker push matrixdotorg/sytest:bullseye
-docker push matrixdotorg/sytest-synapse:py35
-docker push matrixdotorg/sytest-synapse:py37
-docker push matrixdotorg/sytest-synapse:py39
+docker push matrixdotorg/sytest:testing
+
+docker push matrixdotorg/sytest-synapse:buster
+docker push matrixdotorg/sytest-synapse:testing

--- a/docker/synapse.Dockerfile
+++ b/docker/synapse.Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get -qq update && apt-get -qq install -y \
 RUN mkdir /src
 
 # Create the virutal env upfront so we don't need to keep reinstall dependencies
-RUN python3 -m venv /venv
+# Manually upgrade pip to ensure it can locate Cryptography's binary wheels
+RUN python3 -m venv /venv && /venv/bin/pip install -U pip
 RUN /venv/bin/pip install -q --no-cache-dir matrix-synapse[all]
 RUN /venv/bin/pip install -q --no-cache-dir lxml psycopg2 coverage codecov
 

--- a/docker/synapse.Dockerfile
+++ b/docker/synapse.Dockerfile
@@ -3,16 +3,14 @@ ARG DEBIAN_VERSION=buster
 FROM matrixdotorg/sytest:${DEBIAN_VERSION}
 
 RUN apt-get -qq update && apt-get -qq install -y \
-    python3 python3-dev python3-virtualenv eatmydata \
+    python3 python3-dev python3-venv eatmydata \
     redis-server
-
-ENV PYTHON=python3
 
 # /src is where we expect Synapse to be
 RUN mkdir /src
 
 # Create the virutal env upfront so we don't need to keep reinstall dependencies
-RUN $PYTHON -m virtualenv -p $PYTHON /venv/
+RUN python3 -m venv /venv
 RUN /venv/bin/pip install -q --no-cache-dir matrix-synapse[all]
 RUN /venv/bin/pip install -q --no-cache-dir lxml psycopg2 coverage codecov
 


### PR DESCRIPTION
Renames remaining containers based on underlying Debian distro to be a
bit more explicit about the testing environment.

Fixes #1003

Signed-off-by: Dan Callahan <danc@element.io>