### PR TITLE
Replace `Crypt::NaCl::Sodium` with `Crypt::Ed25519`

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -36,6 +36,7 @@ requires 'File::Slurper';
 # Future 0.45 allows you to return immediate values from sequence functions.
 requires 'Future', '>= 0.45';
 requires 'Getopt::Long';
+requires 'HTTP::Request';
 requires 'IO::Async', '>= 0.69';
 requires 'IO::Async::SSL';
 requires 'IO::Socket::IP', '>= 0.04';
@@ -54,7 +55,6 @@ requires 'Module::Pluggable';
 requires 'Net::Async::HTTP', '>= 0.39';
 requires 'Net::Async::HTTP::Server', '>= 0.09';
 requires 'Net::SSLeay', '>= 1.59';
-requires 'Protocol::Matrix', '>= 0.02';
 requires 'Struct::Dumb', '>= 0.04';
 requires 'URI::Escape';
 requires 'YAML::XS';

--- a/cpanfile
+++ b/cpanfile
@@ -1,20 +1,6 @@
 # vim:ft=perl
 
-# Sodium won't install without this.
-requires 'Alien::Base::ModuleBuild';
-
 requires 'Class::Method::Modifiers';
-
-# workaround for https://github.com/matrix-org/sytest/issues/942:
-# Crypt::NaCl::Sodium won't install with Alien::Sodium 2.0.
-requires 'Alien::Sodium', '<2.0', 'AJGB/Alien-Sodium-1.0.8.0.tar.gz';
-
-# this can be a pain to install.
-#
-# We used to have a libcrypt-nacl-sodium-perl deb, but it was only built for
-# perl 5.14.2.
-#
-requires 'Crypt::NaCl::Sodium';
 
 requires 'Crypt::Ed25519';
 

--- a/cpanfile
+++ b/cpanfile
@@ -16,6 +16,8 @@ requires 'Alien::Sodium', '<2.0', 'AJGB/Alien-Sodium-1.0.8.0.tar.gz';
 #
 requires 'Crypt::NaCl::Sodium';
 
+requires 'Crypt::Ed25519';
+
 requires 'Data::Dump';
 
 # DBD::Pg fails to install if DBI is not already installed before we start.

--- a/lib/Protocol/Matrix.pm
+++ b/lib/Protocol/Matrix.pm
@@ -102,13 +102,17 @@ character string. This is re-exported from L<MIME::Base64> for convenience.
 
 =head2 sign_json
 
-   sign_json( $data, secret_key => $key, origin => $name, key_id => $id )
+   sign_json( $data,
+      secret_key => $sodium_secret_key,
+      origin => $name,
+      key_id => $id,
+   )
 
 or:
 
    sign_json( $data,
-      eddsa_secret_key => $secret_key,
-      eddsa_public_key => $public_key,
+      eddsa_secret_key => $eddsa_secret_key,
+      eddsa_public_key => $eddsa_public_key,
       origin => $name,
       key_id => $id,
    )
@@ -117,12 +121,24 @@ Modifies the given HASH reference in-place to add a signature. This signature
 is created from the given key, and annotated as being from the given origin
 name and key ID. Existing signatures already in the hash are not disturbed.
 
-The key can be specified in one of two ways: either with C<secret_key>, in
-which case the C<$key> should be a plain byte string or L<Data::Locker> object
-obtained from L<Crypt::NaCl::Sodium::sign>'s C<keypair> method; or with
-C<eddsa_secret_key> with a key returned by
-L<Crypt::Ed25519::eddsa_secret_key>. In the latter case C<eddsa_public_key> is
-optional, and the public key will be derived if not given.
+The key can be specified in one of two ways:
+
+=over
+
+=item
+
+For C<secret_key>, the C<$sodium_secret_key> should be a plain byte string or
+L<Data::BytesLocker> object obtained from L<Crypt::NaCl::Sodium::sign>'s
+C<keypair> method.
+
+=item
+
+Alternatively, for C<eddsa_secret_key>, the C<$eddsa_secret_key> should be a
+key returned by L<Crypt::Ed25519::eddsa_secret_key>. In this case
+C<eddsa_public_key> is optional, and the public key will be derived from the
+secret key if not given.
+
+=back
 
 =cut
 

