### PR TITLE
Add support for testing Conduit

### DIFF
--- a/lib/SyTest/Homeserver/Conduit.pm
+++ b/lib/SyTest/Homeserver/Conduit.pm
@@ -1,0 +1,98 @@
+package SyTest::Homeserver::Conduit;
+
+use strict;
+use warnings;
+use 5.010;
+use base qw( SyTest::Homeserver );
+
+use Carp;
+
+sub _init
+{
+   my $self = shift;
+   my ( $args ) = @_;
+
+   $self->{$_} = delete $args->{$_} for qw(
+       binary
+   );
+
+   foreach (qw ( binary )) {
+      defined $self->{$_} or croak "Need a $_";
+   }
+
+   $self->{port} = main::alloc_port( "conduit" );
+
+   $self->SUPER::_init( $args );
+}
+
+sub configure
+{
+   my $self = shift;
+   my %params = @_;
+
+   $self->SUPER::configure( %params );
+}
+
+sub start
+{
+   my $self = shift;
+
+   my $hs_dir = $self->{hs_dir};
+
+   $self->{paths}{config} = $self->write_file( "conduit.toml" =>
+"[global]
+server_name = \"" . $self->server_name . "\"
+database_path = \"$self->{hs_dir}/db\"
+port = $self->{port}
+max_request_size = 20_000_000
+allow_registration = true
+allow_federation = true
+address = \"127.0.0.1\""
+ );
+
+   my $output = $self->{output};
+
+   $output->diag( "Starting conduit server" );
+   my @command = ( $self->{binary} );
+
+   return $self->_start_process_and_await_connectable(
+      setup => [
+         env => {
+            CONDUIT_CONFIG => "$self->{hs_dir}/conduit.toml",
+         },
+      ],
+      command => [ @command ],
+      connect_host => $self->{bind_host},
+      connect_port => $self->{port},
+   )->else( sub {
+      die "Unable to start conduit: $_[0]\n";
+   })->on_done( sub {
+      $output->diag( "Started conduit server" );
+   });
+}
+
+sub server_name
+{
+   my $self = shift;
+   return $self->{bind_host} . ":" . $self->{port};
+}
+
+sub federation_host
+{
+   my $self = shift;
+   return $self->{bind_host};
+}
+
+sub federation_port
+{
+   my $self = shift;
+   return $self->{port};
+}
+
+sub public_baseurl
+{
+   my $self = shift;
+   return "http://$self->{bind_host}:" . $self->{port};
+}
+
+1;

--- a/lib/SyTest/HomeserverFactory/Conduit.pm
+++ b/lib/SyTest/HomeserverFactory/Conduit.pm
@@ -1,0 +1,64 @@
+# Copyright 2017 New Vector Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+use strict;
+use warnings;
+
+require SyTest::Homeserver::Conduit;
+
+package SyTest::HomeserverFactory::Conduit;
+use base qw( SyTest::HomeserverFactory );
+
+sub _init
+{
+   my $self = shift;
+
+   $self->{impl} = "SyTest::Homeserver::Conduit";
+
+   $self->{args}{binary} = "conduit";
+
+   $self->SUPER::_init( @_ );
+}
+
+sub implementation_name
+{
+   return "conduit";
+}
+
+sub get_options
+{
+   my $self = shift;
+
+   return (
+      'binary=s' => \$self->{args}{binary},
+      $self->SUPER::get_options(),
+   );
+}
+
+sub print_usage
+{
+   print STDERR <<EOF
+       --binary PATH            - path to the 'conduit' binary
+EOF
+}
+
+sub create_server
+{
+   my $self = shift;
+   my %params = ( @_, %{ $self->{args}} );
+
+   return $self->{impl}->new( %params );
+}
+
+1;


### PR DESCRIPTION
This add initial support for testing Conduit.

I currently know about 3 issues:
- When starting, it shows: `# Starting Homeserver using SyTest::HomeserverFactory::Conduit=HASH(0x55de4cf83420)`. I assume that HASH part is my very limited knowledge of perl.
- After the test is run, the server-0 and server-1 directory still exist. This results in a 2nd run getting additional errors, for instance it attempts the make the same user as the previous run. I'm not sure who is responsible for cleaning up.
- As far as I know, Conduit doesn't have any https server support, but some tests seem to use it.