### PR TITLE
Goodbye, synapse's scripts directory

### DIFF
--- a/scripts/synapse_sytest.sh
+++ b/scripts/synapse_sytest.sh
@@ -122,7 +122,7 @@ fi
 if [ -d "$SYNAPSE_SOURCE" ]; then
     echo "Creating tarball from synapse source"
     tar -C "$SYNAPSE_SOURCE" -czf /tmp/synapse.tar.gz \
-        synapse scripts setup.py README.rst synctl MANIFEST.in
+        synapse setup.py README.rst synctl MANIFEST.in
     SYNAPSE_SOURCE="/tmp/synapse.tar.gz"
 elif [ ! -r "$SYNAPSE_SOURCE" ]; then
     echo "Unable to read synapse source at $SYNAPSE_SOURCE" >&2


### PR DESCRIPTION
In https://github.com/matrix-org/synapse/pull/12118 I am moving scripts into synapse to make CI config neater and tidier. Update Sytest's glue scripts to no longer require the scripts directory to be present. 