### PR TITLE
Attempt to deflake `The only membership state included in an initial …

### DIFF
--- a/tests/10apidoc/09synced.pl
+++ b/tests/10apidoc/09synced.pl
@@ -393,7 +393,7 @@ sub assert_state_room_members_match {
 
    my @members = grep { $_->{type} eq 'm.room.member' } @{ $events };
    @members == scalar @{ $member_ids }
-      or die "Expected only ".(scalar @{ $member_ids })." membership events";
+      or die "Expected only ".(scalar @{ $member_ids })." membership events (got ".(scalar @members).")";
 
    my $found_senders = {};
    my $found_state_keys = {};

--- a/tests/31sync/15lazy-members.pl
+++ b/tests/31sync/15lazy-members.pl
@@ -99,9 +99,21 @@ test "The only membership state included in an initial sync is for all the sende
             )
          }, foreach => [ 1 .. 10 ])
       })->then( sub {
+         # Ensure synapse has propagated this message to Alice's synchotron
+         await_sync_timeline_contains( $alice, $room_id, check => sub {
+            my ($event) = @_;
+            log_if_fail "event", $event;
+            my $result = $event->{type} eq "m.room.message" &&
+               $event->{sender} eq $charlie->user_id &&
+               $event->{content}->{body} eq "Message 10";
+            $result
+         })
+      })->then( sub {
+         $alice->sync_next_batch == 0 or croak "Alice should not have a next batch token set";
          matrix_sync( $alice, filter => $filter_id );
       })->then( sub {
          my ( $body ) = @_;
+         log_if_fail "alice's initial sync returned", $body->{rooms}->{join}->{$room_id}->{timeline};
          assert_room_members ( $body, $room_id, [ $alice->user_id, $charlie->user_id ]);
          Future->done(1);
       });

--- a/tests/31sync/15lazy-members.pl
+++ b/tests/31sync/15lazy-members.pl
@@ -103,10 +103,9 @@ test "The only membership state included in an initial sync is for all the sende
          await_sync_timeline_contains( $alice, $room_id, check => sub {
             my ($event) = @_;
             log_if_fail "event", $event;
-            my $result = $event->{type} eq "m.room.message" &&
+            return $event->{type} eq "m.room.message" &&
                $event->{sender} eq $charlie->user_id &&
                $event->{content}->{body} eq "Message 10";
-            $result
          })
       })->then( sub {
          $alice->sync_next_batch == 0 or croak "Alice should not have a next batch token set";

--- a/tests/31sync/15lazy-members.pl
+++ b/tests/31sync/15lazy-members.pl
@@ -99,7 +99,7 @@ test "The only membership state included in an initial sync is for all the sende
             )
          }, foreach => [ 1 .. 10 ])
       })->then( sub {
-         # Ensure synapse has propagated this message to Alice's synchotron
+         # Ensure synapse has propagated this message to Alice's sync stream
          await_sync_timeline_contains( $alice, $room_id, check => sub {
             my ($event) = @_;
             log_if_fail "event", $event;


### PR DESCRIPTION
…sync is for all the senders in the timeline`

Hopefully fixes #1050 