### PR TITLE
Use a non-deprecated API to send m.room.test

### DIFF
--- a/tests/10apidoc/30room-create.pl
+++ b/tests/10apidoc/30room-create.pl
@@ -424,6 +424,8 @@ The resultant future completes with the room_id.
 
 =cut
 
+my $txn_id = 1000000;
+
 sub matrix_create_room_synced
 {
    my ( $user, %params ) = @_;
@@ -436,11 +438,12 @@ sub matrix_create_room_synced
 
       matrix_do_and_wait_for_sync( $user,
          do => sub {
-            my $uri = "/r0/rooms/$room_id/send/m.room.test";
+            my $uri = "/r0/rooms/$room_id/send/m.room.test/$txn_id";
+            $txn_id++;
 
             do_request_json_for(
                $user,
-               method => "POST",
+               method => "PUT",
                uri    => $uri,
                content => {},
             );


### PR DESCRIPTION
Fixes: #1064
Signed-off-by: Kurt Roeckx <kurt@roeckx.be>

I've tried to use matrix_send_room_message_synced, but I have no perl skills.

This also partially fixes #878