### PR TITLE
Pass format, url as data and http as a kind to /pushers/set

### DIFF
--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -236,6 +236,14 @@ sub _get_config
          },
       },
 
+      push_server => {
+         database => {
+            connection_string => 
+               ( ! defined $ENV{'POSTGRES'} || $ENV{'POSTGRES'} == '0') ?
+               "file:$self->{hs_dir}/push_server.db" : $db_uri,
+         },
+      },
+
       logging => [{
          type => 'file',
          level => 'trace',

--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -236,14 +236,6 @@ sub _get_config
          },
       },
 
-      push_server => {
-         database => {
-            connection_string => 
-               ( ! defined $ENV{'POSTGRES'} || $ENV{'POSTGRES'} == '0') ?
-               "file:$self->{hs_dir}/push_server.db" : $db_uri,
-         },
-      },
-
       logging => [{
          type => 'file',
          level => 'trace',

--- a/tests/61push/06_get_pusher.pl
+++ b/tests/61push/06_get_pusher.pl
@@ -10,7 +10,8 @@ test "Can fetch a user's pushers",
       my $device_display_name = "A testing machine";
       my $pushkey = "This is my pushkey";
       my $lang = "en";
-      my $customdata = "This is some custom data";
+      my $url = "https://dummy.url/_matrix/push/v1/notify";
+      my $format = "id_event_only";
 
       # create a pusher
       do_request_json_for( $alice,
@@ -18,14 +19,15 @@ test "Can fetch a user's pushers",
          uri     => "/r0/pushers/set",
          content => {
             profile_tag         => $profile_tag,
-            kind                => "test",
+            kind                => "http",
             app_id              => $app_id,
             app_display_name    => $app_display_name,
             device_display_name => $device_display_name,
             pushkey             => $pushkey,
             lang                => $lang,
             data                => {
-               testcustom => $customdata,
+               url => $url,
+               format => $format,
             },
          },
       )->then( sub {
@@ -50,7 +52,8 @@ test "Can fetch a user's pushers",
          assert_eq( $pusher->{device_display_name}, $device_display_name, "device_display_name");
          assert_eq( $pusher->{pushkey}, $pushkey, "pushkey");
          assert_eq( $pusher->{lang}, $lang, "lang");
-         assert_eq( $pusher->{data}{testcustom}, $customdata, "custom data");
+         assert_eq( $pusher->{data}{url}, $url, "URL");
+         assert_eq( $pusher->{data}{format}, $format, "format");
 
          Future->done(1);
       });

--- a/tests/61push/06_get_pusher.pl
+++ b/tests/61push/06_get_pusher.pl
@@ -10,6 +10,7 @@ test "Can fetch a user's pushers",
       my $device_display_name = "A testing machine";
       my $pushkey = "This is my pushkey";
       my $lang = "en";
+      my $customdata = "This is some custom data";
       my $url = "https://dummy.url/_matrix/push/v1/notify";
       my $format = "id_event_only";
 
@@ -26,6 +27,7 @@ test "Can fetch a user's pushers",
             pushkey             => $pushkey,
             lang                => $lang,
             data                => {
+               testcustom => $customdata,
                url => $url,
                format => $format,
             },
@@ -52,6 +54,7 @@ test "Can fetch a user's pushers",
          assert_eq( $pusher->{device_display_name}, $device_display_name, "device_display_name");
          assert_eq( $pusher->{pushkey}, $pushkey, "pushkey");
          assert_eq( $pusher->{lang}, $lang, "lang");
+         assert_eq( $pusher->{data}{testcustom}, $customdata, "custom data");
          assert_eq( $pusher->{data}{url}, $url, "URL");
          assert_eq( $pusher->{data}{format}, $format, "format");
 


### PR DESCRIPTION
According to documentation (https://matrix.org/docs/spec/client_server/r0.6.1#post-matrix-client-r0-pushers-set) `kind` field can be `http`, `email` or  `null` (although it's not defined as an enum). Also homeserver should not respect `testcustom` because `PusherData` is defined with another fields.

Signed-off-by: Piotr Kozimor <p1996k@gmail.com>