### PR TITLE
Deprecate tests testing /events and /initialSync

### DIFF
--- a/tests/42tags.pl
+++ b/tests/42tags.pl
@@ -230,7 +230,8 @@ sub check_account_data {
 }
 
 
-test "Tags appear in the v1 /initalSync",
+test "Tags appear in the v1 /initialSync",
+   deprecated_endpoints => 1,
    requires => [ local_user_fixture( with_events => 0 ),
                  qw( can_add_tag can_remove_tag ) ],
 

--- a/tests/44account_data.pl
+++ b/tests/44account_data.pl
@@ -148,6 +148,7 @@ test "Latest account data comes down in room initialSync",
 
 
 test "Account data appears in v1 /events stream",
+   deprecated_endpoints => 1,
    requires => [ local_user_fixture( with_events => 1 ) ],
 
    check => sub {
@@ -168,6 +169,7 @@ test "Account data appears in v1 /events stream",
 
 
 test "Room account data appears in v1 /events stream",
+   deprecated_endpoints => 1,
    requires => [ local_user_and_room_fixtures() ],
 
    check => sub {

--- a/tests/80torture/03events.pl
+++ b/tests/80torture/03events.pl
@@ -15,6 +15,7 @@ test "GET /initialSync with non-numeric 'limit'",
    };
 
 test "GET /events with non-numeric 'limit'",
+   deprecated_endpoints => 1,
    requires => [ $main::SPYGLASS_USER ],
 
    check => sub {
@@ -29,6 +30,7 @@ test "GET /events with non-numeric 'limit'",
    };
 
 test "GET /events with negative 'limit'",
+   deprecated_endpoints => 1,
    requires => [ $main::SPYGLASS_USER ],
 
    check => sub {
@@ -43,6 +45,7 @@ test "GET /events with negative 'limit'",
    };
 
 test "GET /events with non-numeric 'timeout'",
+   deprecated_endpoints => 1,
    requires => [ $main::SPYGLASS_USER ],
 
    check => sub {


### PR DESCRIPTION
Signed-off-by: Kurt Roeckx <kurt@roeckx.be>