### PR TITLE
Switch tests from using the deprecated /events to /sync

### DIFF
--- a/tests/40presence.pl
+++ b/tests/40presence.pl
@@ -19,7 +19,7 @@ test "Presence changes are reported to local room members",
                  qw( can_set_presence )],
 
    do => sub {
-      my ( $senduser, $local_user, undef ) = @_;
+      my ( $senduser, $local_user, $room_id ) = @_;
 
       matrix_set_presence_status( $senduser, "online",
          status_msg => $status_msg,
@@ -27,7 +27,7 @@ test "Presence changes are reported to local room members",
          Future->needs_all( map {
             my $recvuser = $_;
 
-            await_event_for( $recvuser, filter => sub {
+            await_sync_timeline_contains( $recvuser, $room_id, filter => sub {
                my ( $event ) = @_;
                return unless $event->{type} eq "m.presence";
 

--- a/tests/90jira/SYN-442.pl
+++ b/tests/90jira/SYN-442.pl
@@ -22,7 +22,7 @@ multi_test "Test that we can be reinvited to a room we created",
             ->SyTest::pass_on_done( "User A invited user B" )
       })->then( sub {
 
-         await_event_for( $user_2, filter => sub {
+         await_sync_timeline_contains( $user_2, $room_id, filter => sub {
             my ( $event ) = @_;
             return 0 unless $event->{type} eq "m.room.member";
             return 0 unless $event->{content}->{membership} eq "invite";


### PR DESCRIPTION
Signed-off-by: Kurt Roeckx <kurt@roeckx.be>