### PR TITLE
Remove event_id and origin key assertions on /make_leave response

### DIFF
--- a/tests/50federation/35room-invite.pl
+++ b/tests/50federation/35room-invite.pl
@@ -507,7 +507,7 @@ test "Inbound federation can receive invite rejections",
 
          my $protoevent = $resp->{event};
          assert_json_keys( $protoevent, qw(
-            event_id origin room_id sender type content state_key depth prev_events auth_events
+            room_id sender type content state_key depth prev_events auth_events
          ));
 
          assert_eq( $protoevent->{type}, "m.room.member", 'event type' );


### PR DESCRIPTION
They aren't required in later room versions, aren't checked in
the test and are overall unimportant to the processing of invite
rejections.