### PR TITLE
Revert "Fix invalid UTF-8 test"

### DIFF
--- a/tests/10apidoc/01request-encoding.pl
+++ b/tests/10apidoc/01request-encoding.pl
@@ -6,7 +6,7 @@ test "POST rejects invalid utf-8 in JSON",
    do => sub {
       my ( $http ) = @_;
 
-      my $reqbody = '{ "username": "a' . chr(0x81) . '" }';
+      my $reqbody = '{ "test": "a' . chr(0x81) . '" }';
 
       $http->do_request(
          method => "POST",
@@ -18,8 +18,7 @@ test "POST rejects invalid utf-8 in JSON",
       ->then( sub {
          my ( $response ) = @_;
          my $body = decode_json( $response->content );
-         defined $body->{errcode} && ($body->{errcode} eq "M_NOT_JSON" || $body->{errcode} eq "M_BAD_JSON") or
-            croak "Got ${\ pp $$body->{errcode} }, expected M_NOT_JSON or M_BAD_JSON for responsecode";
+         assert_eq( $body->{errcode}, "M_NOT_JSON", 'responsecode' );
          Future->done( 1 );
       });
    };


### PR DESCRIPTION
Reverts matrix-org/sytest#1062.

`M_NOT_JSON` and `M_BAD_JSON` cannot both be valid for the same request. See the above PR for context.