### PR TITLE
Drop bionic from docker builds and add focal

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - base_image: ubuntu:bionic
-            tag: bionic
+          - base_image: ubuntu:focal
+            tag: focal
           - base_image: debian:buster
             tag: buster
           - base_image: debian:testing
@@ -54,9 +54,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - sytest_image_tag: bionic
+          - sytest_image_tag: focal
             dockerfile: synapse
-            tags: "matrixdotorg/sytest-synapse:bionic"
+            tags: "matrixdotorg/sytest-synapse:focal"
           - sytest_image_tag: buster
             dockerfile: synapse
             tags: "matrixdotorg/sytest-synapse:buster"

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -20,15 +20,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - label: Py 3.6, SQLite 3.22.0, Monolith
-            sytest-tag: bionic
+          - label: Py 3.9, SQLite 3.31.1, Monolith
+            sytest-tag: focal
 
-          - label: Py 3.6, PG 10, Monolith
-            sytest-tag: bionic
+          - label: Py 3.9, PG 12, Monolith
+            sytest-tag: focal
             postgres: postgres
 
-          - label: Py 3.6, PG 10, Workers
-            sytest-tag: bionic
+          - label: Py 3.9, PG 12, Workers
+            sytest-tag: focal
             postgres: postgres
             workers: workers
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -20,14 +20,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - label: Py 3.9, SQLite 3.31.1, Monolith
+          - label: Py 3.8, SQLite 3.31.1, Monolith
             sytest-tag: focal
 
-          - label: Py 3.9, PG 12, Monolith
+          - label: Py 3.8, PG 12, Monolith
             sytest-tag: focal
             postgres: postgres
 
-          - label: Py 3.9, PG 12, Workers
+          - label: Py 3.8, PG 12, Workers
             sytest-tag: focal
             postgres: postgres
             workers: workers

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,9 +8,9 @@ but its dependencies are.
 Included currently is:
 
 - `matrixdotorg/sytest` Base container with SyTest dependencies installed
-    - Tagged by underlying Debian/Ubuntu image: `bionic`, `buster` or `testing`
+    - Tagged by underlying Debian/Ubuntu image: `focal`, `buster` or `testing`
 - `matrixdotorg/sytest-synapse`: Runs SyTest against Synapse
-    - Tagged by underlying Debian/Ubunutu image: `bionic`, `buster` or `testing`
+    - Tagged by underlying Debian/Ubunutu image: `focal`, `buster` or `testing`
 - `matrixdotorg/sytest-dendrite:go113`: Runs SyTest against Dendrite on Go 1.13
     - Currently uses Debian 10 (Buster) as its base image
 


### PR DESCRIPTION
Related to #11552, drops bionic from the docker builds which uses EOL python 3.6 and add focal, which uses python 3.9.