### PR TITLE
Try and fix flakey device list update after leave

### DIFF
--- a/tests/41end-to-end-keys/06-device-lists.pl
+++ b/tests/41end-to-end-keys/06-device-lists.pl
@@ -397,9 +397,27 @@ test "If remote user leaves room we no longer receive device updates",
       })->then( sub {
 
          # now one of the remote users leaves the room...
-         matrix_leave_room_synced( $remote_leaver, $room_id );
+         matrix_leave_room( $remote_leaver, $room_id );
       })->then( sub {
          log_if_fail "Remote_leaver " . $remote_leaver->user_id . " left room";
+
+         # wait for the leave to propagate to the creators homeserver
+         await_sync_timeline_contains( $creator, $room_id, check => sub {
+            my ( $event ) = @_;
+
+            assert_json_keys( $event, qw( type content sender ));
+
+            return unless $event->{type} eq "m.room.member";
+            return unless $event->{sender} eq $remote_leaver->user_id;
+
+
+            assert_json_keys( my $content = $event->{content}, qw( membership ));
+
+            return unless $content->{membership} eq "leave";
+
+            return 1;
+         });
+      })->then( sub {
 
          # now /finally/ we can test what we came here for. Both remote users update their
          # device keys, and we check that we only get an update for one of them.

--- a/tests/41end-to-end-keys/06-device-lists.pl
+++ b/tests/41end-to-end-keys/06-device-lists.pl
@@ -410,7 +410,6 @@ test "If remote user leaves room we no longer receive device updates",
             return unless $event->{type} eq "m.room.member";
             return unless $event->{sender} eq $remote_leaver->user_id;
 
-
             assert_json_keys( my $content = $event->{content}, qw( membership ));
 
             return unless $content->{membership} eq "leave";
@@ -418,7 +417,6 @@ test "If remote user leaves room we no longer receive device updates",
             return 1;
          });
       })->then( sub {
-
          # now /finally/ we can test what we came here for. Both remote users update their
          # device keys, and we check that we only get an update for one of them.
          matrix_put_e2e_keys( $remote_leaver, device_keys => { keys => { x => "x2" } } )


### PR DESCRIPTION
Hopefully fixes #1036, but I was unable to reproduce it locally, so :shrug: 

The only race I could think of here is that the creator's HS receives the device list update for the left user while its still processing the leave of that user, but that seems fairly unlikely.