### PR TITLE
Update tests to be nicer to Dendrite

### DIFF
--- a/tests/11register.pl
+++ b/tests/11register.pl
@@ -317,7 +317,7 @@ test "registration is idempotent, without username specified",
          uri    => "/r0/register",
 
          content => {
-            password => "s3kr1t",
+            password => "sUp3rs3kr1t",
          },
       )->main::expect_http_401->then( sub {
          my ( $response ) = @_;
@@ -334,7 +334,7 @@ test "registration is idempotent, without username specified",
             uri    => "/r0/register",
 
             content => {
-               password => "s3kr1t",
+               password => "sUp3rs3kr1t",
                auth     => {
                   session => $session,
                   type    => "m.login.dummy",
@@ -355,7 +355,7 @@ test "registration is idempotent, without username specified",
             uri    => "/r0/register",
 
             content => {
-               password => "s3kr1t",
+               password => "sUp3rs3kr1t",
                auth     => {
                   session => $session,
                   type    => "m.login.dummy",
@@ -390,7 +390,7 @@ test "registration is idempotent, with username specified",
 
          content => {
             username => $localpart,
-            password => "s3kr1t",
+            password => "sUp3rs3kr1t",
          },
       )->main::expect_http_401->then( sub {
          my ( $response ) = @_;
@@ -408,7 +408,7 @@ test "registration is idempotent, with username specified",
 
             content => {
                username => $localpart,
-               password => "s3kr1t",
+               password => "sUp3rs3kr1t",
                auth     => {
                   session => $session,
                   type    => "m.login.dummy",
@@ -428,7 +428,7 @@ test "registration is idempotent, with username specified",
 
             content => {
                username => $localpart,
-               password => "s3kr1t",
+               password => "sUp3rs3kr1t",
                auth     => {
                   session => $session,
                   type    => "m.login.dummy",
@@ -468,7 +468,7 @@ test "registration remembers parameters",
 
          content => {
             username => $localpart,
-            password => "s3kr1t",
+            password => "sUp3rs3kr1t",
             device_id => "xyzzy",
             initial_device_display_name => "display_name",
          },
@@ -578,7 +578,7 @@ test "registration with inhibit_login inhibits login",
 
          content => {
             username => $localpart,
-            password => "s3kr1t",
+            password => "sUp3rs3kr1t",
             inhibit_login => JSON::true,
          },
       )->main::expect_http_401->then( sub {

--- a/tests/42tags.pl
+++ b/tests/42tags.pl
@@ -185,6 +185,7 @@ sub check_tag_event {
 
 
 test "Tags appear in the v1 /events stream",
+   deprecated_endpoints => 1;
    requires => [ local_user_fixture( with_events => 1 ),
                  qw( can_add_tag can_remove_tag ) ],
 

--- a/tests/60app-services/02ghost.pl
+++ b/tests/60app-services/02ghost.pl
@@ -68,10 +68,9 @@ multi_test "AS-ghosted users can use rooms via AS",
          )
       })->SyTest::pass_on_done( "User posted message via AS" )
       ->then( sub {
-         await_event_for( $creator, filter => sub {
+         await_sync_timeline_contains( $creator, $room_id, check => sub {
             my ( $event ) = @_;
             return unless $event->{type} eq "m.room.message";
-            return unless $event->{room_id} eq $room_id;
 
             log_if_fail "Event", $event;
 
@@ -79,7 +78,7 @@ multi_test "AS-ghosted users can use rooms via AS",
 
             $content->{body} eq "Message from AS directly" or
                die "Expected 'body' as 'Message from AS directly'";
-            $event->{user_id} eq $ghost->user_id or
+            $event->{sender} eq $ghost->user_id or
                die "Expected sender user_id as ${\$ghost->user_id}";
 
             return 1;
@@ -139,10 +138,9 @@ multi_test "AS-ghosted users can use rooms themselves",
          )
       })->SyTest::pass_on_done( "Ghost posted message themselves" )
       ->then( sub {
-         await_event_for( $creator, filter => sub {
+         await_sync_timeline_contains( $creator, $room_id, check => sub {
             my ( $event ) = @_;
             return unless $event->{type} eq "m.room.message";
-            return unless $event->{room_id} eq $room_id;
 
             log_if_fail "Event", $event;
 
@@ -150,7 +148,7 @@ multi_test "AS-ghosted users can use rooms themselves",
 
             $content->{body} eq "Message from AS Ghost" or
                die "Expected 'body' as 'Message from AS Ghost'";
-            $event->{user_id} eq $ghost->user_id or
+            $event->{sender} eq $ghost->user_id or
                die "Expected sender user_id as ${\$ghost->user_id}";
 
             return 1;


### PR DESCRIPTION
[Synapse](https://github.com/matrix-org/synapse/blob/6d14b3dabfe38c6ae487d0f663e294056b6cc056/synapse/handlers/room.py#L120-L133) sets the `power_level_content_override` by default, if it is not set, resulting in non-spec behavior in Dendrite with this test.
This sets the `power_level_content_override` as per the Synapse code, so Dendrite can pass this test (would timeout before, because the inviting user wasn't allowed to invite the creator of the room)

I've also tried to update some of the `repeat_until_true` calls to use `retry_until_success` instead. Also uses `await_sync_timeline_contains` instead of calls to `/events`