### PR TITLE
Fix 'Backfilled events whose prev_events are in a different...' test

### DIFF
--- a/tests/50federation/34room-backfill.pl
+++ b/tests/50federation/34room-backfill.pl
@@ -364,14 +364,18 @@ test "Backfilled events whose prev_events are in a different room do not allow c
          );
       })->then( sub {
          # wait for it to arrive
-         my $filter = $json->encode( { room => { timeline => { limit => 2 }}} );
          await_sync_timeline_contains(
             $creator_user, $room2_id,
-            filter => $filter,
             check => sub {
                $_[0]->{event_id} eq $event_id_S
             },
          );
+      })->then( sub {
+         my $filter = $json->encode( { room => { timeline => { limit => 2 }}} );
+         matrix_sync(
+            $creator_user,
+            filter => $filter,
+         )
       })->then( sub {
          my ( $sync_body ) = @_;
          my $room2_sync = $sync_body->{rooms}->{join}->{$room2_id};


### PR DESCRIPTION
This was broken in https://github.com/matrix-org/synapse/pull/10272, where we made incoming federation event processing asynchronous.

The failure mode was that when we called `await_sync_timeline_contains` it would get event `R` and then separately `S`, where previously we'd get them down in the same batch, and so paginating from the `prev_batch` token returned `R` rather than just `Q`. This didn't happen previously as the call to `send_event` previously took long enough that by the time the test called `await_sync_timeline_contains` the server would have process both `R` and `S` and so they'd come down in the same batch.

After this has landed we should remove the test from the blacklist.