### PR TITLE
Use correct start and stop to get the message

### DIFF
--- a/tests/10apidoc/34room-messages.pl
+++ b/tests/10apidoc/34room-messages.pl
@@ -142,7 +142,8 @@ test "GET /rooms/:room_id/messages returns a message",
          matrix_sync( $user )
       })->then( sub {
          my ( $sync_body ) = @_;
-         my $token = $sync_body->{rooms}->{join}->{$room_id}->{timeline}->{prev_batch};
+         my $next_batch = $sync_body->{next_batch};
+         my $prev_batch = $sync_body->{rooms}->{join}->{$room_id}->{timeline}->{prev_batch};
 
          do_request_json_for( $user,
             method => "GET",
@@ -151,7 +152,8 @@ test "GET /rooms/:room_id/messages returns a message",
             # With no params this does "forwards from END"; i.e. nothing useful
             params => {
                 dir => "b",
-                from => $token,
+                from => $next_batch,
+                to => $prev_batch,
             },
          )
       })->then( sub {
@@ -180,7 +182,8 @@ test "GET /rooms/:room_id/messages lazy loads members correctly",
          matrix_sync( $user )
       })->then( sub {
          my ( $sync_body ) = @_;
-         my $token = $sync_body->{rooms}->{join}->{$room_id}->{timeline}->{prev_batch};
+         my $next_batch = $sync_body->{next_batch};
+         my $prev_batch = $sync_body->{rooms}->{join}->{$room_id}->{timeline}->{prev_batch};
 
          do_request_json_for( $user,
             method => "GET",
@@ -189,7 +192,8 @@ test "GET /rooms/:room_id/messages lazy loads members correctly",
             params => {
                dir => "b",
                filter => '{ "lazy_load_members" : true }',
-               from => $token,
+               from => $next_batch,
+               to => $prev_batch,
             },
          )
       })->then( sub {


### PR DESCRIPTION
The output of /sync without since parameter has the most recent
message events, and so should include at least the message we
just sent.

The tests used prev_batch, but this should point before the message
that was returned in /sync. Starting backward from an event before
the test message should not have received any message.

We now test between next_batch and prev_batch, we should get the
message.

Signed-off-by: Kurt Roeckx <kurt@roeckx.be>