### PR TITLE
Don't check for presence of `room_alias` in `createRoom` response

### DIFF
--- a/tests/10apidoc/30room-create.pl
+++ b/tests/10apidoc/30room-create.pl
@@ -21,7 +21,7 @@ test "POST /createRoom makes a public room",
       )->then( sub {
          my ( $body ) = @_;
 
-         assert_json_keys( $body, qw( room_id room_alias ));
+         assert_json_keys( $body, qw( room_id ));
          assert_json_nonempty_string( $body->{room_id} );
 
          Future->done(1);


### PR DESCRIPTION
The specification only has a room_id as return value, there is no room_alias.

Signed-off-by: Kurt Roeckx <kurt@roeckx.be>