### PR TITLE
Don't send garbage to homeserver in end-to-end-keys tests

### DIFF
--- a/tests/41end-to-end-keys/01-upload-key.pl
+++ b/tests/41end-to-end-keys/01-upload-key.pl
@@ -17,7 +17,7 @@ test "Can upload device keys",
                device_id => $user->device_id,
             },
             one_time_keys => {
-               "my_algorithm:my_id_1", "my+base64+key"
+               "my_algorithm:my_id_1", "KIhHVkAQi8r41aPNql2zTqQsInpFa8XdslQLC8F8BHc"
             }
          }
       )->then( sub {
@@ -163,7 +163,7 @@ sub matrix_put_e2e_keys
       content => {
          device_keys => \%device_keys,
          one_time_keys => {
-            "my_algorithm:my_id_1" => "my+base64+key",
+            "ed25519:test" => "xnuozvb3VBxu2hr9Wc5Xe5pj7hbqyr7djaCANodTRAk",
          }
       }
    );

--- a/tests/41end-to-end-keys/03-one-time-keys.pl
+++ b/tests/41end-to-end-keys/03-one-time-keys.pl
@@ -12,7 +12,7 @@ multi_test "Can claim one time key using POST",
          uri     => "/r0/keys/upload",
          content => {
             one_time_keys => {
-               "test_algorithm:test_id", "test+base64+key"
+               "test_algorithm:test_id", "iDBFAwt4T0ntzaZXwEevrKfmelFUMj8KS6n6kYhBPzU"
             }
          }
       )->SyTest::pass_on_done( "Uploaded one-time keys" )
@@ -43,7 +43,7 @@ multi_test "Can claim one time key using POST",
          my $alice_device_keys = $alice_keys->{$device_id};
          assert_json_keys( $alice_device_keys, "test_algorithm:test_id" );
 
-         "test+base64+key" eq $alice_device_keys->{"test_algorithm:test_id"} or
+         "iDBFAwt4T0ntzaZXwEevrKfmelFUMj8KS6n6kYhBPzU" eq $alice_device_keys->{"test_algorithm:test_id"} or
             die "Unexpected key base64";
 
          pass "Took one time key";

--- a/tests/41end-to-end-keys/05-one-time-key-federation.pl
+++ b/tests/41end-to-end-keys/05-one-time-key-federation.pl
@@ -12,7 +12,7 @@ multi_test "Can claim remote one time key using POST",
          uri     => "/r0/keys/upload",
          content => {
             one_time_keys => {
-               "test_algorithm:test_id", "test+base64+key"
+               "test_algorithm:test_id", "kUuAFk05Ig0RjwDimSYHOXKro8BRB14G0efxVOq73VU"
             }
          }
       )->SyTest::pass_on_done( "Uploaded one-time keys" )
@@ -43,7 +43,7 @@ multi_test "Can claim remote one time key using POST",
          my $alice_device_keys = $alice_keys->{$device_id};
          assert_json_keys( $alice_device_keys, "test_algorithm:test_id" );
 
-         "test+base64+key" eq $alice_device_keys->{"test_algorithm:test_id"} or
+         "kUuAFk05Ig0RjwDimSYHOXKro8BRB14G0efxVOq73VU" eq $alice_device_keys->{"test_algorithm:test_id"} or
             die "Unexpected key base64";
 
          pass "Took one time key";

