### PR TITLE
Mark groups tests as using deprecated endpoints

### DIFF
--- a/tests/53groups/01create.pl
+++ b/tests/53groups/01create.pl
@@ -1,4 +1,5 @@
 test "Create group",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ) ],
 
    do => sub {
@@ -27,6 +28,7 @@ test "Create group",
    };
 
 test "Add group rooms",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ) ],
 
    do => sub {
@@ -48,6 +50,7 @@ test "Add group rooms",
 
 
 test "Remove group rooms",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ) ],
 
    do => sub {

--- a/tests/53groups/02read.pl
+++ b/tests/53groups/02read.pl
@@ -5,6 +5,7 @@ foreach my $viewer_fixture ( $local_viewer_fixture, $remote_viewer_fixture) {
    my $test_name = $viewer_fixture == $local_viewer_fixture ? "local" : "remote";
 
    test "Get $test_name group profile",
+      deprecated_endpoints => 1,
       requires => [ local_admin_fixture( with_events => 0 ), $viewer_fixture ],
 
       do => sub {
@@ -34,6 +35,7 @@ foreach my $viewer_fixture ( $local_viewer_fixture, $remote_viewer_fixture) {
       };
 
    test "Get $test_name group users",
+      deprecated_endpoints => 1,
       requires => [ local_admin_fixture( with_events => 0 ), $viewer_fixture ],
 
       do => sub {
@@ -54,6 +56,7 @@ foreach my $viewer_fixture ( $local_viewer_fixture, $remote_viewer_fixture) {
       };
 
    test "Add/remove $test_name group rooms",
+      deprecated_endpoints => 1,
       requires => [ local_admin_fixture( with_events => 0 ), $viewer_fixture ],
 
       do => sub {
@@ -96,6 +99,7 @@ foreach my $viewer_fixture ( $local_viewer_fixture, $remote_viewer_fixture) {
       };
 
    test "Get $test_name group summary",
+      deprecated_endpoints => 1,
       requires => [ local_admin_fixture( with_events => 0 ), $viewer_fixture ],
 
       do => sub {

--- a/tests/53groups/03local.pl
+++ b/tests/53groups/03local.pl
@@ -1,4 +1,5 @@
 test "Add local group users",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ), local_user_fixture( with_events => 0 ) ],
 
    do => sub {
@@ -28,6 +29,7 @@ test "Add local group users",
    };
 
 test "Remove self from local group",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ), local_user_fixture( with_events => 0 ) ],
 
    do => sub {
@@ -62,6 +64,7 @@ test "Remove self from local group",
    };
 
 test "Remove other from local group",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ), local_user_fixture( with_events => 0 ) ],
 
    do => sub {

--- a/tests/53groups/04remote-group.pl
+++ b/tests/53groups/04remote-group.pl
@@ -1,4 +1,5 @@
 test "Add remote group users",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ), remote_user_fixture( with_events => 0 ) ],
 
    do => sub {
@@ -25,6 +26,7 @@ test "Add remote group users",
    };
 
 test "Remove self from remote group",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ), remote_user_fixture( with_events => 0 ) ],
 
    do => sub {
@@ -59,6 +61,7 @@ test "Remove self from remote group",
    };
 
 test "Listing invited users of a remote group when not a member returns a 403",
