### PR TITLE
Move /createRoom to the event_creator worker

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -1319,6 +1319,7 @@ sub generate_haproxy_map
 ^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/(join|invite|leave|ban|unban|kick)$  event_creator
 ^/_matrix/client/(api/v1|r0|unstable)/join/                                         event_creator
 ^/_matrix/client/(api/v1|r0|unstable)/profile/                                      event_creator
+^/_matrix/client/(api/v1|r0|unstable)/createRoom                                    event_creator
 
 EOCONFIG
 


### PR DESCRIPTION
This tests that `/createRoom` actually works on workers, which turns out is only true after https://github.com/matrix-org/synapse/pull/10757 lands.

Thus this PR shares a branch name with that PR.

The failing tests are a bug with the GHA runs, but buildkite should be passing!