### PR TITLE
Configure push server database for dendrite

### DIFF
--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -236,6 +236,14 @@ sub _get_config
          },
       },
 
+      push_server => {
+         database => {
+            connection_string => 
+               ( ! defined $ENV{'POSTGRES'} || $ENV{'POSTGRES'} == '0') ?
+               "file:$self->{hs_dir}/push_server.db" : $db_uri,
+         },
+      },
+
       logging => [{
          type => 'file',
          level => 'trace',


### PR DESCRIPTION
New component in dendrite is developed: https://github.com/matrix-org/dendrite/pull/1842. Sytest fails there because second instance of homeserver tries to access database file that is already opened by first instance. 