--- a/lib/Protocol/Matrix.pm
+++ b/lib/Protocol/Matrix.pm
@@ -1,0 +1,317 @@
+#  You may distribute under the terms of either the GNU General Public License
+#  or the Artistic License (the same terms as Perl itself)
+#
+#  (C) Paul Evans, 2015 -- leonerd@leonerd.org.uk
+
+package Protocol::Matrix;
+
+use strict;
+use warnings;
+use 5.014; # s///r
+
+our $VERSION = '0.02';
+
+use Carp;
+
+use Crypt::NaCl::Sodium;
+use Digest::SHA qw( sha256 );
+use JSON;
+use MIME::Base64 qw( encode_base64 decode_base64 );
+
+use Exporter 'import';
+our @EXPORT_OK = qw(
+   encode_json_for_signing
+   encode_base64_unpadded
+   decode_base64
+
+   sign_json signed_json
+   verify_json_signature
+
+   redact_event redacted_event
+
+   sign_event_json signed_event_json
+   verify_event_json_signature
+);
+
+my $sign = Crypt::NaCl::Sodium->sign;
+
+my $json_canon = JSON->new
+                     ->convert_blessed
+                     ->canonical
+                     ->utf8;
+
+=head1 NAME
+
+C<Protocol::Matrix> - Helper functions for the Matrix protocol
+
+=head1 DESCRIPTION
+
+This module provides some helper functions for implementing a F<matrix> client
+or server. Currently it only contains a few base-level functions to assist
+with signing and verifying signatures on federation-level events.
+
+=cut
+
+=head1 FUNCTIONS
+
+=cut
+
+=head2 encode_json_for_signing
+
+   $json = encode_json_for_signing( $data )
+
+Encodes a given HASH reference as Canonical JSON, having removed the
+C<signatures> and C<unsigned> keys if present. This is the first step
+towards signing it or verifying an embedded signature in it. The hash
+referred to by C<$data> remains unmodified by this function.
+
+=cut
+
+sub encode_json_for_signing
+{
+   my ( $d ) = @_;
+
+   # Remove keys that don't get signed
+   my %to_sign = %$d;
+   delete $to_sign{signatures};
+   delete $to_sign{unsigned};
+
+   return $json_canon->encode( \%to_sign );
+}
+
+=head2 encode_base64_unpadded
+
+   $base64 = encode_base64( $bytes )
+
+Returns a character string containing the Base-64 encoding of the given bytes,
+with no internal linebreaks and no trailing padding.
+
+=cut
+
+sub encode_base64_unpadded
+{
+   return encode_base64( $_[0], "" ) =~ s/=+$//r;
+}
+
+=head2 decode_base64
+
+   $bytes = decode_base64( $base64 )
+
+Returns a byte string containing the bytes obtained by decoding the given
+character string. This is re-exported from L<MIME::Base64> for convenience.
+
+=cut
+
+=head2 sign_json
+
+   sign_json( $data, secret_key => $key, origin => $name, key_id => $id )
+
+Modifies the given HASH reference in-place to add a signature. This signature
+is created from the given key, and annotated as being from the given origin
+name and key ID. Existing signatures already in the hash are not disturbed.
+
+The C<$key> should be a plain byte string or L<Data::Locker> object obtained
+from L<Crypt::NaCl::Sodium::sign>'s C<keypair> method.
+
+=cut
+
+sub sign_json
+{
+   my ( $data, %args ) = @_;
+
+   my $key = $args{secret_key} or croak "Require a 'secret_key'";
+
+   my $origin = $args{origin} or croak "Require an 'origin'";
+   my $key_id = $args{key_id} or croak "Require a 'key_id'";
+
+   my $signature = $sign->mac( encode_json_for_signing( $data ), $key );
+
+   $data->{signatures}{$origin}{$key_id} = encode_base64_unpadded( $signature );
+}
+
+=head2 signed_json
+
+   my $data = signed_json( $data, ... )
+
+Returns a new HASH reference by cloning the original and applying
+L</sign_json> to it. The originally-passed data is unmodified. Takes the same
+arguments as L</sign_json>.
+
+=cut
+
+sub signed_json
+{
+   my ( $data, @args ) = @_;
+   sign_json( $data = { %$data }, @args );
+   return $data;
+}
+
+=head2 verify_json_signature
+
+   verify_json_signature( $data, public_key => $key, origin => $name, key_id => $id )
+
+Inspects the given HASH reference to check that it contains a signature from
+the named origin, with the given key ID, and that it is actually valid.
+
+This function does not return an interesting value; all failures are indicated
+by thrown exceptions. If no exception is thrown, it can be presumed valid.
+
+=cut
+
+sub verify_json_signature
+{
+   my ( $data, %args ) = @_;
+
+   my $key = $args{public_key} or croak "Require a 'public_key'";
+
+   my $origin = $args{origin} or croak "Require an 'origin'";
+   my $key_id = $args{key_id} or croak "Require a 'key_id'";
+
+   $data->{signatures} or
+      croak "No 'signatures'";
+   $data->{signatures}{$origin} or
+      croak "No signatures from '$origin'";
+
+   my $signature = $data->{signatures}{$origin}{$key_id} or
+      croak "No signature from '$origin' using key '$key_id'";
+
+   $sign->verify( decode_base64( $signature ), encode_json_for_signing( $data ), $key ) or
+      croak "Signature verification failed";
+}
+
+=head2 redact_event
+
+   redact_event( $event )
+
+Modifies the given HASH reference in-place to apply the transformation given
+by the Matrix Event Redaction specification.
+
+=cut
+
+my %ALLOWED_KEYS = map { $_ => 1 } qw(
+   auth_events
+   depth
+   event_id
+   hashes
+   membership
+   origin
+   origin_server_ts
+   prev_events
+   prev_state
+   room_id
+   sender
+   signatures
+   state_key
+   type
+);
+
+my %ALLOWED_CONTENT_BY_TYPE = (
+   "m.room.aliases"            => [qw( aliases )],
+   "m.room.create"             => [qw( creator )],
+   "m.room.history_visibility" => [qw( history_visibility )],
+   "m.room.join_rules"         => [qw( join_rule )],
+   "m.room.member"             => [qw( membership )],
+   "m.room.power_levels"       => [qw(
+      users users_default events events_default state_default ban kick redact
+   )],
+);
+
+sub redact_event
+{
+   my ( $event ) = @_;
+
+   defined( my $type = $event->{type} ) or
+      croak "Event requires a 'type'";
+
+   my $old_content = delete $event->{content};
+   my $old_unsigned = delete $event->{unsigned};
+
+   $ALLOWED_KEYS{$_} or delete $event->{$_} for keys %$event;
+
+   my $new_content = $event->{content} = {};
+
+   if( my $allowed_content_keys = $ALLOWED_CONTENT_BY_TYPE{$type} ) {
+      exists $old_content->{$_} and $new_content->{$_} = $old_content->{$_} for
+         @$allowed_content_keys;
+   }
+
+   $event->{unsigned}{age_ts} = $old_unsigned->{age_ts} if exists $old_unsigned->{age_ts};
+}
+
+sub redacted_event
+{
+   my ( $event ) = @_;
+   redact_event( $event = { %$event } );
+   return $event;
+}
+
+=head2 sign_event_json
+
+   sign_event_json( $data, secret_key => $key, origin => $name, key_id => $id )
+
+Modifies the given HASH reference in-place to add a hash and signature,
+presuming it to be a Matrix event structure. This operates in a fashion
+analogous to L</sign_json>.
+
+=cut
+
+sub sign_event_json
+{
+   my ( $event, %args ) = @_;
+
+   my $key = $args{secret_key} or croak "Require a 'secret_key'";
+
+   my $origin = $args{origin} or croak "Require an 'origin'";
+   my $key_id = $args{key_id} or croak "Require a 'key_id'";
+
+   # 'hashes' records the original unredacted version
+   {
+      my %event_without_hashes = %$event; delete $event_without_hashes{hashes};
+      my $bytes_to_hash = encode_json_for_signing( \%event_without_hashes );
+
+      $event->{hashes}{sha256} = encode_base64_unpadded( sha256( $bytes_to_hash ) );
+   }
+
+   # Signature is of redacted version
+   sign_json( my $signed = redacted_event( $event ), %args );
+
+   $event->{signatures} = $signed->{signatures};
+}
+
+=head2 signed_event_json
+
+   my $event = signed_event_json( $event, ... )
+
+Returns a new HASH reference by cloning the original and applying
+L</sign_event_json> to it. The originally-passed data is unmodified. Takes the
+same arguments as L</sign_event_json>.
+
+=cut
+
+sub signed_event_json
+{
+   my ( $event, @args ) = @_;
+   sign_event_json( $event = { %$event }, @args );
+   return $event;
+}
+
+=head2 verify_event_json_signature
+
+   verify_event_json_signature( $event, public_key => $key, origin => $name, key_id => $id )
+
+=cut
+
+sub verify_event_json_signature
+{
+   my ( $event, @args ) = @_;
+
+   verify_json_signature( redacted_event( $event ), @args );
+}
+
+=head1 AUTHOR
+
+Paul Evans <leonerd@leonerd.org.uk>
+
+=cut
+
+0x55AA;

