### PR TITLE
Mark `testing` image as experimental

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,8 +14,10 @@ jobs:
   build-sytest-images:
     name: "Build sytest:${{ matrix.tag }}"
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
+        experimental: [false]
         include:
           - base_image: ubuntu:bionic
             tag: bionic
@@ -23,6 +25,7 @@ jobs:
             tag: buster
           - base_image: debian:testing
             tag: testing
+            experimental: true
     steps:
       - name: Set up Docker Buildx
         id: buildx
@@ -51,8 +54,10 @@ jobs:
     needs: build-sytest-images
     name: "Build sytest-${{ matrix.dockerfile }}:${{ matrix.sytest_image_tag }}"
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
+        experimental: [false]
         include:
           - sytest_image_tag: bionic
             dockerfile: synapse
@@ -63,9 +68,10 @@ jobs:
           - sytest_image_tag: testing
             dockerfile: synapse
             tags: "matrixdotorg/sytest-synapse:testing"
+            experimental: true
           - sytest_image_tag: buster
             dockerfile: dendrite
-            tags: "matrixdotorg/sytest-dendrite:go113,matrixdotorg/sytest-dendrite:latest"
+            tags: "matrixdotorg/sytest-dendrite:latest"
 
     steps:
       - name: Set up Docker Buildx

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: false
       matrix:
         experimental: [false]
         include:
@@ -56,6 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: false
       matrix:
         experimental: [false]
         include:


### PR DESCRIPTION
This marks the `testing` image as experimental and allows the builds of the stable images to continue even if the experimental ones fail.

It's nice to know when something in `testing` will break CI for a future Debian version, but it probably shouldn't stop us from successfully building existing images based on the stable distributions.

It also removes a tag from the Dendrite build that we don't care about anymore.

(Related to #1114)