### PR TITLE
Install correct version of Go into Dendrite sytest image for the target architecture

### DIFF
--- a/docker/dendrite.Dockerfile
+++ b/docker/dendrite.Dockerfile
@@ -2,7 +2,8 @@ ARG SYTEST_IMAGE_TAG=buster
 FROM matrixdotorg/sytest:${SYTEST_IMAGE_TAG}
 
 ARG GO_VERSION=1.15.13
-ENV GO_DOWNLOAD https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz
+ARG TARGETARCH
+ENV GO_DOWNLOAD https://dl.google.com/go/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz
 
 RUN mkdir -p /goroot /gopath
 RUN wget -q $GO_DOWNLOAD -O go.tar.gz


### PR DESCRIPTION
This fixes building native `arm64` images, e.g. for Apple Silicon. This probably also means that cross-compiling the image using `docker buildx` should *probably* work too.

`TARGETARCH` is populated by Docker itself.