### PR TITLE
Handle servers which decide to make `/state` requests

### DIFF
--- a/tests/50federation/33room-get-missing-events.pl
+++ b/tests/50federation/33room-get-missing-events.pl
@@ -377,21 +377,49 @@ test "outliers whose auth_events are in a different room are correctly rejected"
             Future->done(1);
          }),
       )->then( sub {
-         # wait for S to turn up
-         await_sync_timeline_contains(
-            $creator_user, $room2->room_id, check => sub {
-               my ( $event ) = @_;
-               log_if_fail "Got event in room2", $event;
+         # the server may send a /state request; be prepared to answer that.
+         # (it may, alternatively, send individual /event requests)
+         my $state_req_fut = $inbound_server->await_request_v1_state(
+            $room2->{room_id}, $event_id_Q,
+         )->then( sub {
+            my ( $req, @params ) = @_;
+            log_if_fail "/state request", \@params;
 
-               my $event_id = $event->{event_id};
+            my $resp = {
+               state => [ values( %initial_room2_state ) ],
+               auth_chain => [
+                  map { $inbound_server->datastore->get_event( $_ ) } @{ $room2->event_ids_from_refs( $event_Q->{auth_events} ) },
+               ],
+            };
 
-               # if either Q or R show up, that's a problem
-               if( $event->{sender} eq $sytest_user_1 ) {
-                  die "Got an event $event_id from a user who shouldn't be a member";
-               }
+            log_if_fail "/state response", $resp;
+            $req->respond_json( $resp );
 
-               return $event_id eq $event_id_S;
-            },
+            # return a future which never completes, so that wait_any is not
+            # satisfied.
+            return Future->new();
+         });
+
+
+         # wait for either S to turn up in /sync, or $state_req_fut to fail.
+         Future->wait_any(
+            $state_req_fut,
+
+            await_sync_timeline_contains(
+               $creator_user, $room2->room_id, check => sub {
+                  my ( $event ) = @_;
+                  log_if_fail "Got event in room2", $event;
+
+                  my $event_id = $event->{event_id};
+
+                  # if either Q or R show up, that's a problem
+                  if( $event->{sender} eq $sytest_user_1 ) {
+                     die "Got an event $event_id from a user who shouldn't be a member";
+                  }
+
+                  return $event_id eq $event_id_S;
+               },
+            ),
          );
       })->then( sub {
          # finally, check that the state in room 2 looks correct.

--- a/tests/50federation/34room-backfill.pl
+++ b/tests/50federation/34room-backfill.pl
@@ -363,15 +363,48 @@ test "Backfilled events whose prev_events are in a different room do not allow c
             destination => $synapse_server_name,
          );
       })->then( sub {
-         # wait for S to arrive
+         # the server may send a /state request; be prepared to answer that.
+         # (it may, alternatively, send individual /event requests)
+         my $state_req_fut = $inbound_server->await_request_v1_state(
+            $room2->{room_id}, $event_id_Q,
+         )->then( sub {
+            my ( $req, @params ) = @_;
+            log_if_fail "/state request", \@params;
+
+
+            my %state  = %{ $room2->{current_state} };
+            my $resp = {
+               state => [ values( %state ) ],
+
+               # XXX we're supposed to return the whole auth chain here,
+               # not just Q's auth_events. It doesn't matter too much
+               # here though.
+               auth_chain => [
+                  map { $inbound_server->datastore->get_event( $_ ) } @{ $room2->event_ids_from_refs( $event_Q->{auth_events} ) },
+               ],
+            };
+
+            log_if_fail "/state response", $resp;
+            $req->respond_json( $resp );
+
+            # return a future which never completes, so that wait_any is not
+            # satisfied.
+            return Future->new();
+         });
+
          log_if_fail "Awating arrival of event S $event_id_S in room $room2_id";
 
-         await_sync_timeline_contains(
-            $creator_user, $room2_id,
-            check => sub {
-               $_[0]->{event_id} eq $event_id_S
-            },
-         );
+         # wait for either S to turn up in /sync, or $state_req_fut to fail.
+         Future->wait_any(
+            $state_req_fut,
+
+            await_sync_timeline_contains(
+               $creator_user, $room2_id,
+               check => sub {
+                  $_[0]->{event_id} eq $event_id_S
+               },
+            ),
+        );
       })->then( sub {
          my $filter = $json->encode( { room => { timeline => { limit => 2 }}} );
          matrix_sync(

--- a/tests/50federation/34room-backfill.pl
+++ b/tests/50federation/34room-backfill.pl
@@ -304,6 +304,34 @@ test "Backfilled events whose prev_events are in a different room do not allow c
 
       log_if_fail "events P, Q, R, S", [ $event_id_P, $event_id_Q, $event_id_R, $event_id_S ];
 
+      # the server may send a /state request; be prepared to answer that.
+      # (it may, alternatively, send individual /event requests)
+      my $state_req_fut = $inbound_server->await_request_v1_state(
+         $room2->{room_id}, $event_id_Q,
+      )->then( sub {
+         my ( $req, @params ) = @_;
+         log_if_fail "/state request (1)", \@params;
+
+         my %state  = %{ $room2->{current_state} };
+         my $resp = {
+            state => [ values( %state ) ],
+
+            # XXX we're supposed to return the whole auth chain here,
+            # not just Q's auth_events. It doesn't matter too much
+            # here though.
+            auth_chain => [
+               map { $inbound_server->datastore->get_event( $_ ) } @{ $room2->event_ids_from_refs( $event_Q->{auth_events} ) },
+            ],
+         };
+
+         log_if_fail "/state response (1)", $resp;
+         $req->respond_json( $resp );
+
+         # return a future which never completes, so that wait_any is not
+         # satisfied.
+         return Future->new();
+      });
+
       Future->needs_all(
          # kick things off by sending S over federation
          $outbound_client->send_event(
@@ -363,34 +391,6 @@ test "Backfilled events whose prev_events are in a different room do not allow c
             destination => $synapse_server_name,
          );
       })->then( sub {
-         # the server may send a /state request; be prepared to answer that.
-         # (it may, alternatively, send individual /event requests)
-         my $state_req_fut = $inbound_server->await_request_v1_state(
-            $room2->{room_id}, $event_id_Q,
-         )->then( sub {
-            my ( $req, @params ) = @_;
-            log_if_fail "/state request (1)", \@params;
-
-            my %state  = %{ $room2->{current_state} };
-            my $resp = {
-               state => [ values( %state ) ],
-
-               # XXX we're supposed to return the whole auth chain here,
-               # not just Q's auth_events. It doesn't matter too much
-               # here though.
-               auth_chain => [
-                  map { $inbound_server->datastore->get_event( $_ ) } @{ $room2->event_ids_from_refs( $event_Q->{auth_events} ) },
-               ],
-            };
-
-            log_if_fail "/state response (1)", $resp;
-            $req->respond_json( $resp );
-
-            # return a future which never completes, so that wait_any is not
-            # satisfied.
-            return Future->new();
-         });
-
          log_if_fail "Awating arrival of event S $event_id_S in room $room2_id";
 
          # wait for either S to turn up in /sync, or $state_req_fut to fail.


### PR DESCRIPTION
Some server implementations may make `/state` requests when there is a large
amount of state to sync up; add code to handle that.