### PR TITLE
Test basic functionality on room versions 7, 8, and 9.

### DIFF
--- a/tests/32room-versions.pl
+++ b/tests/32room-versions.pl
@@ -2,7 +2,7 @@ use URI::Escape qw( uri_escape );
 use SyTest::Federation::Client;
 
 # We test that some basic functionality works across all room versions
-foreach my $version ( @{ (SyTest::Federation::Client::SUPPORTED_ROOM_VERSIONS)[0] } ) {
+foreach my $version ( @{ (SyTest::Federation::Client::SUPPORTED_ROOM_VERSIONS) } ) {
    multi_test "User can create and send/receive messages in a room with version $version",
       requires => [ local_user_fixture() ],
 


### PR DESCRIPTION
Fixes #1124 by re-using the declared supported room versions.

I'm not 100% sure this is the right thing to do, but it seems frustrating to have two lists of room versions which are almost identical.