### PR TITLE
Fix reference to `unpack_sockaddr_un`

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -1205,7 +1205,7 @@ sub generate_haproxy_config
       },
    );
    my $log_sock = $self->{hs_dir} . "/haproxy_log.sock";
-   my $sockaddr = ::pack_sockaddr_un( $log_sock );
+   my $sockaddr = Socket::pack_sockaddr_un( $log_sock );
    $socket->bind([ 'unix', 'dgram', 0, $sockaddr ]) or die "Could not bind syslog socket: $!";
    $self->add_child( $socket );
 


### PR DESCRIPTION
Hopefully, fixes:

```
WARN: Error starting server-0: Undefined subroutine &main::pack_sockaddr_un called at lib/SyTest/Homeserver/Synapse.pm line 1208.
```