### PR TITLE
Make implementation_specific accept an array

### DIFF
--- a/run-tests.pl
+++ b/run-tests.pl
@@ -645,8 +645,8 @@ sub _push_test
    }
 
    if( exists $params{implementation_specific} ) {
-       if (grep { $_ ne $HS_FACTORY->implementation_name() } $params{implementation_specific}) {
-           return;
+       unless (grep { $_ eq $HS_FACTORY->implementation_name() } @{$params{implementation_specific}}) {
+          return;
        }
    }
 

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -645,7 +645,7 @@ sub _push_test
    }
 
    if( exists $params{implementation_specific} ) {
-       unless (grep { $_ eq $HS_FACTORY->implementation_name() } @{$params{implementation_specific}}) {
+       unless (grep { $_ eq $HS_FACTORY->implementation_name() } @{ $params{implementation_specific} }) {
           return;
        }
    }

--- a/run-tests.pl
+++ b/run-tests.pl
@@ -645,7 +645,7 @@ sub _push_test
    }
 
    if( exists $params{implementation_specific} ) {
-       if ( $HS_FACTORY->implementation_name() ne $params{implementation_specific} ) {
+       if (grep { $_ ne $HS_FACTORY->implementation_name() } $params{implementation_specific}) {
            return;
        }
    }

--- a/tests/10apidoc/01register.pl
+++ b/tests/10apidoc/01register.pl
@@ -349,7 +349,7 @@ sub shared_secret_tests {
 
    test "POST $ep_name with shared secret",
       requires => [ $main::API_CLIENTS[0], localpart_fixture() ],
-      implementation_specific => "synapse",
+      implementation_specific => ['synapse', 'dendrite'],
 
       proves => [qw( can_register_with_secret )],
 
@@ -366,7 +366,7 @@ sub shared_secret_tests {
 
    test "POST $ep_name admin with shared secret",
       requires => [ $main::API_CLIENTS[0], localpart_fixture() ],
-      implementation_specific => "synapse",
+      implementation_specific => ['synapse', 'dendrite'],
 
       do => sub {
          my ( $http, $uid ) = @_;
@@ -382,7 +382,7 @@ sub shared_secret_tests {
 
    test "POST $ep_name with shared secret downcases capitals",
       requires => [ $main::API_CLIENTS[0], localpart_fixture() ],
-      implementation_specific => "synapse",
+      implementation_specific => ['synapse', 'dendrite'],
 
       proves => [qw( can_register_with_secret )],
 
@@ -399,7 +399,7 @@ sub shared_secret_tests {
 
    test "POST $ep_name with shared secret disallows symbols",
       requires => [ $main::API_CLIENTS[0] ],
-      implementation_specific => "synapse",
+      implementation_specific => ['synapse', 'dendrite'],
 
       proves => [qw( can_register_with_secret )],
 

--- a/tests/48admin.pl
+++ b/tests/48admin.pl
@@ -69,7 +69,7 @@ test "/whois",
 
 test "/purge_history",
    requires => [ local_admin_fixture(), local_user_and_room_fixtures() ],
-   implementation_specific => "synapse",
+   implementation_specific => ['synapse'],
 
    do => sub {
       my ( $admin, $user, $room_id ) = @_;
@@ -150,7 +150,7 @@ test "/purge_history",
 
 test "/purge_history by ts",
    requires => [ local_admin_fixture(), local_user_and_room_fixtures() ],
-   implementation_specific => "synapse",
+   implementation_specific => ['synapse'],
 
    do => sub {
       my ( $admin, $user, $room_id ) = @_;
@@ -224,7 +224,7 @@ test "/purge_history by ts",
 test "Can backfill purged history",
    requires => [ local_admin_fixture(), local_user_and_room_fixtures(),
                  remote_user_fixture(), qw( can_paginate_room_remotely ) ],
-   implementation_specific => "synapse",
+   implementation_specific => ['synapse'],
 
    # this test is a bit slow.
    timeout => 50,
@@ -361,7 +361,7 @@ test "Can backfill purged history",
 multi_test "Shutdown room",
    requires => [ local_admin_fixture(), local_user_fixtures( 2 ), remote_user_fixture(),
       room_alias_name_fixture() ],
-   implementation_specific => "synapse",
+   implementation_specific => ['synapse'],
 
    do => sub {
       my ( $admin, $user, $dummy_user, $remote_user, $room_alias_name ) = @_;


### PR DESCRIPTION
Since Dendrite now implements some shared secret registration bits, we want to test it.