### PR TITLE
Use Go 1.14.15 for Dendrite docker image

### DIFF
--- a/docker/dendrite.Dockerfile
+++ b/docker/dendrite.Dockerfile
@@ -1,7 +1,7 @@
 ARG SYTEST_IMAGE_TAG=buster
 FROM matrixdotorg/sytest:${SYTEST_IMAGE_TAG}
 
-ARG GO_VERSION=1.13.7
+ARG GO_VERSION=1.14.15
 ENV GO_DOWNLOAD https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz
 
 RUN mkdir -p /goroot /gopath


### PR DESCRIPTION
We're moving up from Go 1.13 now.