### PR TITLE
Update the soft-fail tests to work with recent room versions

### DIFF
--- a/tests/50federation/52soft-fail.pl
+++ b/tests/50federation/52soft-fail.pl
@@ -309,15 +309,14 @@ test "Inbound federation accepts a second soft-failed event",
                log_if_fail "Received event", $event;
                assert_eq( $event->{content}{body}, "m3", "event content body" );
 
-               my %prev_event_ids = (
-                  map { ($_->[0], 1) } ( @{$event->{prev_events}}),
+               my $prev_event_ids = $room->event_ids_from_refs( $event->{prev_events} );
+               log_if_fail "Received prev_event_ids", $prev_event_ids;
+               assert_elements_eq(
+                  $prev_event_ids,
+                  [ $event_id_pl1, $event_id_m1 ],
+                  "prev_event ids",
                );
-               log_if_fail "prev_event_ids", \%prev_event_ids;
-               assert_deeply_eq( \%prev_event_ids, {
-                     $event_id_pl1 => 1,
-                     $event_id_m1 => 1,
-                  }, "prev_event ids",
-               );
+
                Future->done(1);
             }),
          );
@@ -520,14 +519,10 @@ test "Inbound federation correctly handles soft failed events as extremities",
                my ( $event ) = @_;
                log_if_fail "Received event", $event;
                assert_eq( $event->{content}{body}, "m3", "event content body" );
-
-               my %prev_event_ids = (
-                  map { ($_->[0], 1) } ( @{$event->{prev_events}}),
-               );
-               log_if_fail "prev_event_ids", \%prev_event_ids;
-               assert_deeply_eq( \%prev_event_ids, {
-                     $event_id_m2 => 1,
-                  }, "prev_event ids",
+               my $prev_event_ids = $room->event_ids_from_refs( $event->{prev_events} );
+               log_if_fail "Received prev_event_ids", $prev_event_ids;
+               assert_elements_eq(
+                  $prev_event_ids, [ $event_id_m2 ], "prev_event ids",
                );
                Future->done(1);
             }),

--- a/tests/50federation/52soft-fail.pl
+++ b/tests/50federation/52soft-fail.pl
@@ -191,11 +191,11 @@ test "Inbound federation accepts a second soft-failed event",
       # (The effect of #5090 was that M1 was incorrectly excluded from the
       # forward-extremities.)
 
-      my $join_event_id;
+      my $join_event;
       my $event_id_pl1;
