### PR TITLE
Three fixes for aiding Dendrite push notifications development

### DIFF
--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -61,12 +61,13 @@ fi
 
 # Check for new tests to be added to the test whitelist
 /src/show-expected-fail-tests.sh /logs/results.tap /src/sytest-whitelist \
-    /src/sytest-blacklist > /work/show_expected_fail_tests_output.txt || TEST_STATUS=$?
+    /src/sytest-blacklist | tee /work/show_expected_fail_tests_output.txt || TEST_STATUS=$?
 
 echo >&2 "--- Copying assets"
 
 # Copy out the logs
 rsync -r --ignore-missing-args --min-size=1B -av /work/server-0 /work/server-1 /logs --include "*/" --include="*.log.*" --include="*.log" --exclude="*"
+find /logs | xargs -r chmod go+rX
 
 # Generate annotate.md. This is Buildkite-specific.
 if [ -n "$BUILDKITE_LABEL" ] && [ $TEST_STATUS -ne 0 ]; then

--- a/tests/01http-server.pl
+++ b/tests/01http-server.pl
@@ -47,6 +47,9 @@ sub start_test_server_ssl {
    );
 }
 
+# List of Awaiter structs
+my @pending_awaiters;
+
 our $TEST_SERVER_INFO = fixture(
    requires => [],
 
@@ -58,6 +61,8 @@ our $TEST_SERVER_INFO = fixture(
 
       my $http_client;
       my $server_info;
+
+      @pending_awaiters = ();
 
       start_test_server_ssl( $http_server )->then( sub {
          my ( $listener ) = @_;
@@ -134,9 +139,6 @@ our $TEST_SERVER_INFO = fixture(
       });
    },
 );
-
-# List of Awaiter structs
-my @pending_awaiters;
 
 package SyTest::HTTPServer {
    use base qw( Net::Async::HTTP::Server );


### PR DESCRIPTION
While working on https://github.com/matrix-org/dendrite/pull/1842, I discovered some issues that would help development:

* Clear pending HTTP awaiters between tests.
* Make "Notifications can be viewed with GET /notifications" sync before sending receipts.
* Fix `scripts/dendrite_sytest.sh` to show are-we-synapse-yet in the console, and chmod logs.

More context is in the commit messages.

Since they are all small, I'm hoping a single PR is acceptable.