### PR TITLE
Move from Buildkite to GitHub Actions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -16,47 +16,38 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "Synapse - :python: 3.6 / SQLite / Monolith"
-            homeserver-implementation: synapse
+          - homeserver-implementation: synapse
             sytest-tag: bionic
 
-          - name: "Synapse - :python: 3.6 / :postgres: 10 / Monolith"
-            homeserver-implementation: synapse
+          - homeserver-implementation: synapse
             sytest-tag: bionic
             postgres: postgres
 
-          - name: "Synapse - :python: 3.6 / :postgres: 10 / Workers"
-            homeserver-implementation: synapse
+          - homeserver-implementation: synapse
             sytest-tag: bionic
             postgres: postgres
             synapse-workers: workers
 
-          - name: "Synapse - :python: 3.9 / :postgres: 13 / Monolith"
-            homeserver-implementation: synapse
+          - homeserver-implementation: synapse
             sytest-tag: testing
             postgres: postgres
 
-          - name: "Synapse - :python: 3.9 / :postgres: 13 / Workers"
-            homeserver-implementation: synapse
+          - homeserver-implementation: synapse
             sytest-tag: testing
             postgres: postgres
             synapse-workers: workers
 
-          - name: "Dendrite - :postgres:"
-            homeserver-implementation: dendrite
+          - homeserver-implementation: dendrite
             postgres: postgres
 
-          - name: "Dendrite - :postgres: / full HTTP APIs"
-            homeserver-implementation: dendrite
+          - homeserver-implementation: dendrite
             postgres: postgres
-            denrite-full-http: yes
+            denrite-full-http: full-http
 
-          - name: "Dendrite - :sqlite:"
-            homeserver-implementation: dendrite
+          - homeserver-implementation: dendrite
 
