### PR TITLE
Update deprecated delete room admin API

### DIFF
--- a/tests/48admin.pl
+++ b/tests/48admin.pl
@@ -381,8 +381,8 @@ multi_test "Shutdown room",
          matrix_join_room( $remote_user, $room_id );
       })->then( sub {
          do_request_json_for( $admin,
-            method   => "POST",
-            full_uri => "/_synapse/admin/v1/rooms/$room_id/delete",
+            method   => "DELETE",
+            full_uri => "/_synapse/admin/v1/rooms/$room_id",
             content  => {
                new_room_user_id => $dummy_user->user_id,
                block => JSON::true,


### PR DESCRIPTION
Needed for: https://github.com/matrix-org/synapse/pull/11213
Deprecated in https://github.com/matrix-org/synapse/pull/9889

admin API were deprecated in [Synapse 1.34](https://github.com/matrix-org/synapse/blob/v1.34.0/CHANGES.md#deprecations-and-removals) (released on 2021-05-17)