--- a/lib/Protocol/Matrix/HTTP/Federation.pm
+++ b/lib/Protocol/Matrix/HTTP/Federation.pm
@@ -1,0 +1,68 @@
+#  You may distribute under the terms of either the GNU General Public License
+#  or the Artistic License (the same terms as Perl itself)
+#
+#  (C) Paul Evans, 2015 -- leonerd@leonerd.org.uk
+
+package Protocol::Matrix::HTTP::Federation;
+
+use strict;
+use warnings;
+
+our $VERSION = '0.02';
+
+use HTTP::Request;
+
+=head1 NAME
+
+C<Protocol::Matrix::HTTP::Federation> - helpers for HTTP messages relating to Matrix federation
+
+=cut
+
+sub new
+{
+   bless {}, shift;
+}
+
+=head1 METHODS
+
+=cut
+
+=head2 make_key_v1_request
+
+   $req = $fed->make_key_v1_request( server_name => $name )
+
+=cut
+
+sub make_key_v1_request
+{
+   shift;
+   my %params = @_;
+
+   return HTTP::Request->new(
+      GET => "/_matrix/key/v1",
+      [
+         Host => $params{server_name},
+      ],
+   );
+}
+
+=head2 make_key_v2_server_request
+
+   $req = $fed->make_key_v2_server_request( server_name => $name, key_id => $id )
+
+=cut
+
+sub make_key_v2_server_request
+{
+   shift;
+   my %params = @_;
+
+   return HTTP::Request->new(
+      GET => "/_matrix/key/v2/server/$params{key_id}",
+      [
+         Host => $params{server_name},
+      ],
+   );
+}
+
+0x55AA;

