### PR TITLE
Mark eventstream tests as using a deprecated endpoint.

### DIFF
--- a/tests/30rooms/09eventstream.pl
+++ b/tests/30rooms/09eventstream.pl
@@ -2,6 +2,7 @@ use Future::Utils qw( repeat try_repeat );
 
 
 multi_test "Check that event streams started after a client joined a room work (SYT-1)",
+   deprecated_endpoints => 1,
    requires => [ local_user_fixture(),
       qw( can_create_private_room can_send_message )
    ],
@@ -43,6 +44,7 @@ multi_test "Check that event streams started after a client joined a room work (
 
 
 test "Event stream catches up fully after many messages",
+   deprecated_endpoints => 1,
    requires => [ local_user_fixture(),
                  qw( can_send_message )],
 


### PR DESCRIPTION
Signed-off-by: Kurt Roeckx <kurt@roeckx.be>