--- a/tests/41end-to-end-keys/06-device-lists.pl
+++ b/tests/41end-to-end-keys/06-device-lists.pl
@@ -316,7 +316,7 @@ test "If remote user leaves room, changes device and rejoins we see update in sy
       })->then( sub {
          matrix_leave_room_synced( $remote_leaver, $room_id )
       })->then( sub {
-         matrix_put_e2e_keys( $remote_leaver, device_keys => { keys => { x => "x2" } } )
+         matrix_put_e2e_keys( $remote_leaver, device_keys => { keys => { "ed25519:test" => "cmltKURmLTRV86hBT_jh8AFH9RAdz0yAZOfvlBUQqP8" } } )
       })->then( sub {
          # It takes a while for the leave to propagate so lets just hammer this
          # endpoint...
@@ -370,9 +370,9 @@ test "If remote user leaves room we no longer receive device updates",
          sync_until_user_in_device_list( $creator, $remote_leaver );
       })->then( sub {
          # there must be e2e keys for the devices, otherwise they don't appear in /query.
-         matrix_put_e2e_keys( $remote2, device_keys => { keys => { x => "x" } } );
+         matrix_put_e2e_keys( $remote2, device_keys => { keys => { "ed25519:test" => "aI2BUUeIQ0Y8T7Tv7jJh2ADagpoWdtHf4XipFPvjXI8" } } );
       })->then( sub {
-         matrix_put_e2e_keys( $remote_leaver, device_keys => { keys => { x => "y" } } );
+         matrix_put_e2e_keys( $remote_leaver, device_keys => { keys => { "ed25519:test" => "j9eIBhARnZg5vhKzp8zm1A6up1LmSiDoXuDqTTIvkcI" } } );
       })->then( sub {
          sync_until_user_in_device_list( $creator, $remote_leaver );
 
@@ -391,7 +391,7 @@ test "If remote user leaves room we no longer receive device updates",
             log_if_fail "keys after remote_leaver uploaded keys", $body;
             assert_json_keys( $body, qw( device_keys ));
             my $update = $body->{device_keys}->{ $remote_leaver->user_id }->{ $remote_leaver->device_id };
-            assert_eq( $update->{keys}{x}, "y" );
+            assert_eq( $update->{keys}{"ed25519:test"}, "j9eIBhARnZg5vhKzp8zm1A6up1LmSiDoXuDqTTIvkcI" );
             Future->done;
          });
       })->then( sub {
@@ -403,10 +403,10 @@ test "If remote user leaves room we no longer receive device updates",
 
          # now /finally/ we can test what we came here for. Both remote users update their
          # device keys, and we check that we only get an update for one of them.
-         matrix_put_e2e_keys( $remote_leaver, device_keys => { keys => { x => "x2" } } )
+         matrix_put_e2e_keys( $remote_leaver, device_keys => { keys => { "ed25519:test" => "2NNgAXoqO06lZc3FOOKj76daZT8CmbHmmJKr29Jv85g" } } )
       })->then( sub {
          log_if_fail "Remote_leaver " . $remote_leaver->user_id . " updated keys";
-         matrix_put_e2e_keys( $remote2, device_keys => { keys => { x => "x2" } } )
+         matrix_put_e2e_keys( $remote2, device_keys => { keys => { "ed25519:test" => "c3op6BJi8aUnDGA541Q6TbTPmbiy1GqGv-zzXDQM9Us" } } )
       })->then( sub {
          log_if_fail "Remote user 2 " . $remote2->user_id . " updated keys";
 
@@ -578,7 +578,7 @@ test "If remote user leaves room, changes device and rejoins we see update in /k
 
          matrix_leave_room_synced( $remote_leaver, $room_id )
       })->then( sub {
-         matrix_put_e2e_keys( $remote_leaver, device_keys => { keys => { x => "x2" } } )
+         matrix_put_e2e_keys( $remote_leaver, device_keys => { keys => { "ed25519:test" => "72Fyh13X3itrbsWXHGQkqozmasfNRE6AEQPGbQFIykc" } } )
       })->then( sub {
          # It takes a while for the leave to propagate so lets just hammer this
          # endpoint...
@@ -754,7 +754,7 @@ test "If user leaves room, remote user changes device and rejoins we see update 
 
          matrix_leave_room_synced( $creator, $room_id )
       })->then( sub {
-         matrix_put_e2e_keys( $remote_user, device_keys => { keys => { x => "x2" } } )
+         matrix_put_e2e_keys( $remote_user, device_keys => { keys => { "ed25519:test" => "jAV9juztEM6Fjda60eut1GYyaP6QFlkfCd609celbwo" } } )
       })->then( sub {
          # It takes a while for the leave to propagate so lets just hammer this
          # endpoint...


### PR DESCRIPTION
This updates the `end-to-end-keys` tests to send real base64 and things that look actually like key IDs.