### PR TITLE
Type-cast origin_server_ts as JSON::number to avoid sending it as a string

### DIFF
--- a/tests/50federation/35room-invite.pl
+++ b/tests/50federation/35room-invite.pl
@@ -603,7 +603,7 @@ test "Inbound federation rejects incorrectly-signed invite rejections",
          $leave_event = $resp->{event};
 
          $leave_event->{origin} = $outbound_client->server_name;
-         $leave_event->{origin_server_ts} = $outbound_client->time_ms;
+         $leave_event->{origin_server_ts} = JSON::number($outbound_client->time_ms);
          $leave_event->{event_id} = $leave_event_id = $outbound_client->datastore->next_event_id();
 
          # let's start by sending it back without any signatures


### PR DESCRIPTION
For some reason this test was sending origin_server_ts as a string.
Type-casting this makes the test pass on Dendrite.