### PR TITLE
Fix test failures when optional keys in /sync are left out

### DIFF
--- a/tests/30rooms/06invite.pl
+++ b/tests/30rooms/06invite.pl
@@ -159,8 +159,11 @@ sub invited_user_can_reject_invite
 
       # Check that invitee no longer sees the invite
 
-      assert_json_object( $body->{rooms}{invite} );
-      keys %{ $body->{rooms}{invite} } and die "Expected empty dictionary";
+      if( exists $body->{rooms} and exists $body->{rooms}{invite} ) {
+         assert_json_object( $body->{rooms}{invite} );
+         keys %{ $body->{rooms}{invite} } and die "Expected empty dictionary";
+      }
+
       Future->done(1);
    });
 }
@@ -203,8 +206,10 @@ sub invited_user_can_reject_invite_for_empty_room
 
       # Check that invitee no longer sees the invite
 
-      assert_json_object( $body->{rooms}{invite} );
-      keys %{ $body->{rooms}{invite} } and die "Expected empty dictionary";
+      if( exists $body->{rooms} and exists $body->{rooms}{invite} ) {
+         assert_json_object( $body->{rooms}{invite} );
+         keys %{ $body->{rooms}{invite} } and die "Expected empty dictionary";
+      }
       Future->done(1);
    });
 }
@@ -235,8 +240,12 @@ test "Invited user can reject local invite after originator leaves",
          my ( $body ) = @_;
 
          log_if_fail "Sync body", $body;
-         assert_json_object( $body->{rooms}{invite} );
-         keys %{ $body->{rooms}{invite} } and die "Expected empty dictionary";
+
+         if( exists $body->{rooms} and exists $body->{rooms}{invite} ) {
+            assert_json_object( $body->{rooms}{invite} );
+            keys %{ $body->{rooms}{invite} } and die "Expected empty dictionary";
+         }
+
          Future->done(1);
       });
    };

--- a/tests/31sync/03joined.pl
+++ b/tests/31sync/03joined.pl
@@ -227,13 +227,13 @@ test "Newly joined room includes presence in incremental sync",
       })->then( sub {
          my ( $body ) = @_;
 
-         assert_json_keys( $body, qw( presence ));
-         assert_json_keys( $body->{presence}, qw( events ));
-         assert_json_list( $body->{presence}{events} );
+         if ( exists $body->{presence} and exists $body->{presence}{events} ) {
+            assert_json_list( $body->{presence}{events} );
 
-         my $presence = $body->{presence}{events};
+            my $presence = $body->{presence}{events};
 
-         assert_eq( scalar @$presence, 0, "number of presence events" );
+            assert_eq( scalar @$presence, 0, "number of presence events" );
+         }
 
          Future->done(1);
       });
@@ -289,13 +289,13 @@ test "Get presence for newly joined members in incremental sync",
       })->then( sub {
          my ( $body ) = @_;
 
-         assert_json_keys( $body, qw( presence ));
-         assert_json_keys( $body->{presence}, qw( events ));
-         assert_json_list( $body->{presence}{events} );
+         if ( exists $body->{presence} and exists $body->{presence}{events} ) {
+            assert_json_list( $body->{presence}{events} );
 
-         my $presence = $body->{presence}{events};
+            my $presence = $body->{presence}{events};
 
-         assert_eq( scalar @$presence, 0, "number of presence events" );
+            assert_eq( scalar @$presence, 0, "number of presence events" );
+         }
 
          Future->done(1);
       });

--- a/tests/31sync/09archived.pl
+++ b/tests/31sync/09archived.pl
@@ -258,10 +258,12 @@ test "Previously left rooms don't appear in the leave section of sync",
       })->then( sub {
          my ( $body ) = @_;
 
-         my $leave = $body->{rooms}{leave};
+         if( exists $body->{rooms} and exists $body->{rooms}{leave} ) {
+            my $leave = $body->{rooms}{leave};
 
-         assert_json_object( $leave );
-         keys %$leave == 0 or die "Expected no rooms in 'leave' state";
+            assert_json_object( $leave );
+            keys %$leave == 0 or die "Expected no rooms in 'leave' state";
+         }
 
          Future->done(1);
       });

--- a/tests/31sync/15lazy-members.pl
+++ b/tests/31sync/15lazy-members.pl
@@ -190,8 +190,10 @@ test "The only membership state included in an incremental sync is for senders i
          matrix_sync_again( $alice, filter => $filter_id );
       })->then( sub {
          my ( $body ) = @_;
-         my $joined_rooms = $body->{rooms}{join};
-         assert_deeply_eq($joined_rooms, {});
+         if( exists $body->{rooms} and exists $body->{rooms}{join} ) {
+            my $joined_rooms = $body->{rooms}{join};
+            assert_deeply_eq($joined_rooms, {});
+         }
          Future->done(1);
       });
    };

--- a/tests/46direct/01directmessage.pl
+++ b/tests/46direct/01directmessage.pl
@@ -70,7 +70,7 @@ sub matrix_recv_device_message
       return 1 if $f->failure;
       my $resp = $f->get;
       log_if_fail "Sync response", $resp;
-      if( exists $resp->{to_device}{events} ) {
+      if( exists $resp->{to_device} and exists $resp->{to_device}{events} ) {
         return scalar @{ $resp->{to_device}{events} };
       }
    };


### PR DESCRIPTION
This makes all the sytests pass, if my patched synapse just sends the minimum amount of keys necessary in /sync (apart from 3 email related ones, which is probably my system).

Related: https://github.com/matrix-org/synapse/pull/9919

Signed-off-by: Nicolas Werner <nicolas.werner@hotmail.de>