### PR TITLE
Update user directory variable to right type and name

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -265,7 +265,7 @@ sub start
         send_federation       => ( not $self->{workers} ),
         enable_media_repo     => ( not $self->{workers} ),
         run_background_tasks_on  => ( $self->{workers} ? "background_worker1" : "master" ),
-        worker_to_update_user_directory  => ( $self->{workers} ? "user_dir" : "null" ),
+        worker_to_update_user_directory  => ( $self->{workers} ? "user_dir" : undef ),
         # update_user_directory is kept for backwards compatibility,
         # worker_to_update_user_directory is prioritized before this option.
         update_user_directory => ( not $self->{workers} ),

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -266,7 +266,7 @@ sub start
         enable_media_repo     => ( not $self->{workers} ),
         run_background_tasks_on  => ( $self->{workers} ? "background_worker1" : "master" ),
         $self->{workers} ? (
-            worker_to_update_user_directory  => "user_dir",
+            update_user_directory_on  => "user_dir",
         ) : (),
         # update_user_directory is kept for backwards compatibility,
         # worker_to_update_user_directory is prioritized before this option.

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -265,7 +265,9 @@ sub start
         send_federation       => ( not $self->{workers} ),
         enable_media_repo     => ( not $self->{workers} ),
         run_background_tasks_on  => ( $self->{workers} ? "background_worker1" : "master" ),
-        worker_to_update_user_directory  => ( $self->{workers} ? "user_dir" : undef ),
+        $self->{workers} ? (
+            worker_to_update_user_directory  => "user_dir",
+        ) : (),
         # update_user_directory is kept for backwards compatibility,
         # worker_to_update_user_directory is prioritized before this option.
         update_user_directory => ( not $self->{workers} ),


### PR DESCRIPTION
This fixes a small problem introduced by https://github.com/matrix-org/sytest/pull/1174, i thought that `"null"` would become a null yaml value, but it seems not.

This tries ~~`undef`~~`()` instead.

---

After some review over in https://github.com/matrix-org/synapse/pull/11450 im also using this PR to change over the config variable name to `update_user_directory_on`