### PR TITLE
Build docker images for bionic

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -7,9 +7,9 @@ are.
 Included currently is:
 
 - `matrixdotorg/sytest` Base container with SyTest dependencies installed
-    - Tagged by underlying Debian image: `buster` or `testing`
+    - Tagged by underlying Debian/Ubuntu image: `bionic`, `buster` or `testing`
 - `matrixdotorg/sytest-synapse`: Runs SyTest against Synapse
-    - Tagged by underlying Debian image: `buster` or `testing`
+    - Tagged by underlying Debian/Ubunutu image: `bionic`, `buster` or `testing`
 - `matrixdotorg/sytest-dendrite:go113`: Runs SyTest against Dendrite on Go 1.13
     - Currently uses Debian 10 (Buster) as its base image
 

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -1,6 +1,6 @@
-ARG DEBIAN_VERSION=buster
+ARG BASE_IMAGE=debian:buster
 
-FROM debian:${DEBIAN_VERSION}
+FROM ${BASE_IMAGE}
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -4,11 +4,13 @@ set -ex
 
 cd $(dirname $0)
 
-docker build --pull ../ -f base.Dockerfile --build-arg DEBIAN_VERSION=buster -t matrixdotorg/sytest:buster
-docker build --pull ../ -f base.Dockerfile --build-arg DEBIAN_VERSION=testing -t matrixdotorg/sytest:testing
+docker build --pull ../ -f base.Dockerfile --build-arg BASE_IMAGE=ubuntu:bionic -t matrixdotorg/sytest:bionic
+docker build --pull ../ -f base.Dockerfile --build-arg BASE_IMAGE=debian:buster -t matrixdotorg/sytest:buster
+docker build --pull ../ -f base.Dockerfile --build-arg BASE_IMAGE=debian:testing -t matrixdotorg/sytest:testing
 
 # Note: If changing labels also update docker/push.sh and docker/README.md
-docker build ../ -f synapse.Dockerfile --build-arg DEBIAN_VERSION=buster -t matrixdotorg/sytest-synapse:buster
-docker build ../ -f synapse.Dockerfile --build-arg DEBIAN_VERSION=testing -t matrixdotorg/sytest-synapse:testing
+docker build ../ -f synapse.Dockerfile --build-arg SYTEST_IMAGE_TAG=bionic -t matrixdotorg/sytest-synapse:bionic
+docker build ../ -f synapse.Dockerfile --build-arg SYTEST_IMAGE_TAG=buster -t matrixdotorg/sytest-synapse:buster
+docker build ../ -f synapse.Dockerfile --build-arg SYTEST_IMAGE_TAG=testing -t matrixdotorg/sytest-synapse:testing
 
-docker build ../ -f dendrite.Dockerfile --build-arg DEBIAN_VERSION=stretch -t matrixdotorg/sytest-dendrite:go113 -t matrixdotorg/sytest-dendrite:latest
+docker build ../ -f dendrite.Dockerfile --build-arg SYTEST_IMAGE_TAG=buster -t matrixdotorg/sytest-dendrite:go113 -t matrixdotorg/sytest-dendrite:latest

--- a/docker/dendrite.Dockerfile
+++ b/docker/dendrite.Dockerfile
@@ -1,5 +1,5 @@
-ARG DEBIAN_VERSION=buster
-FROM matrixdotorg/sytest:${DEBIAN_VERSION}
+ARG SYTEST_IMAGE_TAG=buster
+FROM matrixdotorg/sytest:${SYTEST_IMAGE_TAG}
 
 ARG GO_VERSION=1.13.7
 ENV GO_DOWNLOAD https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -4,8 +4,12 @@ set -ex
 
 cd $(dirname $0)
 
+docker push matrixdotorg/sytest:bionic
 docker push matrixdotorg/sytest:buster
 docker push matrixdotorg/sytest:testing
 
+docker push matrixdotorg/sytest-synapse:bionic
 docker push matrixdotorg/sytest-synapse:buster
 docker push matrixdotorg/sytest-synapse:testing
+
+docker push matrixdotorg/sytest-dendrite:go113

--- a/docker/synapse.Dockerfile
+++ b/docker/synapse.Dockerfile
@@ -1,6 +1,5 @@
-ARG DEBIAN_VERSION=buster
-
-FROM matrixdotorg/sytest:${DEBIAN_VERSION}
+ARG SYTEST_IMAGE_TAG=buster
+FROM matrixdotorg/sytest:${SYTEST_IMAGE_TAG}
 
 RUN apt-get -qq update && apt-get -qq install -y \
     python3 python3-dev python3-venv eatmydata \


### PR DESCRIPTION
Synapse is dropping support for stretch, so we need something else to fill the
slot of python 3.6. We can use bionic for that.