+    deprecated_endpoints => 1,
     requires => [ local_admin_fixture( with_events => 0 ), remote_user_fixture( with_events => 0 ) ],
 
     do => sub {

--- a/tests/53groups/05categories.pl
+++ b/tests/53groups/05categories.pl
@@ -1,4 +1,5 @@
 test "Add group category",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ) ],
 
    do => sub {
@@ -26,6 +27,7 @@ test "Add group category",
    };
 
 test "Remove group category",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ) ],
 
    do => sub {
@@ -47,6 +49,7 @@ test "Remove group category",
 
 
 test "Get group categories",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ) ],
 
    do => sub {

--- a/tests/53groups/05roles.pl
+++ b/tests/53groups/05roles.pl
@@ -1,4 +1,5 @@
 test "Add group role",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ) ],
 
    do => sub {
@@ -26,6 +27,7 @@ test "Add group role",
    };
 
 test "Remove group role",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ) ],
 
    do => sub {
@@ -47,6 +49,7 @@ test "Remove group role",
 
 
 test "Get group roles",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ) ],
 
    do => sub {

--- a/tests/53groups/06summaries.pl
+++ b/tests/53groups/06summaries.pl
@@ -1,4 +1,5 @@
 test "Add room to group summary",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ), local_user_fixture( with_events => 0 ) ],
 
    do => sub {
@@ -37,6 +38,7 @@ test "Add room to group summary",
 # Luke claims that adding room to group summary removes the room_id
 # when fetching the rooms in a group
 test "Adding room to group summary keeps room_id when fetching rooms in group",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ), local_user_fixture( with_events => 0 ) ],
 
    do => sub {
@@ -73,6 +75,7 @@ test "Adding room to group summary keeps room_id when fetching rooms in group",
 
 
 test "Adding multiple rooms to group summary have correct order",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ), local_user_fixture( with_events => 0 ) ],
 
    do => sub {
@@ -121,6 +124,7 @@ test "Adding multiple rooms to group summary have correct order",
    };
 
 test "Remove room from group summary",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ), local_user_fixture( with_events => 0 ) ],
 
    do => sub {
@@ -170,6 +174,7 @@ test "Remove room from group summary",
 
 
 test "Add room to group summary with category",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ), local_user_fixture( with_events => 0 ) ],
 
    do => sub {
@@ -217,6 +222,7 @@ test "Add room to group summary with category",
    };
 
 test "Remove room from group summary with category",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ), local_user_fixture( with_events => 0 ) ],
 
    do => sub {
@@ -263,6 +269,7 @@ test "Remove room from group summary with category",
 
 
 test "Add user to group summary",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ), local_user_fixture( with_events => 0 ) ],
 
    do => sub {
@@ -296,6 +303,7 @@ test "Add user to group summary",
 
 
 test "Adding multiple users to group summary have correct order",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ), local_user_fixture( with_events => 0 ) ],
 
    do => sub {
@@ -335,6 +343,7 @@ test "Adding multiple users to group summary have correct order",
    };
 
 test "Remove user from group summary",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ), local_user_fixture( with_events => 0 ) ],
 
    do => sub {
@@ -372,6 +381,7 @@ test "Remove user from group summary",
 
 
 test "Add user to group summary with role",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ), local_user_fixture( with_events => 0 ) ],
 
    do => sub {
@@ -413,6 +423,7 @@ test "Add user to group summary with role",
    };
 
 test "Remove user from group summary with role",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ), local_user_fixture( with_events => 0 ) ],
 
    do => sub {

--- a/tests/53groups/10sync.pl
+++ b/tests/53groups/10sync.pl
@@ -2,6 +2,7 @@ use Future::Utils qw( try_repeat_until_success );
 
 
 test "Local group invites come down sync",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ), local_user_fixture( with_events => 0 ) ],
 
    do => sub {
@@ -49,6 +50,7 @@ test "Local group invites come down sync",
 
 
 test "Group creator sees group in sync",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ) ],
 
    do => sub {
@@ -94,6 +96,7 @@ test "Group creator sees group in sync",
    };
 
 test "Group creator sees group in initial sync",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ) ],
 
    do => sub {

--- a/tests/53groups/11publicise.pl
+++ b/tests/53groups/11publicise.pl
@@ -1,4 +1,5 @@
 test "Get/set local group publicity",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ), local_user_fixture( with_events => 0 ) ],
 
    do => sub {
@@ -30,6 +31,7 @@ test "Get/set local group publicity",
    };
 
 test "Bulk get group publicity",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ), local_user_fixture( with_events => 0 ), remote_user_fixture( with_events => 0 ) ],
 
    do => sub {

--- a/tests/53groups/12joinable.pl
+++ b/tests/53groups/12joinable.pl
@@ -1,4 +1,5 @@
 test "Joinability comes down summary",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ) ],
 
    do => sub {
@@ -37,6 +38,7 @@ test "Joinability comes down summary",
    };
 
 test "Set group joinable and join it",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ), local_user_fixture( with_events => 0 ) ],
 
    do => sub {
@@ -66,6 +68,7 @@ test "Set group joinable and join it",
    };
 
 test "Group is not joinable by default",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ), local_user_fixture( with_events => 0 ) ],
 
    do => sub {
@@ -82,6 +85,7 @@ test "Group is not joinable by default",
    };
 
 test "Group is joinable over federation",
+   deprecated_endpoints => 1,
    requires => [ local_admin_fixture( with_events => 0 ), remote_user_fixture( with_events => 0 ) ],
 
    do => sub {

--- a/tests/53groups/20room-upgrade.pl
+++ b/tests/53groups/20room-upgrade.pl
@@ -16,6 +16,7 @@ use Future::Utils qw( repeat );
 use List::Util qw( all first none );
 
 test "Room is transitioned on local and remote groups upon room upgrade",
+   deprecated_endpoints => 1,
    requires => [
       local_admin_fixture(),
       remote_admin_fixture(),


### PR DESCRIPTION
Since we've replaced Groups with Spaces and new implementations aren't likely to implement Groups, we should mark them as `deprecated_endpoints`.