### PR TITLE
Minor changes to allow Dendrite to pass more tests

### DIFF
--- a/tests/10apidoc/13ui-auth.pl
+++ b/tests/10apidoc/13ui-auth.pl
@@ -369,7 +369,7 @@ test "The user must be consistent through an interactive authentication session 
          my ( $device ) = @_;
          assert_json_keys(
             $device,
-            qw( device_id user_id display_name ),
+            qw( device_id display_name ),
          );
          assert_eq( $device->{device_id}, $DEVICE_ID );
          assert_eq( $device->{display_name}, "device display" );
@@ -430,7 +430,7 @@ test "The operation must be consistent through an interactive authentication ses
          my ( $device ) = @_;
          assert_json_keys(
             $device,
-            qw( device_id user_id display_name ),
+            qw( device_id display_name ),
          );
          assert_eq( $device->{device_id}, $SECOND_DEVICE_ID );
          assert_eq( $device->{display_name}, "device display" );

--- a/tests/90jira/SYN-516.pl
+++ b/tests/90jira/SYN-516.pl
@@ -23,7 +23,7 @@ multi_test "Multiple calls to /sync should not cause 500 errors",
         })->then( sub {
             ( $room_id ) = @_;
 
-            matrix_typing( $user, $room_id, typing => 1, timeout => 30000 )
+            matrix_typing( $user, $room_id, typing => JSON::true, timeout => 30000 )
                 ->SyTest::pass_on_done( "Sent typing notification" );
         })->then( sub {
             matrix_send_room_message( $user, $room_id,


### PR DESCRIPTION
`GET /_matrix/client/v3/devices/{deviceId}` doesn't return the `user_id` anymore.
And `1` can't parsed as `true`.