### PR TITLE
Configure threepid database and emails for Dendrite

### DIFF
--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -252,6 +252,7 @@ sub _get_config
             smtp => {
                host => $self->{smtp_server_config}->{host} . ':' . $self->{smtp_server_config}->{port},
             },
+         },
       },
 
       push_server => {

--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -240,6 +240,19 @@ sub _get_config
                ( ! defined $ENV{'POSTGRES'} || $ENV{'POSTGRES'} == '0') ?
                "file:$self->{hs_dir}/presence.db" : $db_uri,
          },
+         threepid_database => {
+            connection_string => 
+               ( ! defined $ENV{'POSTGRES'} || $ENV{'POSTGRES'} == '0') ?
+               "file:$self->{hs_dir}/threepids.db" : $db_uri,
+         },
+         email => {
+            enabled => JSON::false,
+            templates_path => "/src/res/default",
+            smtp => {
+               host => "localhost:25",
+               user => "exampleusername",
+               password => "examplepassword",
+            },
       },
 
       push_server => {

--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -248,7 +248,6 @@ sub _get_config
          email => {
             enabled => JSON::true,
             from => 'synapse@localhost',
-            templates_path => '/src/res/default',
             smtp => {
                host => $self->{smtp_server_config}->{host} . ':' . $self->{smtp_server_config}->{port},
             },

--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -246,12 +246,11 @@ sub _get_config
                "file:$self->{hs_dir}/threepids.db" : $db_uri,
          },
          email => {
-            enabled => JSON::false,
-            templates_path => "/src/res/default",
+            enabled => JSON::true,
+            from => 'synapse@localhost',
+            templates_path => '/src/res/default',
             smtp => {
-               host => "localhost:25",
-               user => "exampleusername",
-               password => "examplepassword",
+               host => $self->{smtp_server_config}->{host} . ':' . $self->{smtp_server_config}->{port},
             },
       },
 

--- a/tests/11register.pl
+++ b/tests/11register.pl
@@ -227,7 +227,7 @@ sub add_email_for_user {
             three_pid_creds => {
                id_server       => $id_server->name,
                id_access_token => $id_access_token,
-               sid             => $sid,
+               sid             => "$sid",
                client_secret   => $client_secret,
             },
          },

--- a/tests/11register.pl
+++ b/tests/11register.pl
@@ -227,7 +227,7 @@ sub add_email_for_user {
             three_pid_creds => {
                id_server       => $id_server->name,
                id_access_token => $id_access_token,
-               sid             => "$sid",
+               sid             => $sid,
                client_secret   => $client_secret,
             },
          },


### PR DESCRIPTION
Configuration required for https://github.com/matrix-org/dendrite/pull/1970.

When session ID is composed of digits only, perl parses it to number. Then is passes number to `/r0/account/3pid` leading to errors. That's why I suggest converting back to string.