### PR TITLE
Add `worker_to_update_user_directory config` option

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -263,10 +263,12 @@ sub start
         start_pushers         => ( not $self->{workers} ),
         notify_appservices    => ( not $self->{workers} ),
         send_federation       => ( not $self->{workers} ),
-        update_user_directory => ( not $self->{workers} ),
         enable_media_repo     => ( not $self->{workers} ),
         run_background_tasks_on  => ( $self->{workers} ? "background_worker1" : "master" ),
         worker_to_update_user_directory  => ( $self->{workers} ? "user_dir" : "null" ),
+        # update_user_directory is kept for backwards compatibility,
+        # worker_to_update_user_directory is prioritized before this option.
+        update_user_directory => ( not $self->{workers} ),
 
         url_preview_enabled => "true",
         url_preview_ip_range_blacklist => [],

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -266,6 +266,7 @@ sub start
         update_user_directory => ( not $self->{workers} ),
         enable_media_repo     => ( not $self->{workers} ),
         run_background_tasks_on  => ( $self->{workers} ? "background_worker1" : "master" ),
+        worker_to_update_user_directory  => ( $self->{workers} ? "user_dir1" : "null" ),
 
         url_preview_enabled => "true",
         url_preview_ip_range_blacklist => [],

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -266,7 +266,7 @@ sub start
         update_user_directory => ( not $self->{workers} ),
         enable_media_repo     => ( not $self->{workers} ),
         run_background_tasks_on  => ( $self->{workers} ? "background_worker1" : "master" ),
-        worker_to_update_user_directory  => ( $self->{workers} ? "user_dir1" : "null" ),
+        worker_to_update_user_directory  => ( $self->{workers} ? "user_dir" : "null" ),
 
         url_preview_enabled => "true",
         url_preview_ip_range_blacklist => [],


### PR DESCRIPTION
Works together with https://github.com/matrix-org/synapse/pull/11450

I chose to do this over https://github.com/matrix-org/sytest/issues/1173, because this is just less hassle.

The issue stated in 1173 still stands, but this is just an easier fix for now.

This update is backwards-compatible with other synapse branches and versions, as those just ignore extra config keys.

`update_user_directory` is not removed for backwards compat, and likely will stay this way.