### PR TITLE
Fix missing `fi` in bootstrap.sh

### DIFF
--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -21,6 +21,8 @@ else
         # Otherwise, try and find the branch that the Synapse/Dendrite checkout
         # is using. Fall back to develop if unknown.
         branch_name="$(git --git-dir=/src/.git symbolic-ref HEAD 2>/dev/null)" || branch_name="develop"
+    fi
+
     if [ "$SYTEST_TARGET" == "dendrite" ] && [ "$branch_name" == "master" ]; then
         # Dendrite uses master as its main branch. If the branch is master, we probably want sytest develop
         branch_name="develop"


### PR DESCRIPTION
I guess we never noticed this because no-one build and deployed the
sytest containers?

Context: I wasn't able to reproduce sytest failures from elsewhere and wanted to ensure I was running the latest version. Building the docker images locally and then trying to run tests with them failed with an error in bootstrap.sh