### PR TITLE
Remove --no-tls from the help text

### DIFF
--- a/run-tests.pl
+++ b/run-tests.pl
@@ -181,9 +181,6 @@ Options:
    -v, --verbose                - increase the verbosity of output and
                                   synapse's logging level
 
-   -n, --no-tls                 - prefer plaintext client connections where
-                                  possible
-
        --exclude-deprecated     - don't run tests that specifically test deprecated
                                   endpoints
 


### PR DESCRIPTION
The option was removed in commit [2b804ccec11c7acc41f4551c46af98f7ef67d6eb](https://github.com/matrix-org/sytest/commit/2b804ccec11c7acc41f4551c46af98f7ef67d6eb).