### PR TITLE
Note that room versions 7 & 8 exist.

### DIFF
--- a/lib/SyTest/Federation/Client.pm
+++ b/lib/SyTest/Federation/Client.pm
@@ -16,7 +16,7 @@ use SyTest::Assertions qw( :all );
 use URI::Escape qw( uri_escape );
 
 use constant SUPPORTED_ROOM_VERSIONS => [qw(
-   1 2 3 4 5 6
+   1 2 3 4 5 6 7 8
 )];
 
 sub configure


### PR DESCRIPTION
Corresponds to matrix-org/synapse#10449

With this I'm able to run with `--room-version=7` and `--room-version=8` successfully.

This should not be merged until [MSC3289](https://github.com/matrix-org/matrix-doc/pull/3289) is merged.

I can move the room version 7 out to a separate PR if we wanted to merge that now.