-      my $event_id_m1;
-      my $event_id_sf1;
-      my $event_id_sf2;
+      my $event_m1;
+      my $event_sf1;
+      my $event_sf2;
 
       # First we join the room (event J1)
       $outbound_client->join_room(
@@ -208,7 +208,7 @@ test "Inbound federation accepts a second soft-failed event",
          log_if_fail "Joined room";
 
          # Grab the join to use as a prev event
-         $join_event_id = $room->get_current_state_event( "m.room.member", $remote_user_id )->{event_id};
+         $join_event = $room->get_current_state_event( "m.room.member", $remote_user_id );
 
          # Make sure client is up to date
          await_sync_timeline_contains( $creator, $room_id, check => sub {
@@ -243,62 +243,59 @@ test "Inbound federation accepts a second soft-failed event",
          log_if_fail "Blocked new SF events";
 
          # send a regular message (event m1), which should be accepted
-         my $event = $room->create_and_insert_event(
+         $event_m1 = $room->create_and_insert_event(
             event_id_suffix => "m1",
-            prev_events => [ [ $join_event_id, {} ] ],
+            prev_events => $room->make_event_refs( $join_event ),
             sender  => $remote_user_id,
             type => "m.room.message",
             content => { body => "M1" },
          );
 
-         $event_id_m1 = $event->{event_id};
-
-         log_if_fail "Sending", $event;
+         log_if_fail "Sending M1 ".$room->id_for_event( $event_m1 ),
+            $event_m1;
 
          $outbound_client->send_event(
-            event => $event,
+            event => $event_m1,
             destination => $first_home_server,
          );
       })->then( sub {
          # send an event which will be soft-failed (sf1)
-         my $event = $room->create_and_insert_event(
+         $event_sf1 = $room->create_and_insert_event(
             event_id_suffix => "sf1",
-            prev_events => [ [ $event_id_m1, {} ] ],
+            prev_events => $room->make_event_refs( $event_m1 ),
             sender  => $remote_user_id,
             type => "test.sf",
             content => { body => "SF1" },
          );
 
-         $event_id_sf1 = $event->{event_id};
-
-         log_if_fail "Sending blocked event 1", $event;
+         log_if_fail "Sending blocked event 1 ".$room->id_for_event( $event_sf1 ),
+            $event_sf1;
 
          $outbound_client->send_event(
-            event => $event,
+            event => $event_sf1,
             destination => $first_home_server,
          );
       })->then( sub {
          # send a second soft-fail event
-         my $event = $room->create_and_insert_event(
+         $event_sf2 = $room->create_and_insert_event(
             event_id_suffix => "sf2",
-            prev_events => [ [ $event_id_m1, {} ] ],
+            prev_events => $room->make_event_refs( $event_m1 ),
             sender  => $remote_user_id,
             type => "test.sf",
             content => { body => "SF2" },
          );
 
-         $event_id_sf2 = $event->{event_id};
-
-         log_if_fail "Sending blocked event 2", $event;
+         log_if_fail "Sending blocked event 2 ".$room->id_for_event( $event_sf2 ),
+            $event_sf2;
 
          $outbound_client->send_event(
-            event => $event,
+            event => $event_sf2,
             destination => $first_home_server,
          );
       })->then( sub {
          # make sure that at least M1 has propagated
          await_sync_timeline_contains( $creator, $room_id, check => sub {
-            return $_[0]->{event_id} eq $event_id_m1;
+            return $_[0]->{event_id} eq $room->id_for_event( $event_m1 );
          });
       })->then( sub {
          # now tell synapse to send a regular message, and check it
@@ -315,7 +312,7 @@ test "Inbound federation accepts a second soft-failed event",
                log_if_fail "Received prev_event_ids", $prev_event_ids;
                assert_elements_eq(
                   $prev_event_ids,
-                  [ $event_id_pl1, $event_id_m1 ],
+                  [ $event_id_pl1, $room->id_for_event( $event_m1 ) ],
                   "prev_event ids",
                );
 

--- a/tests/50federation/52soft-fail.pl
+++ b/tests/50federation/52soft-fail.pl
@@ -2,7 +2,6 @@ test "Inbound federation correctly soft fails events",
    requires => [ $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
                  local_user_and_room_fixtures(
                     user_opts => { with_events => 1 },
-                    room_opts => { room_version => "1" },
                  ),
                  federation_user_id_fixture() ],
 
@@ -162,7 +161,6 @@ test "Inbound federation accepts a second soft-failed event",
       $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
       local_user_and_room_fixtures(
          user_opts => { with_events => 1 },
-         room_opts => { room_version => "1" }
       ),
       federation_user_id_fixture(),
    ],
@@ -357,7 +355,6 @@ test "Inbound federation correctly handles soft failed events as extremities",
       $main::OUTBOUND_CLIENT, $main::INBOUND_SERVER,
       local_user_and_room_fixtures(
          user_opts => { with_events => 1 },
-          room_opts => { room_version => "1" },
       ),
       federation_user_id_fixture(),
    ],


### PR DESCRIPTION
We have some tests in `tests/50federation/52soft-fail.pl` which test soft-failing, but which have never been updated to work with room versions other than v1.

For the most part, this is just a matter of updating them to use utility functions instead of making assumptions about the shapes of the events, but it turns out that there is another wrinkle, which is that they were making some assumptions about the state-resolution algorithm which are not true in subsequent room versions. More info in the commit comments.

Reviewable commit-by-commit.