### PR TITLE
Use v2 send_join in tests

### DIFF
--- a/lib/SyTest/Federation/Client.pm
+++ b/lib/SyTest/Federation/Client.pm
@@ -247,13 +247,10 @@ sub join_room
       $self->do_request_json(
          method   => "PUT",
          hostname => $server_name,
-         uri      => "/v1/send_join/$room_id/$event_id",
+         uri      => "/v2/send_join/$room_id/$event_id",
          content  => $member_event,
       )->then( sub {
          my ( $join_body ) = @_;
-
-         # /v1/send_join has an extraneous [ 200, ... ] wrapper (see MSC1802)
-         $join_body = $join_body->[1];
 
          my $room = SyTest::Federation::Room->new(
             datastore => $store,


### PR DESCRIPTION
The v1 is still used in other tests

Signed-off-by: Kurt Roeckx <kurt@roeckx.be>