### PR TITLE
Fix `/aliases` test to use stable endpoint

### DIFF
--- a/tests/30rooms/05aliases.pl
+++ b/tests/30rooms/05aliases.pl
@@ -474,7 +474,7 @@ test "Only room members can list aliases of a room",
          do_request_json_for(
             $other_user,
             method => "GET",
-            uri  => "/unstable/org.matrix.msc2432/rooms/$room_id/aliases",
+            uri  => "/r0/rooms/$room_id/aliases",
          );
       })->then( sub {
          my ( $res ) = @_;
@@ -484,7 +484,7 @@ test "Only room members can list aliases of a room",
          do_request_json_for(
             $third_user,
             method => "GET",
-            uri  => "/unstable/org.matrix.msc2432/rooms/$room_id/aliases",
+            uri  => "/r0/rooms/$room_id/aliases",
          );
       })->main::expect_http_403;
    };


### PR DESCRIPTION
The test was previously referring to an unstable endpoint, but it's listed in the latest spec: https://matrix.org/docs/spec/client_server/r0.6.1#id284