### PR TITLE
Check both `SYTEST_BRANCH` and `BUILDKITE_BRANCH` in Docker bootstrap

### DIFF
--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -17,6 +17,8 @@ else
     # Synapse/Dendrite branch we're running
     if [ -n "$SYTEST_BRANCH" ]; then
         branch_name="$SYTEST_BRANCH"
+    elif [ -n "$BUILDKITE_BRANCH" ]; then
+        branch_name="$BUILDKITE_BRANCH"
     else
         # Otherwise, try and find the branch that the Synapse/Dendrite checkout
         # is using. Fall back to develop if unknown.


### PR DESCRIPTION
PR #1123 broke the `Trying to get same-named sytest branch` stage for Dendrite CI which is still in Buildkite.