### PR TITLE
Attempt to deflake `Can paginate public room list`

### DIFF
--- a/tests/30rooms/70publicroomslist.pl
+++ b/tests/30rooms/70publicroomslist.pl
@@ -164,7 +164,7 @@ test "Can paginate public room list",
       # be entries in it).
       ( try_repeat {
          my ($n) = @_;
-         matrix_create_room( $user, visibility => "public" )->on_done( sub {
+         matrix_create_room_synced( $user, visibility => "public" )->on_done( sub {
             my ( $body ) = @_;
             log_if_fail "Created room $n", $body;
          });


### PR DESCRIPTION
I'm guessing we need to ensure Synapse has time to propagate the room
creation to the worker that servers the public room list.

Part of me wishes that everything was synchronous by default.

Fixes #1044 