### PR TITLE
Update presence tests

### DIFF
--- a/tests/30rooms/02members-local.pl
+++ b/tests/30rooms/02members-local.pl
@@ -6,7 +6,7 @@ my $creator_fixture = local_user_fixture(
    avatar_url => "mxc://foo/bar",
 );
 
-my $local_user_fixture = local_user_fixture();
+my $local_user_fixture = local_user_fixture(presence => "online");
 
 my $room_fixture = fixture(
    requires => [ $creator_fixture, $local_user_fixture ],
@@ -106,14 +106,12 @@ test "Existing members see new members' presence",
 
    do => sub {
       my ( $first_user, $local_user ) = @_;
-
-      await_event_for( $first_user, filter => sub {
+      await_sync_presence_contains( $first_user, check => sub {
          my ( $event ) = @_;
          return unless $event->{type} eq "m.presence";
-         assert_json_keys( $event, qw( type content ));
-         assert_json_keys( my $content = $event->{content}, qw( user_id presence ));
-         return unless $content->{user_id} eq $local_user->user_id;
-
+         assert_json_keys( $event, qw( type content sender ));
+         assert_json_keys( $event->{content}, qw( presence last_active_ago currently_active ));
+         return unless $event->{sender} eq $local_user->user_id;
          return 1;
       });
    };

--- a/tests/30rooms/03members-remote.pl
+++ b/tests/30rooms/03members-remote.pl
@@ -164,12 +164,13 @@ test "Existing members see new member's presence",
    do => sub {
       my ( $first_user, $user, $room_id, $room_alias ) = @_;
 
-      await_event_for( $first_user, filter => sub {
+      await_sync_presence_contains( $first_user, check => sub {
          my ( $event ) = @_;
+
          return unless $event->{type} eq "m.presence";
-         assert_json_keys( $event, qw( type content ));
-         assert_json_keys( my $content = $event->{content}, qw( user_id presence ));
-         return unless $content->{user_id} eq $user->user_id;
+         assert_json_keys( $event, qw( type content sender ));
+         assert_json_keys( $event->{content}, qw( presence last_active_ago currently_active ));
+         return unless any { $event->{sender} } eq $user->user_id;
 
          return 1;
       });


### PR DESCRIPTION
Updates some of the tests listed in #1108 to use `GET /r0/sync` instead of `GET /r0/events`