### PR TITLE
Mark POST /rooms/:room_id/send/:event_type as deprecated

### DIFF
--- a/tests/10apidoc/34room-messages.pl
+++ b/tests/10apidoc/34room-messages.pl
@@ -1,4 +1,5 @@
 test "POST /rooms/:room_id/send/:event_type sends a message",
+   deprecated_endpoints => 1,
    requires => [ local_user_and_room_fixtures() ],
 
    do => sub {


### PR DESCRIPTION
Fixes: #878

Signed-off-by: Kurt Roeckx <kurt@roeckx.be>

The other issue is fixed in #1080