### PR TITLE
Add option to print server logs when running against Dendrite

### DIFF
--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -29,7 +29,7 @@ sub _init
    my ( $args ) = @_;
 
    $self->{$_} = delete $args->{$_} for qw(
-       bindir pg_db pg_user pg_pass
+       bindir print_output pg_db pg_user pg_pass
    );
 
    defined $self->{bindir} or croak "Need a bindir";

--- a/lib/SyTest/HomeserverFactory/Dendrite.pm
+++ b/lib/SyTest/HomeserverFactory/Dendrite.pm
@@ -26,6 +26,7 @@ sub _init
 
    $self->{args} = {
       bindir => "../dendrite/bin",
+      print_output => 0,
    };
 
    $self->SUPER::_init( @_ );
@@ -42,6 +43,7 @@ sub get_options
 
    return (
       'd|dendrite-binary-directory=s' => \$self->{args}{bindir},
+      'S|server-log+' => \$self->{args}{print_output},
       $self->SUPER::get_options(),
    );
 }


### PR DESCRIPTION
Add option to print server logs when running against Dendrite

Spawned from https://github.com/matrix-org/sytest/pull/1009


### Dev notes

See https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md#manually-setting-up-sytest

 - `psql`: Open the postgres CLI 
 - `\l`: List databases
 - `DROP DATABASE IF EXISTS dendrite0;`: Drop `dendrite0` database
 - `\q` -> `enter`: To quit/exit
 - `\dt`: list tables


<details>
<summary>random trials</summary>

Can't get this to run successfully

```
$ POSTGRES=1 ./run-tests.pl -I Dendrite::Monolith -d ../dendrite/bin -W ../dendrite/sytest-whitelist tests/10apidoc/30room-create.pl -vvvv
Running tests/10apidoc/30room-create.pl...
 # Starting test POST /createRoom makes a public room
 # Starting fixture local_user_fixture
 # Starting fixture FIXTURE-7
 # Starting fixture HOMESERVER_0
 # Starting fixture FIXTURE-0
  Testing if: POST /createRoom makes a public room...
Tests: 0 / 10 | OKSignature ok
subject=/CN=localhost
 # Starting fixture FIXTURE-3
 # Starting fixture FIXTURE-1
 # Fixture FIXTURE-1 now ready
 # Starting fixture FIXTURE-2
 # Fixture FIXTURE-2 now ready
 # Starting fixture FIXTURE-49
 # Fixture FIXTURE-49 now ready
 # Started test HTTPS Server at localhost:57448
 # Started test SMTP Server at localhost:57449
 # Fixture FIXTURE-3 now ready
 ** HOMESERVER_0: input fixture failed with Connection closed at ./run-tests.pl line 567.
 ** FIXTURE-7: input fixture failed with Connection closed at ./run-tests.pl line 567.
 ** local_user_fixture: input fixture failed with Connection closed at ./run-tests.pl line 567.
 ** Fixture failed with Connection closed at ./run-tests.pl line 736.
 ** Destroying unresponded HTTP request to /http_server_self_test at /Users/eric/perl5/perlbrew/perls/perl-5.32.0/lib/site_perl/5.32.0/Net/Async/HTTP/Server/Protocol.pm line 53.
  Testing if: POST /createRoom makes a public room... FAIL:
 | fixture failed - Connection closed
 +----------------------
 # Starting test POST /createRoom makes a private room
 ** Fixture failed with Connection closed at ./run-tests.pl line 736.
  Testing if: POST /createRoom makes a private room... FAIL:
 | fixture failed - Connection closed
 +----------------------
 # Starting test POST /createRoom makes a private room with invites
  Testing if: POST /createRoom makes a private room with invites... SKIP due to lack of can_create_private_room
 # Starting test POST /createRoom makes a room with a name
  Testing if: POST /createRoom makes a room with a name... SKIP due to lack of can_create_private_room
 # Starting test POST /createRoom makes a room with a topic
  Testing if: POST /createRoom makes a room with a topic... SKIP due to lack of can_create_private_room
 # Starting test Can /sync newly created room
 ** Fixture failed with Connection closed at ./run-tests.pl line 736.
  Testing if: Can /sync newly created room... FAIL:
 | fixture failed - Connection closed
 +----------------------
 # Starting test POST /createRoom creates a room with the given version
 ** Fixture failed with Connection closed at ./run-tests.pl line 736.
  Testing if: POST /createRoom creates a room with the given version... FAIL:
 | fixture failed - Connection closed
 +----------------------
 # Starting test POST /createRoom rejects attempts to create rooms with numeric versions
  Testing if: POST /createRoom rejects attempts to create rooms with numeric versions... SKIP due to lack of can_create_versioned_room
 # Starting test POST /createRoom rejects attempts to create rooms with unknown versions
  Testing if: POST /createRoom rejects attempts to create rooms with unknown versions... SKIP due to lack of can_create_versioned_room
 # Starting test POST /createRoom ignores attempts to set the room version via creation_content
 ** Fixture failed with Connection closed at ./run-tests.pl line 736.
  Testing if: POST /createRoom ignores attempts to set the room version via creation_content... FAIL:
 | fixture failed - Connection closed
 +----------------------

5 tests FAILED
```

The Docker image always prints server logs regardless 🤷‍♀️
```
docker run --rm --name sytest -v "/Users/eric/Documents/github/element/sytest:/sytest" \
	-v "/Users/eric/Documents/github/element/dendrite:/src" -v "/Users/eric/Downloads/logs:/logs" \
	-v "/Users/eric/.gvm/pkgsets/go1.16.6/global/:/gopath" -e "POSTGRES=1" -e "DENDRITE_TRACE_HTTP=1" \
	matrixdotorg/sytest-dendrite:latest tests/50federation/40devicelists.pl
```

</details>