### PR TITLE
Add support for a presence db in Dendrite

### DIFF
--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -234,6 +234,11 @@ sub _get_config
                ( ! defined $ENV{'POSTGRES'} || $ENV{'POSTGRES'} == '0') ?
                "file:$self->{hs_dir}/devices.db" : $db_uri,
          },
+         presence_database => {
+            connection_string =>
+               ( ! defined $ENV{'POSTGRES'} || $ENV{'POSTGRES'} == '0') ?
+               "file:$self->{hs_dir}/presence.db" : $db_uri,
+         },
       },
 
       logging => [{

--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -100,6 +100,7 @@ sub _get_config
       global => {
          server_name => $self->server_name,
          private_key => $self->{paths}{matrix_key},
+         presence_enabled => $JSON::true,
 
          kafka => {
             use_naffka => $JSON::true,

--- a/tests/21presence-events.pl
+++ b/tests/21presence-events.pl
@@ -68,6 +68,7 @@ test "Presence change reports an event to myself",
 my $friend_status = "Status of a Friend";
 
 test "Friends presence changes reports events",
+   deprecated_endpoints => 1,
    requires => [ local_user_fixture(), local_user_fixture(),
                  qw( can_set_presence can_invite_presence )],
 


### PR DESCRIPTION
This adds a presence database for Dendrite.
Also deprecates `/r0/presence/list/:user_id`, as it seems to be removed in the latest CS spec.