### PR TITLE
Put media into a hopefully writable location

### DIFF
--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -187,7 +187,7 @@ sub _get_config
                ( ! defined $ENV{'POSTGRES'} || $ENV{'POSTGRES'} == '0') ?
                "file:$self->{hs_dir}/media_api.db" : $db_uri,
          },
-         base_path => "media_store",
+         base_path => "$self->{hs_dir}/media_store",
       },
 
       mscs => {


### PR DESCRIPTION
It looks like the sytest pipeline mounts `".:/sytest:ro"` which the dendrite pipeline doesn't, and the relative media path was meaning we were hitting errors during CI builds:

`Failed to create temp dir: Failed to create base temp dir: mkdir /sytest/media_store: read-only file system`