--- a/lib/SyTest/Crypto.pm
+++ b/lib/SyTest/Crypto.pm
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# crypto-related utility functions for SyTest
+
+
+package SyTest::Crypto;
+
+use Crypt::Ed25519;
+
+use Exporter qw( import );
+our @EXPORT_OK = qw( ed25519_nacl_keypair );
+
+=head2 ed25519_nacl_keypair
+
+    ( $public_key, $secret_key ) = ed25519_nacl_keypair( [ $seed ] );
+
+A drop in replacement for Crypt::NaCl::Sodium->sign->keypair.
+
+Generate a new Ed25519 keypair, in a format compatible with the NaCl API.
+
+If the optional seed is given, that is used to determiniatically derive the
+public and secret key.
+
+NaCl (http://nacl.cr.yp.to/) uses "secret keys" which are actually 64-byte
+tuples of (seed, public key) (whereas most other libraries either use just the
+seed, or a "preprocessed" 64-byte private key, which is deterministically
+derived from the seed. SyTest includes a bunch of code which relies on the NaCl
+format, so for now we have this shim to create them.
+
+Deprecated: it's better just to use the `Crypt::Ed25519::eddsa_*` APIs directly.
+
+=cut
+
+sub ed25519_nacl_keypair {
+   my ( $seed ) = @_;
+   $seed //= Crypt::Ed25519::eddsa_secret_key();
+   my $public_key = Crypt::Ed25519::eddsa_public_key($seed);
+   return ( $public_key, $seed.$public_key );
+}
+

--- a/lib/SyTest/Identity/Server.pm
+++ b/lib/SyTest/Identity/Server.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use base qw( Net::Async::HTTP::Server );
 
-use Crypt::NaCl::Sodium;
+use SyTest::Crypto qw( ed25519_nacl_keypair );
 use List::Util qw( any );
 use List::UtilsBy qw( extract_first_by );
 use Protocol::Matrix qw( encode_base64_unpadded sign_json );
@@ -14,8 +14,6 @@ use SyTest::HTTPServer::Request;
 use HTTP::Response;
 use Digest::SHA qw( sha256 );
 use Struct::Dumb qw( struct );
-
-my $crypto_sign = Crypt::NaCl::Sodium->sign;
 
 my $next_token = 0;
 
@@ -64,8 +62,8 @@ sub rotate_keys
 {
    my $self = shift;
 
-   ( $self->{public_key}, $self->{private_key} ) = $crypto_sign->keypair;
-   ( $self->{ephemeral_public_key}, $self->{ephemeral_private_key} ) = $crypto_sign->keypair;
+   ( $self->{public_key}, $self->{private_key} ) = ed25519_nacl_keypair;
+   ( $self->{ephemeral_public_key}, $self->{ephemeral_private_key} ) = ed25519_nacl_keypair;
 
    $self->{keys} = {
       "ed25519:0" => encode_base64_unpadded( $self->{public_key} ),

--- a/tests/41end-to-end-keys/08-cross-signing.pl
+++ b/tests/41end-to-end-keys/08-cross-signing.pl
@@ -1,8 +1,6 @@
-use Crypt::NaCl::Sodium;
+use SyTest::Crypto qw( ed25519_nacl_keypair );
 use MIME::Base64;
 use Protocol::Matrix qw( sign_json );
-
-my $crypto_sign = Crypt::NaCl::Sodium->sign;
 
 test "Can upload self-signing keys",
    requires => [ local_user_fixture() ],
@@ -109,8 +107,8 @@ test "Changing master key notifies local users",
       my $user_id = $user1->user_id;
       my $device_id = $user1->device_id;
 
-      my ( $master_pubkey, $master_secret_key ) = $crypto_sign->keypair( decode_base64( "2lonYOM6xYKdEsO+6KrC766xBcHnYnim1x/4LFGF8B0" ) );
-      my ( $self_signing_pubkey, $self_signing_secret_key ) = $crypto_sign->keypair( decode_base64( "HvQBbU+hc2Zr+JP1sE0XwBe1pfZZEYtJNPJLZJtS+F8" ) );
+      my ( $master_pubkey, $master_secret_key ) = ed25519_nacl_keypair( decode_base64( "2lonYOM6xYKdEsO+6KrC766xBcHnYnim1x/4LFGF8B0" ) );
+      my ( $self_signing_pubkey, $self_signing_secret_key ) = ed25519_nacl_keypair( decode_base64( "HvQBbU+hc2Zr+JP1sE0XwBe1pfZZEYtJNPJLZJtS+F8" ) );
       my $cross_signature;
 
       matrix_sync( $user1 )->then(sub {
@@ -259,9 +257,9 @@ test "Changing user-signing key notifies local users",
       my $device_id = $user1->device_id;
       my $user2_id = $user2->user_id;
 
-      my ( $master_pubkey, $master_secret_key ) = $crypto_sign->keypair( decode_base64( "2lonYOM6xYKdEsO+6KrC766xBcHnYnim1x/4LFGF8B0" ) );
-      my ( $self_signing_pubkey, $self_signing_secret_key ) = $crypto_sign->keypair( decode_base64( "HvQBbU+hc2Zr+JP1sE0XwBe1pfZZEYtJNPJLZJtS+F8" ) );
-      my ( $user_signing_pubkey, $user_signing_secret_key ) = $crypto_sign->keypair( decode_base64( "4TL4AjRYwDVwD3pqQzcor+ez/euOB1/q78aTJ+czDNs" ) );
+      my ( $master_pubkey, $master_secret_key ) = ed25519_nacl_keypair( decode_base64( "2lonYOM6xYKdEsO+6KrC766xBcHnYnim1x/4LFGF8B0" ) );
+      my ( $self_signing_pubkey, $self_signing_secret_key ) = ed25519_nacl_keypair( decode_base64( "HvQBbU+hc2Zr+JP1sE0XwBe1pfZZEYtJNPJLZJtS+F8" ) );
+      my ( $user_signing_pubkey, $user_signing_secret_key ) = ed25519_nacl_keypair( decode_base64( "4TL4AjRYwDVwD3pqQzcor+ez/euOB1/q78aTJ+czDNs" ) );
       my $cross_signature;
 
       matrix_sync( $user1 )->then(sub {
@@ -422,7 +420,7 @@ test "can fetch self-signing keys over federation",
 
       my $user2_id = $user2->user_id;
 
-      my ( $master_pubkey, $master_secret_key ) = $crypto_sign->keypair( decode_base64( "2lonYOM6xYKdEsO+6KrC766xBcHnYnim1x/4LFGF8B0" ) );
+      my ( $master_pubkey, $master_secret_key ) = ed25519_nacl_keypair( decode_base64( "2lonYOM6xYKdEsO+6KrC766xBcHnYnim1x/4LFGF8B0" ) );
       my $self_signing_key = {
          # private key: HvQBbU+hc2Zr+JP1sE0XwBe1pfZZEYtJNPJLZJtS+F8
          "user_id" => $user2_id,
@@ -493,7 +491,7 @@ test "uploading self-signing key notifies over federation",
 
       my $room_id;
 
-      my ( $master_pubkey, $master_secret_key ) = $crypto_sign->keypair( decode_base64( "2lonYOM6xYKdEsO+6KrC766xBcHnYnim1x/4LFGF8B0" ) );
+      my ( $master_pubkey, $master_secret_key ) = ed25519_nacl_keypair( decode_base64( "2lonYOM6xYKdEsO+6KrC766xBcHnYnim1x/4LFGF8B0" ) );
       my $self_signing_key = {
          # private key: HvQBbU+hc2Zr+JP1sE0XwBe1pfZZEYtJNPJLZJtS+F8
          "user_id" => $user2_id,
@@ -592,8 +590,8 @@ test "uploading signed devices gets propagated over federation",
 
       my $room_id;
 
-      my ( $master_pubkey, $master_secret_key ) = $crypto_sign->keypair( decode_base64( "2lonYOM6xYKdEsO+6KrC766xBcHnYnim1x/4LFGF8B0" ) );
-      my ( $self_signing_pubkey, $self_signing_secret_key ) = $crypto_sign->keypair( decode_base64( "HvQBbU+hc2Zr+JP1sE0XwBe1pfZZEYtJNPJLZJtS+F8" ) );
+      my ( $master_pubkey, $master_secret_key ) = ed25519_nacl_keypair( decode_base64( "2lonYOM6xYKdEsO+6KrC766xBcHnYnim1x/4LFGF8B0" ) );
+      my ( $self_signing_pubkey, $self_signing_secret_key ) = ed25519_nacl_keypair( decode_base64( "HvQBbU+hc2Zr+JP1sE0XwBe1pfZZEYtJNPJLZJtS+F8" ) );
       my $self_signing_key = {
          # private key: HvQBbU+hc2Zr+JP1sE0XwBe1pfZZEYtJNPJLZJtS+F8
          "user_id" => $user2_id,

--- a/tests/50federation/00prepare.pl
+++ b/tests/50federation/00prepare.pl
@@ -5,11 +5,10 @@ Net::Async::HTTP->VERSION( '0.39' ); # ->GET with 'headers'
 
 require IO::Async::SSL;
 
-use Crypt::NaCl::Sodium;
-
 use SyTest::Federation::Datastore;
 use SyTest::Federation::Client;
 use SyTest::Federation::Server;
+use SyTest::Crypto qw( ed25519_nacl_keypair );
 
 push our @EXPORT, qw( INBOUND_SERVER OUTBOUND_CLIENT create_federation_server );
 
@@ -28,7 +27,7 @@ sub create_federation_server
       # common name.
       my $server_name = sprintf "%s:%d", $BIND_HOST, $sock->sockport;
 
-      my ( $pkey, $skey ) = Crypt::NaCl::Sodium->sign->keypair;
+      my ( $pkey, $skey ) = ed25519_nacl_keypair;
 
       my $datastore = SyTest::Federation::Datastore->new(
          server_name => $server_name,

--- a/tests/50federation/01keys.pl
+++ b/tests/50federation/01keys.pl
@@ -368,7 +368,8 @@ sub build_key_response {
    my $skey = $params{key};
    my $expiry = $params{valid_until_ts};
 
-   my $pkey = Crypt::NaCl::Sodium->sign->public_key( $skey );
+   # libsodium's "private keys" are actually 64-byte tuples of (seed, public key).
+   my $pkey = substr( $skey, 32, 32);
 
    my $response = {
       server_name => $server_name,

--- a/tests/50federation/01keys.pl
+++ b/tests/50federation/01keys.pl
@@ -1,10 +1,7 @@
 use List::Util qw( first );
-
-use Crypt::NaCl::Sodium;
-
+use Crypt::Ed25519;
 use Protocol::Matrix qw( encode_json_for_signing sign_json encode_base64_unpadded );
-
-my $crypto_sign = Crypt::NaCl::Sodium->sign;
+use SyTest::Crypto qw( ed25519_nacl_keypair );
 
 test "Federation key API allows unsigned requests for keys",
    requires => [ $main::HOMESERVER_INFO[0], $main::HTTP_CLIENT ],
@@ -65,7 +62,7 @@ test "Federation key API allows unsigned requests for keys",
 
          log_if_fail "Signed bytes", $signed_bytes ;
 
-         $crypto_sign->verify( $signature, $signed_bytes, $key ) or
+         Crypt::Ed25519::verify( $signed_bytes, $key, $signature ) or
             die "Signature verification failed";
 
          # old_verify_keys is mandatory, even if it's empty
@@ -157,7 +154,7 @@ foreach my $method (keys %FETCHERS) {
             )->then( sub {
                my ( $server_key ) = @_;
 
-               $crypto_sign->verify( $signature, $signed_bytes, $server_key ) or
+               Crypt::Ed25519::verify( $signed_bytes, $server_key, $signature ) or
                   die "Signature verification failed";
 
                Future->done(1);
@@ -173,7 +170,7 @@ test "Key notary server should return an expired key if it can't find any others
       my ( $notary_server, $http_client, $http_server ) = @_;
       my $test_server_name = $http_server->server_name;
 
-      my ( $pkey, $skey ) = Crypt::NaCl::Sodium->sign->keypair;
+      my ( $pkey, $skey ) = ed25519_nacl_keypair;
       my $key_id = "ed25519:key_0";
       my $key_expiry = int(( time - 86400 ) * 1000); # -24h in msec
       my $key_response = build_key_response(
@@ -280,7 +277,7 @@ test "Key notary server must not overwrite a valid key with a spurious result fr
       # origin server, and key_2, which is just used to sign an itermediate
       # response.
 
-      my ( $pkey1, $skey1 ) = Crypt::NaCl::Sodium->sign->keypair;
+      my ( $pkey1, $skey1 ) = ed25519_nacl_keypair;
       my $key_id_1 = "ed25519:key_1";
       my $key1_expiry = int(( time - 86400 ) * 1000); # -24h in msec
 
@@ -324,7 +321,7 @@ test "Key notary server must not overwrite a valid key with a spurious result fr
 
                log_if_fail "Request 2 from notary server: " . $request->method . " " . $request->path;
 
-               my ( $pkey2, $skey2 ) = Crypt::NaCl::Sodium->sign->keypair;
+               my ( $pkey2, $skey2 ) = ed25519_nacl_keypair;
                $request->respond_json( build_key_response(
                   server_name => $test_server_name,
                   key => $skey2,

--- a/tests/50federation/01keys.pl
+++ b/tests/50federation/01keys.pl
@@ -57,6 +57,7 @@ test "Federation key API allows unsigned requests for keys",
 
          assert_base64_unpadded( $signature );
          $signature = decode_base64 $signature;
+         assert_eq( length( $signature ), 64, "signature length" );
 
          my $signed_bytes = encode_json_for_signing( $body );
 
@@ -145,6 +146,7 @@ foreach my $method (keys %FETCHERS) {
 
             assert_base64_unpadded( $signature_base64 );
             my $signature = decode_base64 $signature_base64;
+            assert_eq( length( $signature ), 64, "signature length" );
 
             my $signed_bytes = encode_json_for_signing( $key );
 

--- a/tests/50federation/02server-names.pl
+++ b/tests/50federation/02server-names.pl
@@ -1,3 +1,5 @@
+use SyTest::Crypto qw( ed25519_nacl_keypair );
+
 # check that the rules around server_names are enforced
 
 test "Non-numeric ports in server names are rejected",
@@ -6,7 +8,7 @@ test "Non-numeric ports in server names are rejected",
    do => sub {
       my ( $info, $user ) = @_;
 
-      my ( $pkey, $skey ) = Crypt::NaCl::Sodium->sign->keypair;
+      my ( $pkey, $skey ) = ed25519_nacl_keypair;
 
       my $datastore = SyTest::Federation::Datastore->new(
          server_name => "localhost:http",


### PR DESCRIPTION
First we vendor in `Protocol::Matrix`. Then we patch it to use `Crypt::Ed25519` instead of `Crypt::NaCl::Sodium`. Then we switch the rest of sytest to use `Crypt::Ed25519`.

Hopefully fixes #1114, and generally makes sytest a whole lot easier to install.