### PR TITLE
Use an existing field to test invalid UTF-8

### DIFF
--- a/tests/10apidoc/01request-encoding.pl
+++ b/tests/10apidoc/01request-encoding.pl
@@ -6,7 +6,7 @@ test "POST rejects invalid utf-8 in JSON",
    do => sub {
       my ( $http ) = @_;
 
-      my $reqbody = '{ "test": "a' . chr(0x81) . '" }';
+      my $reqbody = '{ "username": "a' . chr(0x81) . '" }';
 
       $http->do_request(
          method => "POST",


### PR DESCRIPTION
This change is the first commit of https://github.com/matrix-org/sytest/pull/1062, which was reverted after being merged via https://github.com/matrix-org/sytest/pull/1066. The invalid commit was the second one in the changeset, but the first commit is potentially useful.

The test attempts to check for an error from the homeserver indicating that the JSON is invalid by including an invalid character under the key `test` in the request. However, since `test` is not a known key a request to [/register](https://spec.matrix.org/unstable/client-server-api/#post_matrixclientr0register), the homeserver may ignore it entirely.

This change attempts to allow homeservers to pass this test even if they only selectively parse request bodies. Originally written by @kroeckx.