-          - name: "Dendrite - :sqlite: / full HTTP APIs"
-            homeserver-implementation: dendrite
-            denrite-full-http: yes
+          - homeserver-implementation: dendrite
+            denrite-full-http: full-http
 
     container:
       image: matrixdotorg/sytest-${{ matrix.homeserver-implementation }}:${{ matrix.sytest-tag }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,7 +1,7 @@
 name: Run sytest
 on:
   push:
-    branches: ["develop", "release-*"]
+    branches: ["develop", "release-*", "github-actions"]
   pull_request:
 
 concurrency:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -50,11 +50,12 @@ jobs:
             denrite-full-http: full-http
 
     container:
-      image: matrixdotorg/sytest-${{ matrix.homeserver-implementation }}:${{ matrix.sytest-tag }}
+      # The colon is icky. Better way? Could just include the image explicitly?
+      image: matrixdotorg/sytest-${{ matrix.homeserver-implementation }}${{ matrix.sytest-tag && ":" }}${{ matrix.sytest-tag }}
       volumes:
         # TODO PWD mounted as /sytest was originally mounted as readonly. Could pass -v directly?
         - ${{ github.workspace }}:/sytest
-        - ./logs:/logs
+        - ${{ github.workspace }}/logs:/logs
       env:
         POSTGRES: ${{ matrix.postgres && 1 }}
         WORKERS: ${{ matrix.synapse-workers && 1 }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -51,7 +51,7 @@ jobs:
 
     container:
       # The colon is icky. Better way? Could just include the image explicitly?
-      image: matrixdotorg/sytest-${{ matrix.homeserver-implementation }}${{ matrix.sytest-tag && ":" }}${{ matrix.sytest-tag }}
+      image: matrixdotorg/sytest-${{ matrix.homeserver-implementation }}${{ matrix.sytest-tag && ':' }}${{ matrix.sytest-tag }}
       volumes:
         # TODO PWD mounted as /sytest was originally mounted as readonly. Could pass -v directly?
         - ${{ github.workspace }}:/sytest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,0 +1,32 @@
+name: Run sytest
+on:
+  push:
+    branches: ["develop", "release-*"]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sytest:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - sytest-tag: bionic
+
+    container:
+      image: matrixdotorg/sytest-${{ matrix.sytest-tag }}
+      volumes:
+        - ${{ github.workspace }}:/src
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: TODO Prepare test blacklist
+      - name: Run bootstrap script
+        run: bash /bootstrap.sh synapse
+      - name: TODO upload artifacts
+      - name: TODO annotate logs

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -17,10 +17,10 @@ jobs:
       matrix:
         include:
           - homeserver-implementation: synapse
-          - sytest-tag: bionic
+            sytest-tag: bionic
 
     container:
-      image: matrixdotorg/sytest-${{ matrix.sytest-tag }}
+      image: matrixdotorg/sytest-${{ matrix.homeserver-implementation }}:${{ matrix.sytest-tag }}
       volumes:
         - ${{ github.workspace }}:/src
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run sytest
         working-directory: /sytest
-        run: bash /bootstrap.sh ${{ matrix.homeserver-implementation }}
+        run: bash -xe /bootstrap.sh ${{ matrix.homeserver-implementation }}
       - name: Summarise results.tap
         if: ${{ always() }}
         run:  /sytest/scripts/tap_to_gha.pl /logs/results.tap

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -16,24 +16,65 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - homeserver-implementation: synapse
+          - name: "Synapse - :python: 3.6 / SQLite / Monolith"
+            homeserver-implementation: synapse
             sytest-tag: bionic
+
+          - name: "Synapse - :python: 3.6 / :postgres: 10 / Monolith"
+            homeserver-implementation: synapse
+            sytest-tag: bionic
+            postgres: postgres
+
+          - name: "Synapse - :python: 3.6 / :postgres: 10 / Workers"
+            homeserver-implementation: synapse
+            sytest-tag: bionic
+            postgres: postgres
+            synapse-workers: workers
+
+          - name: "Synapse - :python: 3.9 / :postgres: 13 / Monolith"
+            homeserver-implementation: synapse
+            sytest-tag: testing
+            postgres: postgres
+
+          - name: "Synapse - :python: 3.9 / :postgres: 13 / Workers"
+            homeserver-implementation: synapse
+            sytest-tag: testing
+            postgres: postgres
+            synapse-workers: workers
+
+          - name: "Dendrite - :postgres:"
+            homeserver-implementation: dendrite
+            postgres: postgres
+
+          - name: "Dendrite - :postgres: / full HTTP APIs"
+            homeserver-implementation: dendrite
+            postgres: postgres
+            denrite-full-http: yes
+
+          - name: "Dendrite - :sqlite:"
+            homeserver-implementation: dendrite
+
+          - name: "Dendrite - :sqlite: / full HTTP APIs"
+            homeserver-implementation: dendrite
+            denrite-full-http: yes
 
     container:
       image: matrixdotorg/sytest-${{ matrix.homeserver-implementation }}:${{ matrix.sytest-tag }}
       volumes:
         - ${{ github.workspace }}:/src
+      env:
+        POSTGRES: ${{ matrix.postgres && 1 }}
+        WORKERS: ${{ matrix.synapse-workers && 1 }}
+        BLACKLIST: ${{ (matrix.synapse-workers && "synapse-blacklist-with-workers") || "synapse-blacklist" }}
+        API: ${{ matrix.dendrite-full-http && 1 }}
 
     steps:
       - uses: actions/checkout@v2
-      - name: TODO Prepare test blacklist
-        run: "false"
       - name: Run sytest
         run: bash /bootstrap.sh ${{ matrix.homeserver-implementation }}
       - name: Summarise results.tap
         if: ${{ always() }}
-        run: "false"
-#        run: /sytest/scripts/tap_to_gha.pl /logs/results.tap
+        run:  /sytest/scripts/tap_to_gha.pl /logs/results.tap
       - name: TODO upload artifacts
         run: "false"
       - name: TODO annotate logs

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -53,6 +53,8 @@ jobs:
       image: matrixdotorg/sytest-${{ matrix.homeserver-implementation }}:${{ matrix.sytest-tag }}
       volumes:
         - ${{ github.workspace }}:/src
+        # TODO PWD mounted as /sytest was originally mounted as readonly. Could pass -v directly
+        - ".:/sytest"
       env:
         POSTGRES: ${{ matrix.postgres && 1 }}
         WORKERS: ${{ matrix.synapse-workers && 1 }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -19,35 +19,35 @@ jobs:
           - homeserver-implementation: synapse
             sytest-tag: bionic
 
-          - homeserver-implementation: synapse
-            sytest-tag: bionic
-            postgres: postgres
-
-          - homeserver-implementation: synapse
-            sytest-tag: bionic
-            postgres: postgres
-            synapse-workers: workers
-
-          - homeserver-implementation: synapse
-            sytest-tag: testing
-            postgres: postgres
-
-          - homeserver-implementation: synapse
-            sytest-tag: testing
-            postgres: postgres
-            synapse-workers: workers
-
-          - homeserver-implementation: dendrite
-            postgres: postgres
-
-          - homeserver-implementation: dendrite
-            postgres: postgres
-            denrite-full-http: full-http
-
-          - homeserver-implementation: dendrite
-
-          - homeserver-implementation: dendrite
-            denrite-full-http: full-http
+#          - homeserver-implementation: synapse
+#            sytest-tag: bionic
+#            postgres: postgres
+#
+#          - homeserver-implementation: synapse
+#            sytest-tag: bionic
+#            postgres: postgres
+#            synapse-workers: workers
+#
+#          - homeserver-implementation: synapse
+#            sytest-tag: testing
+#            postgres: postgres
+#
+#          - homeserver-implementation: synapse
+#            sytest-tag: testing
+#            postgres: postgres
+#            synapse-workers: workers
+#
+#          - homeserver-implementation: dendrite
+#            postgres: postgres
+#
+#          - homeserver-implementation: dendrite
+#            postgres: postgres
+#            denrite-full-http: full-http
+#
+#          - homeserver-implementation: dendrite
+#
+#          - homeserver-implementation: dendrite
+#            denrite-full-http: full-http
 
     container:
       # The colon is icky. Better way? Could just include the image explicitly?
@@ -68,7 +68,7 @@ jobs:
         working-directory: /sytest
         run: bash -xe /bootstrap.sh ${{ matrix.homeserver-implementation }}
       - name: Summarise results.tap
-        if: ${{ always() }}
+#        if: ${{ always() }}
         run:  /sytest/scripts/tap_to_gha.pl /logs/results.tap
       - name: TODO upload artifacts
         run: "false"

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -16,6 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - homeserver-implementation: synapse
           - sytest-tag: bionic
 
     container:
@@ -26,7 +27,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: TODO Prepare test blacklist
-      - name: Run bootstrap script
-        run: bash /bootstrap.sh synapse
+        run: "false"
+      - name: Run sytest
+        run: bash /bootstrap.sh ${{ matrix.homeserver-implementation }}
+      - name: Summarise results.tap
+        if: ${{ always() }}
+        run: "false"
+#        run: /sytest/scripts/tap_to_gha.pl /logs/results.tap
       - name: TODO upload artifacts
+        run: "false"
       - name: TODO annotate logs
+        run: "false"

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -62,6 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run sytest
+        working-directory: /sytest
         run: bash /bootstrap.sh ${{ matrix.homeserver-implementation }}
       - name: Summarise results.tap
         if: ${{ always() }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -65,7 +65,7 @@ jobs:
       env:
         POSTGRES: ${{ matrix.postgres && 1 }}
         WORKERS: ${{ matrix.synapse-workers && 1 }}
-        BLACKLIST: ${{ (matrix.synapse-workers && "synapse-blacklist-with-workers") || "synapse-blacklist" }}
+        BLACKLIST: ${{ (matrix.synapse-workers && 'synapse-blacklist-with-workers') || 'synapse-blacklist' }}
         API: ${{ matrix.dendrite-full-http && 1 }}
 
     steps:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -52,9 +52,9 @@ jobs:
     container:
       image: matrixdotorg/sytest-${{ matrix.homeserver-implementation }}:${{ matrix.sytest-tag }}
       volumes:
-        - ${{ github.workspace }}:/src
-        # TODO PWD mounted as /sytest was originally mounted as readonly. Could pass -v directly
-        - ".:/sytest"
+        # TODO PWD mounted as /sytest was originally mounted as readonly. Could pass -v directly?
+        - ${{ github.workspace }}:/sytest
+        - ./logs:/logs
       env:
         POSTGRES: ${{ matrix.postgres && 1 }}
         WORKERS: ${{ matrix.synapse-workers && 1 }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   synapse:
-    name: Synapse - ${{ matrix.job-name }}
+    name: Synapse - ${{ matrix.label }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -84,19 +84,29 @@ jobs:
         uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
-          name: Sytest Logs - ${{ job.status }} - (Synapse, ${{ join(matrix.*, ', ') }})
+          name: Sytest Logs - ${{ job.status }} - (Synapse, ${{ matrix.label }})
           path: |
             /logs/results.tap
             /logs/**/*.log*
 
   dendrite:
     runs-on: ubuntu-latest
-    name: Dendrite - ${{ matrix.db }} ${{ (matrix.api == 'full-http') && 'full HTTP APIs' }}
+    name: Dendrite - ${{ matrix.label }}
     strategy:
       fail-fast: false
       matrix:
-        db: ["sqlite", "postgres"]
-        api: ["not-full-http", "full-http"]
+        include:
+          - label: "SQLite"
+
+          - label: "SQLite / full HTTP APIs"
+            api: full-http
+
+          - label: "Postgres"
+            postgres: postgres
+
+          - label: "Postgres / full HTTP APIs"
+            postgres: postgres
+            api: full-http
 
     container:
       image: matrixdotorg/sytest-dendrite
@@ -107,8 +117,8 @@ jobs:
         # synapse_sytest.sh expects a synapse checkout at /src
         - ${{ github.workspace }}/dendrite:/src
       env:
-        POSTGRES: ${{ matrix.db == 'postgres' }}
-        API: ${{ matrix.api == 'full-http' }}
+        POSTGRES: ${{ matrix.postgres && 1 }}
+        API: ${{ matrix.api && 1 }}
 
     steps:
       - name: Checkout sytest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -51,9 +51,8 @@ jobs:
         - ${{ github.workspace }}/synapse:/src
       env:
         POSTGRES: ${{ matrix.postgres && 1 }}
-        WORKERS: ${{ matrix.synapse-workers && 1 }}
+        WORKERS: ${{ matrix.workers && 1 }}
         BLACKLIST: ${{ (matrix.workers && 'synapse-blacklist-with-workers') || 'sytest-blacklist' }}
-        API: ${{ matrix.dendrite-full-http && 1 }}
 
     steps:
       - name: Checkout sytest
@@ -73,7 +72,11 @@ jobs:
         run: cat /src/sytest-blacklist /src/.ci/worker-blacklist > /src/synapse-blacklist-with-workers
 
       - name: Run sytest
-        run: bash -xe /bootstrap.sh synapse
+        run: |
+          echo POSTGRES=${POSTGRES:-<NOT SET>}
+          echo WORKERS=${WORKERS:-<NOT SET>}
+          echo BLACKLIST=${BLACKLIST:-<NOT SET>}
+          bash -xe /bootstrap.sh synapse
 
       - name: Summarise results.tap
         # Use always() to run this step even if previous ones failed.
@@ -134,7 +137,10 @@ jobs:
             | tar -xz --strip-components=1 -C /src/
 
       - name: Run sytest
-        run: bash -xe /bootstrap.sh dendrite
+        run: |
+          echo POSTGRES=${POSTGRES:-<NOT SET>}
+          echo API=${API:-<NOT SET>}
+          bash -xe /bootstrap.sh dendrite
 
       - name: Summarise results.tap
         if: ${{ always() }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -20,23 +20,23 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - label: Python 3.6 / SQLite / Monolith
+          - label: Py3.6 / SQLite / Monolith
             sytest-tag: bionic
 
-          - label: Python 3.6 / Postgres 10 / Monolith
+          - label: Py3.6 / PGSQL 10 / Monolith
             sytest-tag: bionic
             postgres: postgres
 
-          - label: Python 3.6 / Postgres 10 / Workers
+          - label: Py3.6 / PGSQL10 / Workers
             sytest-tag: bionic
             postgres: postgres
             workers: workers
 
-          - label: Python 3.9 / Postgres 13 / Monolith
+          - label: Py3.9 / PGSQL13 / Monolith
             sytest-tag: testing
             postgres: postgres
 
-          - label: Python 3.9 / Postgres 13 / Workers
+          - label: Py3.9 / PGSQL13 / Workers
             sytest-tag: testing
             postgres: postgres
             workers: workers

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -56,7 +56,8 @@ jobs:
         shell: bash
         run: |
           BRANCH=${GITHUB_REF#refs/heads/}
-          (wget -O - https://github.com/matrix-org/synapse/archive/$BRANCH.tar.gz || wget -O - https://github.com/matrix-org/synapse/archive/master.tar.gz) | tar -xz --strip-components=1 -C /src/"
+          (wget -O - https://github.com/matrix-org/synapse/archive/$BRANCH.tar.gz || wget -O - https://github.com/matrix-org/synapse/archive/master.tar.gz) \
+            | tar -xz --strip-components=1 -C /src/
 
       - name: Run sytest
         run: bash -xe /bootstrap.sh synapse

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -67,7 +67,7 @@ jobs:
           (wget -O - https://github.com/matrix-org/synapse/archive/$BRANCH.tar.gz || wget -O - https://github.com/matrix-org/synapse/archive/develop.tar.gz) \
             | tar -xz --strip-components=1 -C /src/
 
-      - name: Prepare blacklist file
+      - name: Prepare blacklist file for running with workers
         if: ${{ matrix.workers }}
         run: cat /src/sytest-blacklist /src/.ci/worker-blacklist > /src/synapse-blacklist-with-workers
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -106,7 +106,7 @@ jobs:
         with:
           path: sytest
 
-      - name: Fetch corresponding synapse branch
+      - name: Fetch corresponding dendrite branch
         shell: bash
         run: |
           BRANCH=${GITHUB_REF#refs/heads/}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -52,31 +52,11 @@ jobs:
         with:
           path: sytest
 
-      - name: Select corresponding synapse branch
-        id: select_synapse_branch
+      - name: Fetch corresponding synapse branch
         shell: bash
         run: |
           BRANCH=${GITHUB_REF#refs/heads/}
-          STATUS_CODE=$(curl -X GET \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            -o /dev/null -w "%{http_code}"
-            https://api.github.com/repos/matrix-org/synapse/branches/$BRANCH
-          )
-          if [ STATUS_CODE == 200 ]; then
-            echo ::set-output name=branch:$BRANCH
-          else
-            echo ::set-output name=branch:develop
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout synapse ${{ steps.select_synapse_branch.outputs.branch }} branch
-        uses: actions/checkout@v2
-        with:
-          repository: matrix-org/synapse
-          path: synapse
-          ref: ${{ steps.select_synapse_branch.outputs.branch }}
+          (wget -O - https://github.com/matrix-org/synapse/archive/$BRANCH.tar.gz || wget -O - https://github.com/matrix-org/synapse/archive/master.tar.gz) | tar -xz --strip-components=1 -C /src/"
 
       - name: Run sytest
         run: bash -xe /bootstrap.sh synapse

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -51,25 +51,37 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: sytest
-#      # From https://stackoverflow.com/a/58035262 . Surprising that GHA doesn't provide this by default?
-#      - name: Extract branch name
-#        shell: bash
-#        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-#        id: extract_branch
-      # TODO get this to use our branch, if that exists in synapse
-      # TODO synapse has a similar need when its tests.yml checks out complement.
-      # Could we turn "Checkout complement" into a new GitHub Action?
-      - name: Checkout synapse
+
+      # From https://stackoverflow.com/a/58035262 . Surprising that GHA doesn't provide this by default?
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+
+      - name: Try to checkout synapse `${{ steps.extract_branch.outputs.branch }}` branch
+        id: checkout_synapse_branch
+        uses: actions/checkout@v2
+        with:
+          repository: matrix-org/synapse
+          path: synapse
+          ref: ${{ steps.extract_branch.outputs.branch }}
+        continue-on-error: true
+
+      - name: Checkout synapse `develop` branch
+        if: ${{ steps.checkout_synapse_branch.outcome != 'success' }}
         uses: actions/checkout@v2
         with:
           repository: matrix-org/synapse
           path: synapse
           ref: develop
+
       - name: Run sytest
         run: bash -xe /bootstrap.sh synapse
+
       - name: Summarise results.tap
-#        if: ${{ always() }}
+        if: ${{ always() }}
         run:  /sytest/scripts/tap_to_gha.pl /logs/results.tap
+
       - name: Upload SyTest logs
         uses: actions/upload-artifact@v2
         if: ${{ always() }}
@@ -78,6 +90,7 @@ jobs:
           path: |
             /logs/results.tap
             /logs/**/*.log*
+
       - name: TODO annotate logs
         run: "false"
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -56,7 +56,7 @@ jobs:
         shell: bash
         run: |
           BRANCH=${GITHUB_REF#refs/heads/}
-          (wget -O - https://github.com/matrix-org/synapse/archive/$BRANCH.tar.gz || wget -O - https://github.com/matrix-org/synapse/archive/master.tar.gz) \
+          (wget -O - https://github.com/matrix-org/synapse/archive/$BRANCH.tar.gz || wget -O - https://github.com/matrix-org/synapse/archive/develop.tar.gz) \
             | tar -xz --strip-components=1 -C /src/
 
       - name: Run sytest
@@ -102,38 +102,12 @@ jobs:
         with:
           path: sytest
 
-      # From https://stackoverflow.com/a/58035262
-      - name: Extract branch name
-        shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        id: extract_branch
-
-      - name: Find dendrite ${{ steps.extract_branch.outputs.branch }} branch
-        id: find_dendrite_branch
-        uses: octokit/request-action@v2.1.0
-        with:
-          route: GET /repos/matrix-org/dendrite/branches/${{ steps.extract_branch.outputs.branch }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true
-
-      - name: Select dendrite branch to checkout
-        id: select_dendrite_branch
+      - name: Fetch corresponding synapse branch
         shell: bash
         run: |
-          if [ ${{ steps.find_dendrite_branch.outcome }} == "success" ]; then
-            branch=${{ steps.extract_branch.outputs.branch }}
-          else
-            branch=master
-          fi
-          echo "::set-output name=branch::$branch"
-
-      - name: Checkout dendrite ${{ steps.select_dendrite_branch.outputs.branch }} branch
-        uses: actions/checkout@v2
-        with:
-          repository: matrix-org/dendrite
-          path: dendrite
-          ref: ${{ steps.select_dendrite_branch.outputs.branch }}
+          BRANCH=${GITHUB_REF#refs/heads/}
+          (wget -O - https://github.com/matrix-org/dendrite/archive/$BRANCH.tar.gz || wget -O - https://github.com/matrix-org/dendrite/archive/master.tar.gz) \
+            | tar -xz --strip-components=1 -C /src/
 
       - name: Run sytest
         run: bash -xe /bootstrap.sh dendrite

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -4,6 +4,9 @@ on:
     branches: ["develop", "release-*"]
   pull_request:
 
+# Only run this action once per pull request/branch; restart if a new commit arrives.
+# C.f. https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
+# and https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -67,6 +70,7 @@ jobs:
         run: bash -xe /bootstrap.sh synapse
 
       - name: Summarise results.tap
+        # Use always() to run this step even if previous ones failed.
         if: ${{ always() }}
         run:  /sytest/scripts/tap_to_gha.pl /logs/results.tap
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -58,7 +58,7 @@ jobs:
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
 
-      - name: Find synapse `${{ steps.extract_branch.outputs.branch }}` branch
+      - name: Find synapse ${{ steps.extract_branch.outputs.branch }} branch
         id: find_synapse_branch
         uses: octokit/request-action@v2.1.0
         with:
@@ -77,7 +77,7 @@ jobs:
           fi
           echo "::set-output name=branch::$branch"
 
-      - name: Checkout synapse `${{ steps.select_synapse_branch.outputs.branch }}` branch
+      - name: Checkout synapse ${{ steps.select_synapse_branch.outputs.branch }} branch
         uses: actions/checkout@v2
         with:
           repository: matrix-org/synapse

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -18,19 +18,19 @@ jobs:
         include:
           - sytest-tag: bionic
 
-#          - sytest-tag: bionic
-#            postgres: postgres
-#
-#          - sytest-tag: bionic
-#            postgres: postgres
-#            workers: workers
-#
-#          - sytest-tag: testing
-#            postgres: postgres
-#
-#          - sytest-tag: testing
-#            postgres: postgres
-#            workers: workers
+          - sytest-tag: bionic
+            postgres: postgres
+
+          - sytest-tag: bionic
+            postgres: postgres
+            workers: workers
+
+          - sytest-tag: testing
+            postgres: postgres
+
+          - sytest-tag: testing
+            postgres: postgres
+            workers: workers
 
     container:
       image: matrixdotorg/sytest-synapse:${{ matrix.sytest-tag }}
@@ -56,12 +56,14 @@ jobs:
 #        shell: bash
 #        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
 #        id: extract_branch
+      # TODO get this to use our branch, if that exists in synapse
+      # TODO synapse has a similar need when its tests.yml checks out complement.
+      # Could we turn "Checkout complement" into a new GitHub Action?
       - name: Checkout synapse
         uses: actions/checkout@v2
         with:
           repository: matrix-org/synapse
           path: synapse
-          # TODO get this to use our branch, if that exists in synapse
           ref: develop
       - name: Run sytest
         run: bash -xe /bootstrap.sh synapse

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -13,25 +13,31 @@ concurrency:
 
 jobs:
   synapse:
+    name: Synapse - ${{ matrix.job-name }}
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
         include:
-          - sytest-tag: bionic
+          - label: Python 3.6 / SQLite / Monolith
+            sytest-tag: bionic
 
-          - sytest-tag: bionic
+          - label: Python 3.6 / Postgres 10 / Monolith
+            sytest-tag: bionic
             postgres: postgres
 
-          - sytest-tag: bionic
+          - label: Python 3.6 / Postgres 10 / Workers
+            sytest-tag: bionic
             postgres: postgres
             workers: workers
 
-          - sytest-tag: testing
+          - label: Python 3.9 / Postgres 13 / Monolith
+            sytest-tag: testing
             postgres: postgres
 
-          - sytest-tag: testing
+          - label: Python 3.9 / Postgres 13 / Workers
+            sytest-tag: testing
             postgres: postgres
             workers: workers
 
@@ -85,7 +91,7 @@ jobs:
 
   dendrite:
     runs-on: ubuntu-latest
-
+    name: Dendrite - ${{ matrix.db }} ${{ (matrix.api == 'full-http') && 'full HTTP APIs' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -43,7 +43,7 @@ jobs:
       env:
         POSTGRES: ${{ matrix.postgres && 1 }}
         WORKERS: ${{ matrix.synapse-workers && 1 }}
-        BLACKLIST: ${{ (matrix.workers && '.ci/worker-blacklist') || 'sytest-blacklist' }}
+        BLACKLIST: ${{ (matrix.workers && 'synapse-blacklist-with-workers') || 'sytest-blacklist' }}
         API: ${{ matrix.dendrite-full-http && 1 }}
 
     steps:
@@ -58,6 +58,10 @@ jobs:
           BRANCH=${GITHUB_REF#refs/heads/}
           (wget -O - https://github.com/matrix-org/synapse/archive/$BRANCH.tar.gz || wget -O - https://github.com/matrix-org/synapse/archive/develop.tar.gz) \
             | tar -xz --strip-components=1 -C /src/
+
+      - name: Prepare blacklist file
+        if: ${{ matrix.workers }}
+        run: cat /src/sytest-blacklist /src/.ci/worker-blacklist > /src/synapse-blacklist-with-workers
 
       - name: Run sytest
         run: bash -xe /bootstrap.sh synapse

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -18,19 +18,19 @@ jobs:
         include:
           - sytest-tag: bionic
 
-          - sytest-tag: bionic
-            postgres: postgres
-
-          - sytest-tag: bionic
-            postgres: postgres
-            workers: workers
-
-          - sytest-tag: testing
-            postgres: postgres
-
-          - sytest-tag: testing
-            postgres: postgres
-            workers: workers
+#          - sytest-tag: bionic
+#            postgres: postgres
+#
+#          - sytest-tag: bionic
+#            postgres: postgres
+#            workers: workers
+#
+#          - sytest-tag: testing
+#            postgres: postgres
+#
+#          - sytest-tag: testing
+#            postgres: postgres
+#            workers: workers
 
     container:
       image: matrixdotorg/sytest-synapse:${{ matrix.sytest-tag }}
@@ -61,7 +61,7 @@ jobs:
           path: 'src'
       - name: Run sytest
         working-directory: /sytest
-        run: bash -xe /bootstrap.sh ${{ matrix.homeserver-implementation }}
+        run: bash -xe /bootstrap.sh synapse
       - name: Summarise results.tap
 #        if: ${{ always() }}
         run:  /sytest/scripts/tap_to_gha.pl /logs/results.tap

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -53,8 +53,12 @@ jobs:
       # The colon is icky. Better way? Could just include the image explicitly?
       image: matrixdotorg/sytest-${{ matrix.homeserver-implementation }}${{ matrix.sytest-tag && ':' }}${{ matrix.sytest-tag }}
       volumes:
-        # TODO PWD mounted as /sytest was originally mounted as readonly. Could pass -v directly?
+        # Bootstrap script expects the sytest source available at /sytest.
+        # TODO Buildkite mounted /sytest as readonly. Can we do this on GHA? Do we need it?
         - ${{ github.workspace }}:/sytest
+        # synapse_sytest.sh seems to expect it at /src, but the bootstrap script will feed
+        # it /sytest via an environment variable
+        # - ${{ github.workspace }}:/src
         - ${{ github.workspace }}/logs:/logs
       env:
         POSTGRES: ${{ matrix.postgres && 1 }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -62,8 +62,8 @@ jobs:
         id: find_synapse_branch
         uses: octokit/request-action@v2.1.0
         with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           route: GET /repos/matrix-org/synapse/branches/${{ steps.extract_branch.outputs.branch }}
-          ref: ${{ steps.extract_branch.outputs.branch }}
         continue-on-error: true
 
       - name: Select synapse branch to checkout

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -52,28 +52,37 @@ jobs:
         with:
           path: sytest
 
-      # From https://stackoverflow.com/a/58035262 . Surprising that GHA doesn't provide this by default?
+      # From https://stackoverflow.com/a/58035262
       - name: Extract branch name
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
 
-      - name: Try to checkout synapse `${{ steps.extract_branch.outputs.branch }}` branch
-        id: checkout_synapse_branch
-        uses: actions/checkout@v2
+      - name: Find synapse `${{ steps.extract_branch.outputs.branch }}` branch
+        id: find_synapse_branch
+        uses: octokit/request-action@v2.1.0
         with:
-          repository: matrix-org/synapse
-          path: synapse
+          route: GET /repos/matrix-org/synapse/branches/${{ steps.extract_branch.outputs.branch }}
           ref: ${{ steps.extract_branch.outputs.branch }}
         continue-on-error: true
 
-      - name: Checkout synapse `develop` branch
-        if: ${{ steps.checkout_synapse_branch.outcome != 'success' }}
+      - name: Select synapse branch to checkout
+        id: select_synapse_branch
+        shell: bash
+        run: |
+          if [ ${{ steps.find_synapse_branch.outcome }} == "success" ]; then
+            branch=${{ steps.extract_branch.outputs.branch }}
+          else
+            branch=develop
+          fi
+          echo "::set-output name=branch::$branch"
+
+      - name: Checkout synapse `${{ steps.select_synapse_branch.outputs.branch }}` branch
         uses: actions/checkout@v2
         with:
           repository: matrix-org/synapse
           path: synapse
-          ref: develop
+          ref: ${{ steps.select_synapse_branch.outputs.branch }}
 
       - name: Run sytest
         run: bash -xe /bootstrap.sh synapse

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -43,7 +43,7 @@ jobs:
       env:
         POSTGRES: ${{ matrix.postgres && 1 }}
         WORKERS: ${{ matrix.synapse-workers && 1 }}
-        BLACKLIST: ${{ (matrix.workers && 'ci/worker-blacklist') || 'sytest-blacklist' }}
+        BLACKLIST: ${{ (matrix.workers && '.ci/worker-blacklist') || 'sytest-blacklist' }}
         API: ${{ matrix.dendrite-full-http && 1 }}
 
     steps:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -39,7 +39,7 @@ jobs:
         # TODO Buildkite mounted /sytest as readonly. Can we do this on GHA? Do we need it?
         - ${{ github.workspace }}/sytest:/sytest
         # synapse_sytest.sh expects a synapse checkout at /src
-        - ${{ github.workspace }}/synapse:/src
+        - ${{ github.workspace }}/dendrite:/src
       env:
         POSTGRES: ${{ matrix.postgres && 1 }}
         WORKERS: ${{ matrix.synapse-workers && 1 }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  sytest:
+  synapse:
     runs-on: ubuntu-latest
 
     strategy:
@@ -39,7 +39,7 @@ jobs:
         # TODO Buildkite mounted /sytest as readonly. Can we do this on GHA? Do we need it?
         - ${{ github.workspace }}/sytest:/sytest
         # synapse_sytest.sh expects a synapse checkout at /src
-        - ${{ github.workspace }}/dendrite:/src
+        - ${{ github.workspace }}/synapse:/src
       env:
         POSTGRES: ${{ matrix.postgres && 1 }}
         WORKERS: ${{ matrix.synapse-workers && 1 }}
@@ -116,7 +116,7 @@ jobs:
         # TODO Buildkite mounted /sytest as readonly. Can we do this on GHA? Do we need it?
         - ${{ github.workspace }}/sytest:/sytest
         # synapse_sytest.sh expects a synapse checkout at /src
-        - ${{ github.workspace }}/synapse:/src
+        - ${{ github.workspace }}/dendrite:/src
       env:
         POSTGRES: ${{ matrix.db == 'postgres' }}
         API: ${{ matrix.api == 'full-http' }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,7 +1,7 @@
 name: Run sytest
 on:
   push:
-    branches: ["develop", "release-*", "github-actions"]
+    branches: ["develop", "release-*"]
   pull_request:
 
 concurrency:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -52,30 +52,24 @@ jobs:
         with:
           path: sytest
 
-      # From https://stackoverflow.com/a/58035262
-      - name: Extract branch name
-        shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        id: extract_branch
-
-      - name: Find synapse ${{ steps.extract_branch.outputs.branch }} branch
-        id: find_synapse_branch
-        uses: octokit/request-action@v2.1.0
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          route: GET /repos/matrix-org/synapse/branches/${{ steps.extract_branch.outputs.branch }}
-        continue-on-error: true
-
-      - name: Select synapse branch to checkout
+      - name: Select corresponding synapse branch
         id: select_synapse_branch
         shell: bash
         run: |
-          if [ ${{ steps.find_synapse_branch.outcome }} == "success" ]; then
-            branch=${{ steps.extract_branch.outputs.branch }}
+          BRANCH=${GITHUB_REF#refs/heads/}
+          STATUS_CODE=$(curl -X GET \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -o /dev/null -w "%{http_code}"
+            https://api.github.com/repos/matrix-org/synapse/branches/$BRANCH
+          )
+          if [ STATUS_CODE == 200 ]; then
+            echo ::set-output name=branch:$BRANCH
           else
-            branch=develop
+            echo ::set-output name=branch:develop
           fi
-          echo "::set-output name=branch::$branch"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout synapse ${{ steps.select_synapse_branch.outputs.branch }} branch
         uses: actions/checkout@v2
@@ -137,8 +131,9 @@ jobs:
         id: find_dendrite_branch
         uses: octokit/request-action@v2.1.0
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           route: GET /repos/matrix-org/dendrite/branches/${{ steps.extract_branch.outputs.branch }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
       - name: Select dendrite branch to checkout

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -43,7 +43,7 @@ jobs:
       env:
         POSTGRES: ${{ matrix.postgres && 1 }}
         WORKERS: ${{ matrix.synapse-workers && 1 }}
-        BLACKLIST: ${{ (matrix.workers && 'synapse-blacklist-with-workers') || 'synapse-blacklist' }}
+        BLACKLIST: ${{ (matrix.workers && 'ci/worker-blacklist') || 'sytest-blacklist' }}
         API: ${{ matrix.dendrite-full-http && 1 }}
 
     steps:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -48,19 +48,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      # From https://stackoverflow.com/a/58035262 . Surprising that GHA doesn't provide this by default?
-      - name: Extract branch name
-        shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        id: extract_branch
+#      # From https://stackoverflow.com/a/58035262 . Surprising that GHA doesn't provide this by default?
+#      - name: Extract branch name
+#        shell: bash
+#        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+#        id: extract_branch
       - name: Checkout synapse
         uses: actions/checkout@v2
         with:
           repository: matrix-org/synapse
+          # TODO get this to use our branch, if that exists in synapse
           ref: develop
-          path: 'src'
+          path: '/src'
       - name: Run sytest
-        working-directory: /sytest
         run: bash -xe /bootstrap.sh synapse
       - name: Summarise results.tap
 #        if: ${{ always() }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -37,7 +37,7 @@ jobs:
       volumes:
         # bootstrap.sh expects the sytest source available at /sytest.
         # TODO Buildkite mounted /sytest as readonly. Can we do this on GHA? Do we need it?
-        - ${{ github.workspace }}:/sytest
+        - ${{ github.workspace }}/sytest:/sytest
         # synapse_sytest.sh expects a synapse checkout at /src
         - ${{ github.workspace }}/synapse:/src
       env:
@@ -47,7 +47,8 @@ jobs:
         API: ${{ matrix.dendrite-full-http && 1 }}
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout sytest
+        uses: actions/checkout@v2
 #      # From https://stackoverflow.com/a/58035262 . Surprising that GHA doesn't provide this by default?
 #      - name: Extract branch name
 #        shell: bash
@@ -59,7 +60,6 @@ jobs:
           repository: matrix-org/synapse
           # TODO get this to use our branch, if that exists in synapse
           ref: develop
-          path: '/src'
       - name: Run sytest
         run: bash -xe /bootstrap.sh synapse
       - name: Summarise results.tap

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -100,14 +100,77 @@ jobs:
             /logs/results.tap
             /logs/**/*.log*
 
-#          - homeserver-implementation: dendrite
-#            postgres: postgres
-#
-#          - homeserver-implementation: dendrite
-#            postgres: postgres
-#            denrite-full-http: full-http
-#
-#          - homeserver-implementation: dendrite
-#
-#          - homeserver-implementation: dendrite
-#            denrite-full-http: full-http
+  dendrite:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        db: ["sqlite", "postgres"]
+        api: ["not-full-http", "full-http"]
+
+    container:
+      image: matrixdotorg/sytest-dendrite
+      volumes:
+        # bootstrap.sh expects the sytest source available at /sytest.
+        # TODO Buildkite mounted /sytest as readonly. Can we do this on GHA? Do we need it?
+        - ${{ github.workspace }}/sytest:/sytest
+        # synapse_sytest.sh expects a synapse checkout at /src
+        - ${{ github.workspace }}/synapse:/src
+      env:
+        POSTGRES: ${{ matrix.db == 'postgres' }}
+        API: ${{ matrix.api == 'full-http' }}
+
+    steps:
+      - name: Checkout sytest
+        uses: actions/checkout@v2
+        with:
+          path: sytest
+
+      # From https://stackoverflow.com/a/58035262
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+
+      - name: Find dendrite ${{ steps.extract_branch.outputs.branch }} branch
+        id: find_dendrite_branch
+        uses: octokit/request-action@v2.1.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          route: GET /repos/matrix-org/dendrite/branches/${{ steps.extract_branch.outputs.branch }}
+        continue-on-error: true
+
+      - name: Select dendrite branch to checkout
+        id: select_dendrite_branch
+        shell: bash
+        run: |
+          if [ ${{ steps.find_dendrite_branch.outcome }} == "success" ]; then
+            branch=${{ steps.extract_branch.outputs.branch }}
+          else
+            branch=master
+          fi
+          echo "::set-output name=branch::$branch"
+
+      - name: Checkout dendrite ${{ steps.select_dendrite_branch.outputs.branch }} branch
+        uses: actions/checkout@v2
+        with:
+          repository: matrix-org/dendrite
+          path: dendrite
+          ref: ${{ steps.select_dendrite_branch.outputs.branch }}
+
+      - name: Run sytest
+        run: bash -xe /bootstrap.sh dendrite
+
+      - name: Summarise results.tap
+        if: ${{ always() }}
+        run:  /sytest/scripts/tap_to_gha.pl /logs/results.tap
+
+      - name: Upload SyTest logs
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: Sytest Logs - ${{ job.status }} - (Dendrite, ${{ join(matrix.*, ', ') }})
+          path: |
+            /logs/results.tap
+            /logs/**/*.log*

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -56,9 +56,9 @@ jobs:
         # Bootstrap script expects the sytest source available at /sytest.
         # TODO Buildkite mounted /sytest as readonly. Can we do this on GHA? Do we need it?
         - ${{ github.workspace }}:/sytest
-        # synapse_sytest.sh seems to expect it at /src, but the bootstrap script will feed
-        # it /sytest via an environment variable
-        # - ${{ github.workspace }}:/src
+        # But synapse_sytest.sh expects it at /src
+        # TODO could change the bootstrap script to pass SYTEST_SOURCE=/sytest
+        - ${{ github.workspace }}:/src
         - ${{ github.workspace }}/logs:/logs
       env:
         POSTGRES: ${{ matrix.postgres && 1 }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,7 +1,7 @@
 name: Run sytest
 on:
   push:
-    branches: ["develop", "release-*"]
+    branches: ["develop", "release-*", "github-actions"]
   pull_request:
 
 # Only run this action once per pull request/branch; restart if a new commit arrives.

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -100,9 +100,6 @@ jobs:
             /logs/results.tap
             /logs/**/*.log*
 
-      - name: TODO annotate logs
-        run: "false"
-
 #          - homeserver-implementation: dendrite
 #            postgres: postgres
 #

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -68,8 +68,14 @@ jobs:
       - name: Summarise results.tap
 #        if: ${{ always() }}
         run:  /sytest/scripts/tap_to_gha.pl /logs/results.tap
-      - name: TODO upload artifacts
-        run: "false"
+      - name: Upload SyTest logs
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: Sytest Logs - ${{ job.status }} - (Synapse, ${{ join(matrix.*, ', ') }})
+          path: |
+            /logs/results.tap
+            /logs/**/*.log*
       - name: TODO annotate logs
         run: "false"
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Checkout sytest
         uses: actions/checkout@v2
+        with:
+          path: sytest
 #      # From https://stackoverflow.com/a/58035262 . Surprising that GHA doesn't provide this by default?
 #      - name: Extract branch name
 #        shell: bash
@@ -58,6 +60,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: matrix-org/synapse
+          path: synapse
           # TODO get this to use our branch, if that exists in synapse
           ref: develop
       - name: Run sytest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -16,58 +16,49 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - homeserver-implementation: synapse
-            sytest-tag: bionic
+          - sytest-tag: bionic
 
-#          - homeserver-implementation: synapse
-#            sytest-tag: bionic
-#            postgres: postgres
-#
-#          - homeserver-implementation: synapse
-#            sytest-tag: bionic
-#            postgres: postgres
-#            synapse-workers: workers
-#
-#          - homeserver-implementation: synapse
-#            sytest-tag: testing
-#            postgres: postgres
-#
-#          - homeserver-implementation: synapse
-#            sytest-tag: testing
-#            postgres: postgres
-#            synapse-workers: workers
-#
-#          - homeserver-implementation: dendrite
-#            postgres: postgres
-#
-#          - homeserver-implementation: dendrite
-#            postgres: postgres
-#            denrite-full-http: full-http
-#
-#          - homeserver-implementation: dendrite
-#
-#          - homeserver-implementation: dendrite
-#            denrite-full-http: full-http
+          - sytest-tag: bionic
+            postgres: postgres
+
+          - sytest-tag: bionic
+            postgres: postgres
+            workers: workers
+
+          - sytest-tag: testing
+            postgres: postgres
+
+          - sytest-tag: testing
+            postgres: postgres
+            workers: workers
 
     container:
-      # The colon is icky. Better way? Could just include the image explicitly?
-      image: matrixdotorg/sytest-${{ matrix.homeserver-implementation }}${{ matrix.sytest-tag && ':' }}${{ matrix.sytest-tag }}
+      image: matrixdotorg/sytest-synapse:${{ matrix.sytest-tag }}
       volumes:
-        # Bootstrap script expects the sytest source available at /sytest.
+        # bootstrap.sh expects the sytest source available at /sytest.
         # TODO Buildkite mounted /sytest as readonly. Can we do this on GHA? Do we need it?
         - ${{ github.workspace }}:/sytest
-        # But synapse_sytest.sh expects it at /src
-        # TODO could change the bootstrap script to pass SYTEST_SOURCE=/sytest
-        - ${{ github.workspace }}:/src
-        - ${{ github.workspace }}/logs:/logs
+        # synapse_sytest.sh expects a synapse checkout at /src
+        - ${{ github.workspace }}/synapse:/src
       env:
         POSTGRES: ${{ matrix.postgres && 1 }}
         WORKERS: ${{ matrix.synapse-workers && 1 }}
-        BLACKLIST: ${{ (matrix.synapse-workers && 'synapse-blacklist-with-workers') || 'synapse-blacklist' }}
+        BLACKLIST: ${{ (matrix.workers && 'synapse-blacklist-with-workers') || 'synapse-blacklist' }}
         API: ${{ matrix.dendrite-full-http && 1 }}
 
     steps:
       - uses: actions/checkout@v2
+      # From https://stackoverflow.com/a/58035262 . Surprising that GHA doesn't provide this by default?
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+      - name: Checkout synapse
+        uses: actions/checkout@v2
+        with:
+          repository: matrix-org/synapse
+          ref: develop
+          path: 'src'
       - name: Run sytest
         working-directory: /sytest
         run: bash -xe /bootstrap.sh ${{ matrix.homeserver-implementation }}
@@ -78,3 +69,15 @@ jobs:
         run: "false"
       - name: TODO annotate logs
         run: "false"
+
+#          - homeserver-implementation: dendrite
+#            postgres: postgres
+#
+#          - homeserver-implementation: dendrite
+#            postgres: postgres
+#            denrite-full-http: full-http
+#
+#          - homeserver-implementation: dendrite
+#
+#          - homeserver-implementation: dendrite
+#            denrite-full-http: full-http

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -13,30 +13,30 @@ concurrency:
 
 jobs:
   synapse:
-    name: Synapse - ${{ matrix.label }}
+    name: "Synapse: ${{ matrix.label }}"
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
         include:
-          - label: Py3.6 / SQLite / Monolith
+          - label: Py 3.6, SQLite, Monolith
             sytest-tag: bionic
 
-          - label: Py3.6 / PGSQL 10 / Monolith
+          - label: Py 3.6, PG 10, Monolith
             sytest-tag: bionic
             postgres: postgres
 
-          - label: Py3.6 / PGSQL10 / Workers
+          - label: Py 3.6, PG 10, Workers
             sytest-tag: bionic
             postgres: postgres
             workers: workers
 
-          - label: Py3.9 / PGSQL13 / Monolith
+          - label: Py 3.9, PG 13, Monolith
             sytest-tag: testing
             postgres: postgres
 
-          - label: Py3.9 / PGSQL13 / Workers
+          - label: Py 3.9, PG 13, Workers
             sytest-tag: testing
             postgres: postgres
             workers: workers
@@ -91,20 +91,20 @@ jobs:
 
   dendrite:
     runs-on: ubuntu-latest
-    name: Dendrite - ${{ matrix.label }}
+    name: "Dendrite: ${{ matrix.label }}"
     strategy:
       fail-fast: false
       matrix:
         include:
-          - label: "SQLite"
+          - label: SQLite
 
-          - label: "SQLite / full HTTP APIs"
+          - label: SQLite, full HTTP APIs
             api: full-http
 
-          - label: "Postgres"
+          - label: Postgres
             postgres: postgres
 
-          - label: "Postgres / full HTTP APIs"
+          - label: Postgres, full HTTP APIs
             postgres: postgres
             api: full-http
 

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -7,23 +7,17 @@ set -ex
 export SYTEST_TARGET="$1"
 shift
 
-env | sort
+env | sort | cat
 
 if [ -d "/sytest" ]; then
     # If the user has mounted in a SyTest checkout, use that.
+    # This is the case for sytest's GitHub Actions.
     echo "Using local sytests"
 else
     echo "--- Trying to get same-named sytest branch..."
-
-    # Check if we're running under GitHub Actions. If so it can tell us what
-    # Synapse/Dendrite branch we're running
-    if [ -n "$GITHUB_HEAD_REF" ]; then
-        branch_name=$GITHUB_HEAD_REF
-    else
-        # Otherwise, try and find the branch that the Synapse/Dendrite checkout
-        # is using. Fall back to develop if unknown.
-        branch_name="$(git --git-dir=/src/.git symbolic-ref HEAD 2>/dev/null)" || branch_name="develop"
-    fi
+    # Otherwise, try and find the branch that the Synapse/Dendrite checkout
+    # is using. Fall back to develop if unknown.
+    branch_name="$(git --git-dir=/src/.git symbolic-ref HEAD 2>/dev/null)" || branch_name="develop"
 
     if [ "$SYTEST_TARGET" == "dendrite" ] && [ "$branch_name" == "master" ]; then
         # Dendrite uses master as its main branch. If the branch is master, we probably want sytest develop

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -7,16 +7,18 @@ set -ex
 export SYTEST_TARGET="$1"
 shift
 
+env | sort
+
 if [ -d "/sytest" ]; then
     # If the user has mounted in a SyTest checkout, use that.
     echo "Using local sytests"
 else
     echo "--- Trying to get same-named sytest branch..."
 
-    # Check if we're running in buildkite, if so it can tell us what
+    # Check if we're running under GitHub Actions. If so it can tell us what
     # Synapse/Dendrite branch we're running
-    if [ -n "$BUILDKITE_BRANCH" ]; then
-        branch_name=$BUILDKITE_BRANCH
+    if [ -n "$GITHUB_HEAD_REF" ]; then
+        branch_name=$GITHUB_HEAD_REF
     else
         # Otherwise, try and find the branch that the Synapse/Dendrite checkout
         # is using. Fall back to develop if unknown.

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -13,10 +13,14 @@ if [ -d "/sytest" ]; then
     echo "Using local sytests"
 else
     echo "--- Trying to get same-named sytest branch..."
-    # Otherwise, try and find the branch that the Synapse/Dendrite checkout
-    # is using. Fall back to develop if unknown.
-    branch_name="$(git --git-dir=/src/.git symbolic-ref HEAD 2>/dev/null)" || branch_name="develop"
-
+    # Check if we're running in CI. If so it can tell us what
+    # Synapse/Dendrite branch we're running
+    if [ -n "$SYTEST_BRANCH" ]; then
+        branch_name="$SYTEST_BRANCH"
+    else
+        # Otherwise, try and find the branch that the Synapse/Dendrite checkout
+        # is using. Fall back to develop if unknown.
+        branch_name="$(git --git-dir=/src/.git symbolic-ref HEAD 2>/dev/null)" || branch_name="develop"
     if [ "$SYTEST_TARGET" == "dendrite" ] && [ "$branch_name" == "master" ]; then
         # Dendrite uses master as its main branch. If the branch is master, we probably want sytest develop
         branch_name="develop"

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -53,6 +53,7 @@ echo "--- Preparing sytest for ${SYTEST_TARGET}"
 export SYTEST_LIB="/sytest/lib"
 
 if [ -x "/sytest/scripts/${SYTEST_TARGET}_sytest.sh" ]; then
+    echo hello I am really running this line
     export SYNAPSE_SOURCE="/sytest"
     exec "/sytest/scripts/${SYTEST_TARGET}_sytest.sh" "$@"
 

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -7,8 +7,6 @@ set -ex
 export SYTEST_TARGET="$1"
 shift
 
-env | sort | cat
-
 if [ -d "/sytest" ]; then
     # If the user has mounted in a SyTest checkout, use that.
     # This is the case for sytest's GitHub Actions.
@@ -52,20 +50,14 @@ echo "--- Preparing sytest for ${SYTEST_TARGET}"
 
 export SYTEST_LIB="/sytest/lib"
 
-
-echo "DMR 1"
 if [ -x "/sytest/scripts/${SYTEST_TARGET}_sytest.sh" ]; then
-    echo "DMR 2"
-    export SYNAPSE_SOURCE="/sytest"
     exec "/sytest/scripts/${SYTEST_TARGET}_sytest.sh" "$@"
 
 elif [ -x "/sytest/docker/${SYTEST_TARGET}_sytest.sh" ]; then
-    echo "DMR 3"
     # old branches of sytest used to put the sytest running script in the "/docker" directory
     exec "/sytest/docker/${SYTEST_TARGET}_sytest.sh" "$@"
 
 else
-    echo "DMR 4"
     PLUGIN_RUNNER=$(find /sytest/plugins/ -type f -name "${SYTEST_TARGET}_sytest.sh" -print)
     if [ -n PLUGIN_RUNNER ]; then
         exec ${PLUGIN_RUNNER} "$@"

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -53,19 +53,19 @@ echo "--- Preparing sytest for ${SYTEST_TARGET}"
 export SYTEST_LIB="/sytest/lib"
 
 
-echo DMR 1
+echo "DMR 1"
 if [ -x "/sytest/scripts/${SYTEST_TARGET}_sytest.sh" ]; then
-    echo DMR 2
+    echo "DMR 2"
     export SYNAPSE_SOURCE="/sytest"
     exec "/sytest/scripts/${SYTEST_TARGET}_sytest.sh" "$@"
 
 elif [ -x "/sytest/docker/${SYTEST_TARGET}_sytest.sh" ]; then
-    echo DMR 3
+    echo "DMR 3"
     # old branches of sytest used to put the sytest running script in the "/docker" directory
     exec "/sytest/docker/${SYTEST_TARGET}_sytest.sh" "$@"
 
 else
-    echo DMR 4
+    echo "DMR 4"
     PLUGIN_RUNNER=$(find /sytest/plugins/ -type f -name "${SYTEST_TARGET}_sytest.sh" -print)
     if [ -n PLUGIN_RUNNER ]; then
         exec ${PLUGIN_RUNNER} "$@"

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -53,6 +53,7 @@ echo "--- Preparing sytest for ${SYTEST_TARGET}"
 export SYTEST_LIB="/sytest/lib"
 
 if [ -x "/sytest/scripts/${SYTEST_TARGET}_sytest.sh" ]; then
+    export SYNAPSE_SOURCE="/sytest"
     exec "/sytest/scripts/${SYTEST_TARGET}_sytest.sh" "$@"
 
 elif [ -x "/sytest/docker/${SYTEST_TARGET}_sytest.sh" ]; then

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -52,16 +52,20 @@ echo "--- Preparing sytest for ${SYTEST_TARGET}"
 
 export SYTEST_LIB="/sytest/lib"
 
+
+echo DMR 1
 if [ -x "/sytest/scripts/${SYTEST_TARGET}_sytest.sh" ]; then
-    echo hello I am really running this line
+    echo DMR 2
     export SYNAPSE_SOURCE="/sytest"
     exec "/sytest/scripts/${SYTEST_TARGET}_sytest.sh" "$@"
 
 elif [ -x "/sytest/docker/${SYTEST_TARGET}_sytest.sh" ]; then
+    echo DMR 3
     # old branches of sytest used to put the sytest running script in the "/docker" directory
     exec "/sytest/docker/${SYTEST_TARGET}_sytest.sh" "$@"
 
 else
+    echo DMR 4
     PLUGIN_RUNNER=$(find /sytest/plugins/ -type f -name "${SYTEST_TARGET}_sytest.sh" -print)
     if [ -n PLUGIN_RUNNER ]; then
         exec ${PLUGIN_RUNNER} "$@"

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -68,6 +68,7 @@ echo >&2 "--- Copying assets"
 # Copy out the logs
 rsync -r --ignore-missing-args --min-size=1B -av /work/server-0 /work/server-1 /logs --include "*/" --include="*.log.*" --include="*.log" --exclude="*"
 
+# Generate annotate.md This is Buildkite-specific.
 if [ $TEST_STATUS -ne 0 ]; then
     # Build the annotation
     perl /sytest/scripts/format_tap.pl /logs/results.tap "$GITHUB_SHA" >/logs/annotate.md

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -70,7 +70,7 @@ rsync -r --ignore-missing-args --min-size=1B -av /work/server-0 /work/server-1 /
 
 if [ $TEST_STATUS -ne 0 ]; then
     # Build the annotation
-    perl /sytest/scripts/format_tap.pl /logs/results.tap "$BUILDKITE_LABEL" >/logs/annotate.md
+    perl /sytest/scripts/format_tap.pl /logs/results.tap "$GITHUB_SHA" >/logs/annotate.md
     # If show-expected-fail-tests logged something, put it into the annotation
     # Annotations from a failed build show at the top of buildkite, alerting
     # developers quickly as to what needs to change in the black/whitelist.

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -69,9 +69,9 @@ echo >&2 "--- Copying assets"
 rsync -r --ignore-missing-args --min-size=1B -av /work/server-0 /work/server-1 /logs --include "*/" --include="*.log.*" --include="*.log" --exclude="*"
 
 # Generate annotate.md This is Buildkite-specific.
-if [ $TEST_STATUS -ne 0 ]; then
+if [ -n "$BUILDKITE_LABEL" ] && [ $TEST_STATUS -ne 0 ]; then
     # Build the annotation
-    perl /sytest/scripts/format_tap.pl /logs/results.tap "$GITHUB_SHA" >/logs/annotate.md
+    perl /sytest/scripts/format_tap.pl /logs/results.tap "$BUILDKITE_LABEL" >/logs/annotate.md
     # If show-expected-fail-tests logged something, put it into the annotation
     # Annotations from a failed build show at the top of buildkite, alerting
     # developers quickly as to what needs to change in the black/whitelist.

--- a/scripts/synapse_sytest.sh
+++ b/scripts/synapse_sytest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -xe
 #
 # This script is run by the bootstrap.sh script in the docker image.
 #

--- a/scripts/synapse_sytest.sh
+++ b/scripts/synapse_sytest.sh
@@ -2,9 +2,9 @@
 #
 # This script is run by the bootstrap.sh script in the docker image.
 #
-# It expects to find the synapse source in /src, and a virtualenv in /venv.
-# It installs synapse into the virtualenv, configures sytest according to the
-# env vars, and runs sytest.
+# It expects to find the synapse source in $SYNAPSE_SOURCE (default /src),
+# and a virtualenv in /venv. It installs synapse into the virtualenv,
+# configures sytest according to the env vars, and runs sytest.
 #
 
 # Run the sytests.
@@ -160,10 +160,10 @@ fi
 # Run the tests
 echo >&2 "+++ Running tests"
 
-export COVERAGE_PROCESS_START="/src/.coveragerc"
+export COVERAGE_PROCESS_START="$SYNAPSE_SOURCE/.coveragerc"
 
 RUN_TESTS=(
-    perl -I "$SYTEST_LIB" /sytest/run-tests.pl --python=/venv/bin/python --synapse-directory=/src -B "/src/$BLACKLIST" --coverage -O tap --all
+    perl -I "$SYTEST_LIB" /sytest/run-tests.pl --python=/venv/bin/python --synapse-directory="$SYNAPSE_SOURCE" -B "$SYNAPSE_SOURCe/$BLACKLIST" --coverage -O tap --all
     --work-directory="/work"
 )
 
@@ -198,10 +198,10 @@ echo >&2 "--- Copying assets"
 
 # Copy out the logs
 rsync --ignore-missing-args --min-size=1B -av /work/server-0 /work/server-1 /logs --include "*/" --include="*.log.*" --include="*.log" --exclude="*"
-#cp /.coverage.* /src || true
+#cp /.coverage.* "$SYNAPSE_SOURCE" || true
 
-#cd /src
-#export TOP=/src
+#cd "$SYNAPSE_SOURCE"
+#export TOP="$SYNAPSE_SOURCE"
 #/venv/bin/coverage combine
 
 if [ $TEST_STATUS -ne 0 ]; then

--- a/scripts/synapse_sytest.sh
+++ b/scripts/synapse_sytest.sh
@@ -119,6 +119,9 @@ fi
 # it will otherwise try to build it in-tree, which means writing changes to the
 # source volume outside the container.)
 #
+
+echo Help I\'m stuck in $PWD
+
 if [ -d "$SYNAPSE_SOURCE" ]; then
     echo "Creating tarball from synapse source"
     tar -C "$SYNAPSE_SOURCE" -czf /tmp/synapse.tar.gz \

--- a/scripts/synapse_sytest.sh
+++ b/scripts/synapse_sytest.sh
@@ -203,7 +203,7 @@ rsync --ignore-missing-args --min-size=1B -av /work/server-0 /work/server-1 /log
 
 if [ $TEST_STATUS -ne 0 ]; then
     # Build the annotation
-    perl /sytest/scripts/format_tap.pl /logs/results.tap "$BUILDKITE_LABEL" >/logs/annotate.md
+    perl /sytest/scripts/format_tap.pl /logs/results.tap "$GITHUB_SHA" >/logs/annotate.md
 fi
 
 exit $TEST_STATUS

--- a/scripts/synapse_sytest.sh
+++ b/scripts/synapse_sytest.sh
@@ -201,6 +201,7 @@ rsync --ignore-missing-args --min-size=1B -av /work/server-0 /work/server-1 /log
 #export TOP=/src
 #/venv/bin/coverage combine
 
+# Generate annotate.md This is Buildkite-specific.
 if [ $TEST_STATUS -ne 0 ]; then
     # Build the annotation
     perl /sytest/scripts/format_tap.pl /logs/results.tap "$GITHUB_SHA" >/logs/annotate.md

--- a/scripts/synapse_sytest.sh
+++ b/scripts/synapse_sytest.sh
@@ -202,9 +202,9 @@ rsync --ignore-missing-args --min-size=1B -av /work/server-0 /work/server-1 /log
 #/venv/bin/coverage combine
 
 # Generate annotate.md This is Buildkite-specific.
-if [ $TEST_STATUS -ne 0 ]; then
+if [ -n "$BUILDKITE_LABEL" ] && [ $TEST_STATUS -ne 0 ]; then
     # Build the annotation
-    perl /sytest/scripts/format_tap.pl /logs/results.tap "$GITHUB_SHA" >/logs/annotate.md
+    perl /sytest/scripts/format_tap.pl /logs/results.tap "$BUILDKITE_LABEL" >/logs/annotate.md
 fi
 
 exit $TEST_STATUS

--- a/scripts/synapse_sytest.sh
+++ b/scripts/synapse_sytest.sh
@@ -2,9 +2,9 @@
 #
 # This script is run by the bootstrap.sh script in the docker image.
 #
-# It expects to find the synapse source in $SYNAPSE_SOURCE (default /src),
-# and a virtualenv in /venv. It installs synapse into the virtualenv,
-# configures sytest according to the env vars, and runs sytest.
+# It expects to find the synapse source in /src, and a virtualenv in /venv.
+# It installs synapse into the virtualenv, configures sytest according to the
+# env vars, and runs sytest.
 #
 
 # Run the sytests.
@@ -13,7 +13,7 @@ set -e
 
 cd "$(dirname $0)/.."
 
-mkdir /work
+mkdir -p /work
 
 # start the redis server, if desired
 if [ -n "$REDIS" ]; then
@@ -119,9 +119,6 @@ fi
 # it will otherwise try to build it in-tree, which means writing changes to the
 # source volume outside the container.)
 #
-
-echo Help I\'m stuck in $PWD
-
 if [ -d "$SYNAPSE_SOURCE" ]; then
     echo "Creating tarball from synapse source"
     tar -C "$SYNAPSE_SOURCE" -czf /tmp/synapse.tar.gz \
@@ -160,10 +157,10 @@ fi
 # Run the tests
 echo >&2 "+++ Running tests"
 
-export COVERAGE_PROCESS_START="$SYNAPSE_SOURCE/.coveragerc"
+export COVERAGE_PROCESS_START="/src/.coveragerc"
 
 RUN_TESTS=(
-    perl -I "$SYTEST_LIB" /sytest/run-tests.pl --python=/venv/bin/python --synapse-directory="$SYNAPSE_SOURCE" -B "$SYNAPSE_SOURCe/$BLACKLIST" --coverage -O tap --all
+    perl -I "$SYTEST_LIB" /sytest/run-tests.pl --python=/venv/bin/python --synapse-directory=/src -B "/src/$BLACKLIST" --coverage -O tap --all
     --work-directory="/work"
 )
 
@@ -198,10 +195,10 @@ echo >&2 "--- Copying assets"
 
 # Copy out the logs
 rsync --ignore-missing-args --min-size=1B -av /work/server-0 /work/server-1 /logs --include "*/" --include="*.log.*" --include="*.log" --exclude="*"
-#cp /.coverage.* "$SYNAPSE_SOURCE" || true
+#cp /.coverage.* /src || true
 
-#cd "$SYNAPSE_SOURCE"
-#export TOP="$SYNAPSE_SOURCE"
+#cd /src
+#export TOP=/src
 #/venv/bin/coverage combine
 
 if [ $TEST_STATUS -ne 0 ]; then


### PR DESCRIPTION
Ended up with a fairly direct translation from Buildkite to GHA. I tried to make more use of actions and so on, but generally found this to be more trouble that it's worth.

* https://github.com/DMRobertson/sytest/actions/runs/1124068606 is an example where I'd screwed up the blacklist for synapse with workers. But that shows how test failures will appear (annotations, with a link through to logs)
* https://github.com/DMRobertson/sytest/actions/workflows/pipeline.yml has the complete history
* https://github.com/DMRobertson/sytest/actions/runs/1124143216 is an example of a happy run---except I don't understand why the failing dendrite workflow was unhappy.

