### PR TITLE
Add support for testing on Python 3.10

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,6 +23,8 @@ jobs:
             tag: buster
           - base_image: debian:testing
             tag: testing
+          - base_image: debian:bookworm
+            tag: bookworm
     steps:
       - name: Set up Docker Buildx
         id: buildx
@@ -60,6 +62,9 @@ jobs:
           - sytest_image_tag: buster
             dockerfile: synapse
             tags: "matrixdotorg/sytest-synapse:buster"
+          - sytest_image_tag: bookworm
+            dockerfile: synapse
+            tags: "matrixdotorg/sytest-synapse:bookworm"
           - sytest_image_tag: testing
             dockerfile: synapse
             tags: "matrixdotorg/sytest-synapse:testing"

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -32,6 +32,15 @@ jobs:
             postgres: postgres
             workers: workers
 
+          - label: Py 3.10, PG 14, Monolith
+            sytest-tag: bookworm
+            postgres: postgres
+
+          - label: Py 3.10, PG 14, Workers
+            sytest-tag: bookworm
+            postgres: postgres
+            workers: workers
+
           - label: debian-testing, Monolith
             sytest-tag: testing
             postgres: postgres


### PR DESCRIPTION
As the title states. One of the tasks outlined here:  #11780. Builds a new Docker image with debian:bookworm as the base, pushes it to DockerHub and adds the new image to CI for testing.  