### PR TITLE
Use `/v3` endpoints

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -1284,10 +1284,10 @@ sub generate_haproxy_map
    # haproxy. Also, the routing for GET requests below takes precedence over
    # these routes.
    my $haproxy_map = <<'EOCONFIG';
-^/_matrix/client/(v2_alpha|r0)/sync$                  synchrotron
+^/_matrix/client/(v2_alpha|r0|v3)/sync$                  synchrotron
 ^/_matrix/client/(api/v1|v2_alpha|r0)/events$         synchrotron
-^/_matrix/client/(api/v1|r0)/initialSync$             synchrotron
-^/_matrix/client/(api/v1|r0)/rooms/[^/]+/initialSync$ synchrotron
+^/_matrix/client/(api/v1|r0|v3)/initialSync$             synchrotron
+^/_matrix/client/(api/v1|r0|v3)/rooms/[^/]+/initialSync$ synchrotron
 
 ^/_matrix/media/    media_repository
 
@@ -1311,44 +1311,44 @@ sub generate_haproxy_map
 ^/_matrix/federation/v1/user/devices/                 federation_reader
 ^/_matrix/key/v2/query                                federation_reader
 
-^/_matrix/client/(api/v1|r0|unstable)/publicRooms$                client_reader
-^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/joined_members$    client_reader
-^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/context/.*$        client_reader
-^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/members$           client_reader
-^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/state$             client_reader
-^/_matrix/client/(api/v1|r0|unstable)/login$                      client_reader
-^/_matrix/client/(api/v1|r0|unstable)/account/3pid$               client_reader
+^/_matrix/client/(api/v1|r0|v3|unstable)/publicRooms$                client_reader
+^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/joined_members$    client_reader
+^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/context/.*$        client_reader
+^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/members$           client_reader
+^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/state$             client_reader
+^/_matrix/client/(api/v1|r0|v3|unstable)/login$                      client_reader
+^/_matrix/client/(api/v1|r0|v3|unstable)/account/3pid$               client_reader
 ^/_matrix/client/versions$                                        client_reader
-^/_matrix/client/(api/v1|r0|unstable)/voip/turnServer$            client_reader
-^/_matrix/client/(r0|unstable)/register$                          client_reader
-^/_matrix/client/(r0|unstable)/auth/.*/fallback/web$              client_reader
-^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/messages$          client_reader
-^/_matrix/client/(api/v1|r0|unstable)/get_groups_publicised$      client_reader
-^/_matrix/client/(api/v1|r0|unstable)/joined_groups$              client_reader
-^/_matrix/client/(api/v1|r0|unstable)/publicised_groups$          client_reader
-^/_matrix/client/(api/v1|r0|unstable)/publicised_groups/          client_reader
-^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/event              client_reader
-^/_matrix/client/(api/v1|r0|unstable)/joined_rooms                client_reader
-^/_matrix/client/(api/v1|r0|unstable/.*)/rooms/.*/aliases         client_reader
-^/_matrix/client/(api/v1|r0|unstable)/search                      client_reader
+^/_matrix/client/(api/v1|r0|v3|unstable)/voip/turnServer$            client_reader
+^/_matrix/client/(r0|v3|unstable)/register$                          client_reader
+^/_matrix/client/(r0|v3|unstable)/auth/.*/fallback/web$              client_reader
+^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/messages$          client_reader
+^/_matrix/client/(api/v1|r0|v3|unstable)/get_groups_publicised$      client_reader
+^/_matrix/client/(api/v1|r0|v3|unstable)/joined_groups$              client_reader
+^/_matrix/client/(api/v1|r0|v3|unstable)/publicised_groups$          client_reader
+^/_matrix/client/(api/v1|r0|v3|unstable)/publicised_groups/          client_reader
+^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/event              client_reader
+^/_matrix/client/(api/v1|r0|v3|unstable)/joined_rooms                client_reader
+^/_matrix/client/(api/v1|r0|v3|unstable/.*)/rooms/.*/aliases         client_reader
+^/_matrix/client/(api/v1|r0|v3|unstable)/search                      client_reader
 
-^/_matrix/client/(api/v1|r0|unstable)/devices$                    stream_writer
-^/_matrix/client/(api/v1|r0|unstable)/keys/query$                 stream_writer
-^/_matrix/client/(api/v1|r0|unstable)/keys/changes$               stream_writer
-^/_matrix/client/(api/v1|r0|unstable)/keys/claim                  stream_writer
-^/_matrix/client/(api/v1|r0|unstable)/room_keys                   stream_writer
-^/_matrix/client/(api/v1|r0|unstable)/presence/                   stream_writer
+^/_matrix/client/(api/v1|r0|v3|unstable)/devices$                    stream_writer
+^/_matrix/client/(api/v1|r0|v3|unstable)/keys/query$                 stream_writer
+^/_matrix/client/(api/v1|r0|v3|unstable)/keys/changes$               stream_writer
+^/_matrix/client/(api/v1|r0|v3|unstable)/keys/claim                  stream_writer
+^/_matrix/client/(api/v1|r0|v3|unstable)/room_keys                   stream_writer
+^/_matrix/client/(api/v1|r0|v3|unstable)/presence/                   stream_writer
 
-^/_matrix/client/(api/v1|r0|unstable)/keys/upload  frontend_proxy
+^/_matrix/client/(api/v1|r0|v3|unstable)/keys/upload  frontend_proxy
 
-^/_matrix/client/(r0|unstable|v2_alpha)/user_directory/    user_dir
+^/_matrix/client/(r0|v3|unstable|v2_alpha)/user_directory/    user_dir
 
-^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/redact                               event_creator
-^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/send                                 event_creator
-^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/(join|invite|leave|ban|unban|kick)$  event_creator
-^/_matrix/client/(api/v1|r0|unstable)/join/                                         event_creator
-^/_matrix/client/(api/v1|r0|unstable)/profile/                                      event_creator
-^/_matrix/client/(api/v1|r0|unstable)/createRoom                                    event_creator
+^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/redact                               event_creator
+^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/send                                 event_creator
+^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/(join|invite|leave|ban|unban|kick)$  event_creator
+^/_matrix/client/(api/v1|r0|v3|unstable)/join/                                         event_creator
+^/_matrix/client/(api/v1|r0|v3|unstable)/profile/                                      event_creator
+^/_matrix/client/(api/v1|r0|v3|unstable)/createRoom                                    event_creator
 
 EOCONFIG
 
@@ -1356,12 +1356,12 @@ EOCONFIG
    if ( $self->{redis_host} ne '' ) {
       $haproxy_map .= <<'EOCONFIG';
 
-^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/typing     stream_writer
-^/_matrix/client/(api/v1|r0|unstable)/sendToDevice/          stream_writer
-^/_matrix/client/(api/v1|r0|unstable)/.*/tags                stream_writer
-^/_matrix/client/(api/v1|r0|unstable)/.*/account_data        stream_writer
-^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/receipt       stream_writer
-^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/read_markers  stream_writer
+^/_matrix/client/(api/v1|r0|v3|v3|unstable)/rooms/.*/typing     stream_writer
+^/_matrix/client/(api/v1|r0|v3|unstable)/sendToDevice/          stream_writer
+^/_matrix/client/(api/v1|r0|v3|unstable)/.*/tags                stream_writer
+^/_matrix/client/(api/v1|r0|v3|unstable)/.*/account_data        stream_writer
+^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/receipt       stream_writer
+^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/read_markers  stream_writer
 
 EOCONFIG
    }
@@ -1373,10 +1373,10 @@ sub generate_haproxy_get_map
 {
     return <<'EOCONFIG';
 # pushrules should be here, but the tests seem to be racy.
-# ^/_matrix/client/(api/v1|r0|unstable)/pushrules/            client_reader
-^/_matrix/client/(api/v1|r0|unstable)/groups/               client_reader
-^/_matrix/client/r0/user/[^/]*/account_data/                client_reader
-^/_matrix/client/r0/user/[^/]*/rooms/[^/]*/account_data/    client_reader
+# ^/_matrix/client/(api/v1|r0|v3|unstable)/pushrules/            client_reader
+^/_matrix/client/(api/v1|r0|v3|unstable)/groups/               client_reader
+^/_matrix/client/(r0|v3)/user/[^/]*/account_data/                client_reader
+^/_matrix/client/(r0|v3)/user/[^/]*/rooms/[^/]*/account_data/    client_reader
 
 ^/_matrix/federation/v1/groups/                             federation_reader
 EOCONFIG

--- a/tests/10apidoc/01register.pl
+++ b/tests/10apidoc/01register.pl
@@ -13,7 +13,7 @@ test "GET /register yields a set of flows",
 
       $http->do_request_json(
          method => "POST",
-         uri    => "/r0/register",
+         uri    => "/v3/register",
 
          content => {},
       )->main::expect_http_401
@@ -23,11 +23,11 @@ test "GET /register yields a set of flows",
          # Despite being an HTTP failure, the body is still JSON encoded and
          # has useful information
          assert_eq( $response->content_type, "application/json",
-            'POST /r0/register results in application/json 401 failure'
+            'POST /v3/register results in application/json 401 failure'
          );
 
          my $body = decode_json( $response->content );
-         log_if_fail "/r0/register flow information", $body;
+         log_if_fail "/v3/register flow information", $body;
 
          assert_json_keys( $body, qw( flows ));
          ref $body->{flows} eq "ARRAY" or die "Expected 'flows' as a list";
@@ -60,7 +60,7 @@ test "POST /register can create a user",
 
       $http->do_request_json(
          method => "POST",
-         uri    => "/r0/register",
+         uri    => "/v3/register",
 
          content => {
             auth => {
@@ -87,7 +87,7 @@ test "POST /register downcases capitals in usernames",
 
       $http->do_request_json(
          method => "POST",
-         uri    => "/r0/register",
+         uri    => "/v3/register",
 
          content => {
             auth => {
@@ -117,7 +117,7 @@ test "POST /register returns the same device_id as that in the request",
 
       $http->do_request_json(
          method => "POST",
-         uri    => "/r0/register",
+         uri    => "/v3/register",
 
          content => {
             auth => {
@@ -159,7 +159,7 @@ foreach my $chr (split '', '!":?\@[]{|}£é' . "\n'" ) {
          # registration without the dodgy char should be ok
          $http->do_request_json(
             method => "POST",
-            uri    => "/r0/register",
+            uri    => "/v3/register",
 
             content => $reqbody,
          )->then( sub {
@@ -167,7 +167,7 @@ foreach my $chr (split '', '!":?\@[]{|}£é' . "\n'" ) {
             $reqbody->{username} .= $chr;
             $http->do_request_json(
                method => "POST",
-               uri    => "/r0/register",
+               uri    => "/v3/register",
                content => $reqbody,
             );
          })->main::expect_http_400()
@@ -204,7 +204,7 @@ foreach my $chr (split '', 'q3._=-/' ) {
 
          $http->do_request_json(
             method => "POST",
-            uri    => "/r0/register",
+            uri    => "/v3/register",
 
             content => $reqbody,
          );
@@ -242,7 +242,7 @@ sub matrix_register_user
 
    $http->do_request_json(
       method => "POST",
-      uri    => "/r0/register",
+      uri    => "/v3/register",
 
       content => {
          auth => {
@@ -510,7 +510,7 @@ sub setup_user
       my $user = $f->get;
       do_request_json_for( $user,
          method => "PUT",
-         uri    => "/r0/profile/:user_id/displayname",
+         uri    => "/v3/profile/:user_id/displayname",
 
          content => { displayname => $displayname },
       )->then_done( $user );
@@ -521,7 +521,7 @@ sub setup_user
       my $user = $f->get;
       do_request_json_for( $user,
          method => "PUT",
-         uri    => "/r0/profile/:user_id/avatar_url",
+         uri    => "/v3/profile/:user_id/avatar_url",
 
          content => { avatar_url => $avatar_url },
       )->then_done( $user );
@@ -532,7 +532,7 @@ sub setup_user
       my $user = $f->get;
       do_request_json_for( $user,
          method => "PUT",
-         uri    => "/r0/presence/:user_id/status",
+         uri    => "/v3/presence/:user_id/status",
 
          content => {
             presence   => $presence,

--- a/tests/10apidoc/01request-encoding.pl
+++ b/tests/10apidoc/01request-encoding.pl
@@ -10,7 +10,7 @@ test "POST rejects invalid utf-8 in JSON",
 
       $http->do_request(
          method => "POST",
-         uri    => "/r0/register",
+         uri    => "/v3/register",
 
          content => $reqbody,
          content_type =>"application/json",

--- a/tests/10apidoc/02login.pl
+++ b/tests/10apidoc/02login.pl
@@ -11,7 +11,7 @@ my $registered_user_fixture = fixture(
 
       $http->do_request_json(
          method => "POST",
-         uri    => "/r0/register",
+         uri    => "/v3/register",
 
          content => {
             auth => {
@@ -38,7 +38,7 @@ test "GET /login yields a set of flows",
 
       $http->do_request_json(
          method => "GET",
-         uri => "/r0/login",
+         uri => "/v3/login",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -78,7 +78,7 @@ test "POST /login can log in as a user",
 
       $http->do_request_json(
          method => "POST",
-         uri    => "/r0/login",
+         uri    => "/v3/login",
 
          content => {
             type     => "m.login.password",
@@ -113,7 +113,7 @@ test "POST /login returns the same device_id as that in the request",
 
       $http->do_request_json(
          method => "POST",
-         uri    => "/r0/login",
+         uri    => "/v3/login",
 
          content => {
             type     => "m.login.password",
@@ -148,7 +148,7 @@ test "POST /login can log in as a user with just the local part of the id",
 
       $http->do_request_json(
          method => "POST",
-         uri    => "/r0/login",
+         uri    => "/v3/login",
 
          content => {
             type     => "m.login.password",
@@ -179,7 +179,7 @@ test "POST /login as non-existing user is rejected",
 
       $http->do_request_json(
          method => "POST",
-         uri    => "/r0/login",
+         uri    => "/v3/login",
 
          content => {
             type     => "m.login.password",
@@ -201,7 +201,7 @@ test "POST /login wrong password is rejected",
 
       $http->do_request_json(
          method => "POST",
-         uri    => "/r0/login",
+         uri    => "/v3/login",
 
          content => {
             type     => "m.login.password",
@@ -237,7 +237,7 @@ sub matrix_login_again_with_user
 
    $user->http->do_request_json(
       method  => "POST",
-      uri     => "/r0/login",
+      uri     => "/v3/login",
       content  => {
          type     => "m.login.password",
          identifier => {

--- a/tests/10apidoc/03events-initial.pl
+++ b/tests/10apidoc/03events-initial.pl
@@ -39,7 +39,7 @@ test "GET /initialSync initially",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/r0/initialSync",
+         uri    => "/v3/initialSync",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -63,7 +63,7 @@ sub matrix_initialsync
 
    do_request_json_for( $user,
       method => "GET",
-      uri    => "/r0/initialSync",
+      uri    => "/v3/initialSync",
 
       params => {
          ( map { defined $args{$_} ? ( $_ => $args{$_} ) : () }
@@ -227,7 +227,7 @@ sub matrix_sync
 
    do_request_json_for( $user,
       method  => "GET",
-      uri     => "/r0/sync",
+      uri     => "/v3/sync",
       params  => \%params,
    )->on_done( sub {
       my ( $body ) = @_;

--- a/tests/10apidoc/10profile-displayname.pl
+++ b/tests/10apidoc/10profile-displayname.pl
@@ -12,7 +12,7 @@ test "PUT /profile/:user_id/displayname sets my name",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/r0/profile/:user_id/displayname",
+         uri    => "/v3/profile/:user_id/displayname",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -30,7 +30,7 @@ test "PUT /profile/:user_id/displayname sets my name",
 
       do_request_json_for( $user,
          method => "PUT",
-         uri    => "/r0/profile/:user_id/displayname",
+         uri    => "/v3/profile/:user_id/displayname",
 
          content => {
             displayname => $displayname,
@@ -50,7 +50,7 @@ test "GET /profile/:user_id/displayname publicly accessible",
 
       $http->do_request_json(
          method => "GET",
-         uri    => "/r0/profile/$user_id/displayname",
+         uri    => "/v3/profile/$user_id/displayname",
          # no access_token
       )->then( sub {
          my ( $body ) = @_;
@@ -74,7 +74,7 @@ sub matrix_set_displayname
 
    do_request_json_for( $user,
       method => "PUT",
-      uri    => "/r0/profile/:user_id/displayname",
+      uri    => "/v3/profile/:user_id/displayname",
 
       content => { displayname => $displayname },
    );

--- a/tests/10apidoc/11profile-avatar_url.pl
+++ b/tests/10apidoc/11profile-avatar_url.pl
@@ -12,7 +12,7 @@ test "PUT /profile/:user_id/avatar_url sets my avatar",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/r0/profile/:user_id/avatar_url",
+         uri    => "/v3/profile/:user_id/avatar_url",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -30,7 +30,7 @@ test "PUT /profile/:user_id/avatar_url sets my avatar",
 
       do_request_json_for( $user,
          method => "PUT",
-         uri    => "/r0/profile/:user_id/avatar_url",
+         uri    => "/v3/profile/:user_id/avatar_url",
 
          content => {
             avatar_url => $avatar_url,
@@ -50,7 +50,7 @@ test "GET /profile/:user_id/avatar_url publicly accessible",
 
       $http->do_request_json(
          method => "GET",
-         uri    => "/r0/profile/$user_id/avatar_url",
+         uri    => "/v3/profile/$user_id/avatar_url",
          # no access_token
       )->then( sub {
          my ( $body ) = @_;

--- a/tests/10apidoc/12device_management.pl
+++ b/tests/10apidoc/12device_management.pl
@@ -8,7 +8,7 @@ sub matrix_get_device {
    return do_request_json_for(
       $user,
       method => "GET",
-      uri    => "/r0/devices/${device_id}",
+      uri    => "/v3/devices/${device_id}",
    );
 }
 
@@ -18,7 +18,7 @@ sub matrix_set_device_display_name {
     return do_request_json_for(
         $user,
         method => "PUT",
-        uri    => "/r0/devices/${device_id}",
+        uri    => "/v3/devices/${device_id}",
         content => {
             display_name => $display_name,
         },
@@ -31,7 +31,7 @@ sub matrix_delete_device {
     return do_request_json_for(
         $user,
         method  => "DELETE",
-        uri     => "/r0/devices/${device_id}",
+        uri     => "/v3/devices/${device_id}",
         content => $request_body,
     );
 }
@@ -72,7 +72,7 @@ test "GET /device/{deviceId} gives a 404 for unknown devices",
       do_request_json_for(
          $user,
          method => "GET",
-         uri    => "/r0/devices/unknown_device",
+         uri    => "/v3/devices/unknown_device",
       )->main::expect_http_404;
    };
 
@@ -106,7 +106,7 @@ test "GET /devices",
           do_request_json_for(
              $user,
              method => "GET",
-             uri => "/r0/devices",
+             uri => "/v3/devices",
           );
       })->then( sub {
          my ( $devices ) = @_;
@@ -151,7 +151,7 @@ test "PUT /device/{deviceId} updates device fields",
          do_request_json_for(
             $user,
             method => "PUT",
-            uri    => "/r0/devices/${DEVICE_ID}",
+            uri    => "/v3/devices/${DEVICE_ID}",
             content => {
                display_name => "new display name",
             },
@@ -179,7 +179,7 @@ test "PUT /device/{deviceId} gives a 404 for unknown devices",
       do_request_json_for(
          $user,
          method => "PUT",
-         uri    => "/r0/devices/unknown_device",
+         uri    => "/v3/devices/unknown_device",
          content => {
             display_name => "new display name",
          },
@@ -206,7 +206,7 @@ test "DELETE /device/{deviceId}",
          do_request_json_for(
             $other_login,
             method  => "GET",
-            uri     => "/r0/sync",
+            uri     => "/v3/sync",
          );
       })->then( sub {
          # attempt request with empty auth dict
@@ -262,7 +262,7 @@ test "DELETE /device/{deviceId}",
             do_request_json_for(
                $other_login,
                method  => "GET",
-               uri     => "/r0/sync",
+               uri     => "/v3/sync",
             )->main::check_http_code(
                401 => "ok",
                200 => "redo",

--- a/tests/10apidoc/13ui-auth.pl
+++ b/tests/10apidoc/13ui-auth.pl
@@ -14,7 +14,7 @@ sub cas_login_fixture {
 
          $http->do_request_json(
             method => "GET",
-            uri    => "/r0/login",
+            uri    => "/v3/login",
          )->then(sub {
             my ($body) = @_;
 
@@ -99,7 +99,7 @@ sub matrix_login_with_cas
    # hope to get redirected back to
    my $REDIRECT_URL = "https://client?p=http%3A%2F%2Fserver";
 
-   my $HS_URI = $homeserver_info->client_location . "/_matrix/client/r0/login/cas/ticket?redirectUrl=" . uri_escape($REDIRECT_URL);
+   my $HS_URI = $homeserver_info->client_location . "/_matrix/client/v3/login/cas/ticket?redirectUrl=" . uri_escape($REDIRECT_URL);
 
    # the ticket our mocked-up CAS server "generates"
    my $CAS_TICKET = "goldenticket";
@@ -110,7 +110,7 @@ sub matrix_login_with_cas
       wait_for_cas_request( "/cas/login" ),
       $http->do_request(
          method => "GET",
-         uri    => "/r0/login/sso/redirect",
+         uri    => "/v3/login/sso/redirect",
          params => {
             redirectUrl => $REDIRECT_URL,
          },
@@ -170,7 +170,7 @@ sub matrix_login_with_cas
       # step 7: the client uses the loginToken via the /login API.
       $http->do_request_json(
          method => "POST",
-         uri    => "/r0/login",
+         uri    => "/v3/login",
 
          content => {
             type     => "m.login.token",
@@ -206,7 +206,7 @@ sub make_ticket_request
    # Note that we skip almost all of the CAS flow since it isn't important
    # for this test. The user just needs to end up back at the homeserver
    # with a valid ticket (and the original UI Auth session ID).
-   my $login_uri = $homeserver_info->client_location . "/_matrix/client/r0/login/cas/ticket?session=$session&ticket=$CAS_TICKET";
+   my $login_uri = $homeserver_info->client_location . "/_matrix/client/v3/login/cas/ticket?session=$session&ticket=$CAS_TICKET";
 
    Future->needs_all(
       wait_for_cas_request(

--- a/tests/10apidoc/13ui-auth.pl
+++ b/tests/10apidoc/13ui-auth.pl
@@ -99,7 +99,9 @@ sub matrix_login_with_cas
    # hope to get redirected back to
    my $REDIRECT_URL = "https://client?p=http%3A%2F%2Fserver";
 
-   my $HS_URI = $homeserver_info->client_location . "/_matrix/client/v3/login/cas/ticket?redirectUrl=" . uri_escape($REDIRECT_URL);
+   # note: the URL returned here contains r0 because of
+   # https://github.com/matrix-org/synapse/blob/f44d729d4ccae61bc0cdd5774acb3233eb5f7c13/synapse/config/cas.py#L41
+   my $HS_URI = $homeserver_info->client_location . "/_matrix/client/r0/login/cas/ticket?redirectUrl=" . uri_escape($REDIRECT_URL);
 
    # the ticket our mocked-up CAS server "generates"
    my $CAS_TICKET = "goldenticket";
@@ -206,7 +208,7 @@ sub make_ticket_request
    # Note that we skip almost all of the CAS flow since it isn't important
    # for this test. The user just needs to end up back at the homeserver
    # with a valid ticket (and the original UI Auth session ID).
-   my $login_uri = $homeserver_info->client_location . "/_matrix/client/v3/login/cas/ticket?session=$session&ticket=$CAS_TICKET";
+   my $login_uri = $homeserver_info->client_location . "/_matrix/client/r0/login/cas/ticket?session=$session&ticket=$CAS_TICKET";
 
    Future->needs_all(
       wait_for_cas_request(

--- a/tests/10apidoc/20presence.pl
+++ b/tests/10apidoc/20presence.pl
@@ -18,7 +18,7 @@ sub matrix_get_presence_status
 
    do_request_json_for( $user,
       method => "GET",
-      uri    => "/r0/presence/:user_id/status",
+      uri    => "/v3/presence/:user_id/status",
    );
 }
 
@@ -37,7 +37,7 @@ sub matrix_set_presence_status
 
    do_request_json_for( $user,
       method => "PUT",
-      uri    => "/r0/presence/:user_id/status",
+      uri    => "/v3/presence/:user_id/status",
 
       content => { presence => $presence, %params }
    )->then_done();

--- a/tests/10apidoc/30room-create.pl
+++ b/tests/10apidoc/30room-create.pl
@@ -11,7 +11,7 @@ test "POST /createRoom makes a public room",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/r0/createRoom",
+         uri    => "/v3/createRoom",
 
          content => {
             visibility      => "public",
@@ -38,7 +38,7 @@ test "POST /createRoom makes a private room",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/r0/createRoom",
+         uri    => "/v3/createRoom",
 
          content => {
             visibility => "private",
@@ -64,7 +64,7 @@ test "POST /createRoom makes a private room with invites",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/r0/createRoom",
+         uri    => "/v3/createRoom",
 
          content => {
             visibility => "private",
@@ -97,7 +97,7 @@ test "POST /createRoom makes a room with a name",
 
          do_request_json_for( $user,
             method => "GET",
-            uri    => "/r0/rooms/$room_id/state/m.room.name",
+            uri    => "/v3/rooms/$room_id/state/m.room.name",
          )
       })->then( sub {
          my ( $state ) = @_;
@@ -129,7 +129,7 @@ test "POST /createRoom makes a room with a topic",
 
          do_request_json_for( $user,
             method => "GET",
-            uri    => "/r0/rooms/$room_id/state/m.room.topic",
+            uri    => "/v3/rooms/$room_id/state/m.room.topic",
          )
       })->then( sub {
          my ( $state ) = @_;
@@ -308,7 +308,7 @@ sub matrix_create_room
 
    do_request_json_for( $user,
       method => "POST",
-      uri    => "/r0/createRoom",
+      uri    => "/v3/createRoom",
       content => \%opts,
    )->then( sub {
       my ( $body ) = @_;
@@ -438,7 +438,7 @@ sub matrix_create_room_synced
 
       matrix_do_and_wait_for_sync( $user,
          do => sub {
-            my $uri = "/r0/rooms/$room_id/send/m.room.test/$txn_id";
+            my $uri = "/v3/rooms/$room_id/send/m.room.test/$txn_id";
             $txn_id++;
 
             do_request_json_for(

--- a/tests/10apidoc/31room-state.pl
+++ b/tests/10apidoc/31room-state.pl
@@ -31,7 +31,7 @@ test "GET /rooms/:room_id/state/m.room.member/:user_id fetches my membership",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/r0/rooms/$room_id/state/m.room.member/:user_id",
+         uri    => "/v3/rooms/$room_id/state/m.room.member/:user_id",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -57,7 +57,7 @@ test "GET /rooms/:room_id/state/m.room.member/:user_id?format=event fetches my m
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/r0/rooms/$room_id/state/m.room.member/:user_id",
+         uri    => "/v3/rooms/$room_id/state/m.room.member/:user_id",
          params => {
             format => "event",
          },
@@ -88,7 +88,7 @@ test "GET /rooms/:room_id/state/m.room.power_levels fetches powerlevels",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/r0/rooms/$room_id/state/m.room.power_levels",
+         uri    => "/v3/rooms/$room_id/state/m.room.power_levels",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -112,7 +112,7 @@ test "GET /rooms/:room_id/joined_members fetches my membership",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/r0/rooms/$room_id/joined_members",
+         uri    => "/v3/rooms/$room_id/joined_members",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -167,7 +167,7 @@ test "GET /publicRooms lists newly-created room",
 
       $http->do_request_json(
          method => "GET",
-         uri    => "/r0/publicRooms",
+         uri    => "/v3/publicRooms",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -198,7 +198,7 @@ test "GET /directory/room/:room_alias yields room ID",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/r0/directory/room/$room_alias",
+         uri    => "/v3/directory/room/$room_alias",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -221,7 +221,7 @@ test "GET /joined_rooms lists newly-created room",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/r0/joined_rooms",
+         uri    => "/v3/joined_rooms",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -248,7 +248,7 @@ test "POST /rooms/:room_id/state/m.room.name sets name",
 
       do_request_json_for( $user,
          method => "PUT",
-         uri    => "/r0/rooms/$room_id/state/m.room.name",
+         uri    => "/v3/rooms/$room_id/state/m.room.name",
 
          content => { name => $name },
       )->then( sub {
@@ -274,7 +274,7 @@ test "GET /rooms/:room_id/state/m.room.name gets name",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/r0/rooms/$room_id/state/m.room.name",
+         uri    => "/v3/rooms/$room_id/state/m.room.name",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -299,7 +299,7 @@ test "POST /rooms/:room_id/state/m.room.topic sets topic",
 
       do_request_json_for( $user,
          method => "PUT",
-         uri    => "/r0/rooms/$room_id/state/m.room.topic",
+         uri    => "/v3/rooms/$room_id/state/m.room.topic",
 
          content => { topic => $topic },
       )->then( sub {
@@ -325,7 +325,7 @@ test "GET /rooms/:room_id/state/m.room.topic gets topic",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/r0/rooms/$room_id/state/m.room.topic",
+         uri    => "/v3/rooms/$room_id/state/m.room.topic",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -348,7 +348,7 @@ test "GET /rooms/:room_id/state fetches entire room state",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/r0/rooms/$room_id/state",
+         uri    => "/v3/rooms/$room_id/state",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -375,7 +375,7 @@ test "POST /createRoom with creation content",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/r0/createRoom",
+         uri    => "/v3/createRoom",
 
          content => {
             creation_content => {
@@ -390,7 +390,7 @@ test "POST /createRoom with creation content",
 
          do_request_json_for( $user,
             method => "GET",
-            uri    => "/r0/rooms/$room_id/state/m.room.create",
+            uri    => "/v3/rooms/$room_id/state/m.room.create",
          )
       })->then( sub {
          my ( $state ) = @_;
@@ -419,7 +419,7 @@ sub matrix_get_room_state
    do_request_json_for( $user,
       method => "GET",
       uri    => join( "/",
-         "/r0/rooms/$room_id/state", grep { defined } $opts{type}, $opts{state_key}
+         "/v3/rooms/$room_id/state", grep { defined } $opts{type}, $opts{state_key}
       ),
    );
 }
@@ -484,7 +484,7 @@ sub matrix_put_room_state
    do_request_json_for( $user,
       method => "PUT",
       uri    => join( "/",
-         "/r0/rooms/$room_id/state", grep { defined } $opts{type}, $opts{state_key}
+         "/v3/rooms/$room_id/state", grep { defined } $opts{type}, $opts{state_key}
       ),
 
       content => $opts{content},
@@ -514,7 +514,7 @@ sub matrix_initialsync_room
 
    do_request_json_for( $user,
       method => "GET",
-      uri    => "/r0/rooms/$room_id/initialSync",
+      uri    => "/v3/rooms/$room_id/initialSync",
       params => \%params,
    );
 }

--- a/tests/10apidoc/32room-alias.pl
+++ b/tests/10apidoc/32room-alias.pl
@@ -23,7 +23,7 @@ test "PUT /directory/room/:room_alias creates alias",
 
       do_request_json_for( $user,
          method => "PUT",
-         uri    => "/r0/directory/room/$room_alias",
+         uri    => "/v3/directory/room/$room_alias",
 
          content => {
             room_id => $room_id,
@@ -36,7 +36,7 @@ test "PUT /directory/room/:room_alias creates alias",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/r0/directory/room/$room_alias",
+         uri    => "/v3/directory/room/$room_alias",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -63,7 +63,7 @@ test "GET /rooms/:room_id/aliases lists aliases",
          do_request_json_for(
             $user,
             method => "GET",
-            uri => "/r0/rooms/$room_id/aliases",
+            uri => "/v3/rooms/$room_id/aliases",
          );
       })->then( sub {
          my ( $res ) = @_;
@@ -76,7 +76,7 @@ test "GET /rooms/:room_id/aliases lists aliases",
          do_request_json_for(
             $user,
             method => "PUT",
-            uri    => "/r0/directory/room/$room_alias",
+            uri    => "/v3/directory/room/$room_alias",
             content => { room_id => $room_id },
          );
       })->then( sub {
@@ -90,7 +90,7 @@ test "GET /rooms/:room_id/aliases lists aliases",
             return do_request_json_for(
                $user,
                method => "GET",
-               uri => "/r0/rooms/$room_id/aliases",
+               uri => "/v3/rooms/$room_id/aliases",
             )->then( sub {
                my ( $res ) = @_;
                log_if_fail "$iter: response from /aliases", $res;

--- a/tests/10apidoc/33room-members.pl
+++ b/tests/10apidoc/33room-members.pl
@@ -26,7 +26,7 @@ test "POST /rooms/:room_id/join can join a room",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/r0/rooms/$room_id/join",
+         uri    => "/v3/rooms/$room_id/join",
 
          content => {},
       )->then( sub {
@@ -68,7 +68,7 @@ sub matrix_join_room
 
    do_request_json_for( $user,
       method => "POST",
-      uri    => "/r0/join/$room",
+      uri    => "/v3/join/$room",
       params => \%params,
 
       content => \%content,
@@ -93,7 +93,7 @@ test "POST /join/:room_alias can join a room",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/r0/join/$room_alias",
+         uri    => "/v3/join/$room_alias",
 
          content => {},
       )->then( sub {
@@ -129,7 +129,7 @@ test "POST /join/:room_id can join a room",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/r0/join/$room_id",
+         uri    => "/v3/join/$room_id",
 
          content => {},
       )->then( sub {
@@ -166,7 +166,7 @@ test "POST /join/:room_id can join a room with custom content",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/r0/join/$room_id",
+         uri    => "/v3/join/$room_id",
 
          content => { "foo" => "bar" },
       )->then( sub {
@@ -205,7 +205,7 @@ test "POST /join/:room_alias can join a room with custom content",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/r0/join/$room_alias",
+         uri    => "/v3/join/$room_alias",
 
          content => { "foo" => "bar" },
       )->then( sub {
@@ -246,7 +246,7 @@ test "POST /rooms/:room_id/leave can leave a room",
       ->then( sub {
          do_request_json_for( $joiner_to_leave,
             method => "POST",
-            uri    => "/r0/rooms/$room_id/leave",
+            uri    => "/v3/rooms/$room_id/leave",
 
             content => {},
          )
@@ -286,7 +286,7 @@ sub matrix_leave_room
 
    do_request_json_for( $user,
       method => "POST",
-      uri    => "/r0/rooms/$room_id/leave",
+      uri    => "/v3/rooms/$room_id/leave",
 
       content => {},
    )->then_done(1);
@@ -303,7 +303,7 @@ test "POST /rooms/:room_id/invite can send an invite",
 
       do_request_json_for( $creator,
          method => "POST",
-         uri    => "/r0/rooms/$room_id/invite",
+         uri    => "/v3/rooms/$room_id/invite",
 
          content => { user_id => $invited_user->user_id },
       )->then( sub {
@@ -346,7 +346,7 @@ sub matrix_invite_user_to_room
 
    do_request_json_for( $user,
       method => "POST",
-      uri    => "/r0/rooms/$room_id/invite",
+      uri    => "/v3/rooms/$room_id/invite",
 
       content => { user_id => $invitee_id }
    )->then( sub {
@@ -367,7 +367,7 @@ test "POST /rooms/:room_id/ban can ban a user",
 
       do_request_json_for( $creator,
          method => "POST",
-         uri    => "/r0/rooms/$room_id/ban",
+         uri    => "/v3/rooms/$room_id/ban",
 
          content => {
             user_id => $banned_user->user_id,

--- a/tests/10apidoc/34room-messages.pl
+++ b/tests/10apidoc/34room-messages.pl
@@ -7,7 +7,7 @@ test "POST /rooms/:room_id/send/:event_type sends a message",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/r0/rooms/$room_id/send/m.room.message",
+         uri    => "/v3/rooms/$room_id/send/m.room.message",
 
          content => { msgtype => "m.message", body => "Here is the message content" },
       )->then( sub {
@@ -31,7 +31,7 @@ test "PUT /rooms/:room_id/send/:event_type/:txn_id sends a message",
 
       do_request_json_for( $user,
          method => "PUT",
-         uri    => "/r0/rooms/$room_id/send/m.room.message/$txn_id",
+         uri    => "/v3/rooms/$room_id/send/m.room.message/$txn_id",
 
          content => { msgtype => "m.message", body => "Here is the message content" },
       )->then( sub {
@@ -54,7 +54,7 @@ test "PUT /rooms/:room_id/send/:event_type/:txn_id deduplicates the same txn id"
 
       do_request_json_for( $user,
          method => "PUT",
-         uri    => "/r0/rooms/$room_id/send/m.room.message/$txn_id",
+         uri    => "/v3/rooms/$room_id/send/m.room.message/$txn_id",
 
          content => { msgtype => "m.message", body => "Here is the message content" },
       )->then( sub {
@@ -64,7 +64,7 @@ test "PUT /rooms/:room_id/send/:event_type/:txn_id deduplicates the same txn id"
 
          do_request_json_for( $user,
             method => "PUT",
-            uri    => "/r0/rooms/$room_id/send/m.room.message/$txn_id",
+            uri    => "/v3/rooms/$room_id/send/m.room.message/$txn_id",
 
             content => { msgtype => "m.message", body => "Here is the message content" },
          )
@@ -94,7 +94,7 @@ sub matrix_send_room_message
 
    my $type = $opts{type} // "m.room.message";
 
-   my $uri = "/r0/rooms/$room_id/send/$type";
+   my $uri = "/v3/rooms/$room_id/send/$type";
    $opts{txn_id} //= $global_txn_id++;
    $uri = "$uri/$opts{txn_id}";
 
@@ -147,7 +147,7 @@ test "GET /rooms/:room_id/messages returns a message",
 
          do_request_json_for( $user,
             method => "GET",
-            uri    => "/r0/rooms/$room_id/messages",
+            uri    => "/v3/rooms/$room_id/messages",
 
             # With no params this does "forwards from END"; i.e. nothing useful
             params => {
@@ -185,7 +185,7 @@ test "GET /rooms/:room_id/messages lazy loads members correctly",
 
          do_request_json_for( $user,
             method => "GET",
-            uri    => "/r0/rooms/$room_id/messages",
+            uri    => "/v3/rooms/$room_id/messages",
 
             params => {
                dir => "b",
@@ -232,7 +232,7 @@ sub matrix_get_room_messages
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/r0/rooms/$room_id/messages",
+         uri    => "/v3/rooms/$room_id/messages",
 
          params => \%params,
       );

--- a/tests/10apidoc/35room-typing.pl
+++ b/tests/10apidoc/35room-typing.pl
@@ -8,7 +8,7 @@ test "PUT /rooms/:room_id/typing/:user_id sets typing notification",
 
       do_request_json_for( $user,
          method => "PUT",
-         uri    => "/r0/rooms/$room_id/typing/:user_id",
+         uri    => "/v3/rooms/$room_id/typing/:user_id",
 
          content => { typing => JSON::true },
       )->then( sub {

--- a/tests/10apidoc/36room-levels.pl
+++ b/tests/10apidoc/36room-levels.pl
@@ -10,7 +10,7 @@ test "GET /rooms/:room_id/state/m.room.power_levels can fetch levels",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/r0/rooms/$room_id/state/m.room.power_levels",
+         uri    => "/v3/rooms/$room_id/state/m.room.power_levels",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -52,7 +52,7 @@ test "PUT /rooms/:room_id/state/m.room.power_levels can set levels",
 
          do_request_json_for( $user,
             method => "PUT",
-            uri    => "/r0/rooms/$room_id/state/m.room.power_levels",
+            uri    => "/v3/rooms/$room_id/state/m.room.power_levels",
             content => $levels,
          )
       })->then( sub {

--- a/tests/10apidoc/37room-receipts.pl
+++ b/tests/10apidoc/37room-receipts.pl
@@ -16,7 +16,7 @@ test "POST /rooms/:room_id/receipt can create receipts",
 
          do_request_json_for( $user,
             method => "POST",
-            uri    => "/r0/rooms/$room_id/receipt/m.read/$event_id",
+            uri    => "/v3/rooms/$room_id/receipt/m.read/$event_id",
 
             content => {},
          );
@@ -33,7 +33,7 @@ sub matrix_advance_room_receipt
 
    do_request_json_for( $user,
       method => "POST",
-      uri    => "/r0/rooms/$room_id/receipt/$type/$event_id",
+      uri    => "/v3/rooms/$room_id/receipt/$type/$event_id",
 
       content => {},
    )->then_done();

--- a/tests/10apidoc/38room-read-marker.pl
+++ b/tests/10apidoc/38room-read-marker.pl
@@ -14,7 +14,7 @@ test "POST /rooms/:room_id/read_markers can create read marker",
 
          do_request_json_for( $user,
             method => "POST",
-            uri    => "/r0/rooms/$room_id/read_markers",
+            uri    => "/v3/rooms/$room_id/read_markers",
 
             content => {
                "m.fully_read" => $event_id,
@@ -32,7 +32,7 @@ sub matrix_advance_room_read_marker
 
    do_request_json_for( $user,
       method => "POST",
-      uri    => "/r0/rooms/$room_id/read_markers",
+      uri    => "/v3/rooms/$room_id/read_markers",
 
       content => {
          "m.fully_read" => $event_id,

--- a/tests/10apidoc/40content.pl
+++ b/tests/10apidoc/40content.pl
@@ -5,7 +5,7 @@ EOF
 my $content_type = "text/plain";
 my $content_id;
 
-test "POST /media/r0/upload can create an upload",
+test "POST /media/v3/upload can create an upload",
    requires => [ $main::API_CLIENTS[0], local_user_fixture() ],
 
    proves => [qw( can_upload_media )],
@@ -16,7 +16,7 @@ test "POST /media/r0/upload can create an upload",
       # Because we're POST'ing non-JSON
       $http->do_request(
          method   => "POST",
-         full_uri => "/_matrix/media/r0/upload",
+         full_uri => "/_matrix/media/v3/upload",
          params => {
             access_token => $user->access_token,
          },
@@ -35,7 +35,7 @@ test "POST /media/r0/upload can create an upload",
       });
    };
 
-test "GET /media/r0/download can fetch the value again",
+test "GET /media/v3/download can fetch the value again",
    requires => [ $main::API_CLIENTS[0],
                  qw( can_upload_media )],
 
@@ -46,7 +46,7 @@ test "GET /media/r0/download can fetch the value again",
 
       $http->do_request(
          method   => "GET",
-         full_uri => "/_matrix/media/r0/download/" . join( "", @$content_id ),
+         full_uri => "/_matrix/media/v3/download/" . join( "", @$content_id ),
          # No access_token; it should be public
       )->then( sub {
          my ( $got_content, $response ) = @_;

--- a/tests/10apidoc/44account_data.pl
+++ b/tests/10apidoc/44account_data.pl
@@ -18,7 +18,7 @@ sub matrix_add_account_data
 
    do_request_json_for( $user,
       method  => "PUT",
-      uri     => "/r0/user/:user_id/account_data/$type",
+      uri     => "/v3/user/:user_id/account_data/$type",
       content => $content
    );
 }
@@ -37,7 +37,7 @@ sub matrix_add_room_account_data
 
    do_request_json_for( $user,
       method  => "PUT",
-      uri     => "/r0/user/:user_id/rooms/$room_id/account_data/$type",
+      uri     => "/v3/user/:user_id/rooms/$room_id/account_data/$type",
       content => $content
    );
 }
@@ -56,7 +56,7 @@ sub matrix_get_account_data
 
    do_request_json_for( $user,
       method  => "GET",
-      uri     => "/r0/user/:user_id/account_data/$type",
+      uri     => "/v3/user/:user_id/account_data/$type",
    );
 }
 
@@ -74,7 +74,7 @@ sub matrix_get_room_account_data
 
    do_request_json_for( $user,
       method  => "GET",
-      uri     => "/r0/user/:user_id/rooms/$room_id/account_data/$type",
+      uri     => "/v3/user/:user_id/rooms/$room_id/account_data/$type",
    );
 }
 

--- a/tests/10apidoc/45server-capabilities.pl
+++ b/tests/10apidoc/45server-capabilities.pl
@@ -6,7 +6,7 @@ test "GET /capabilities is present and well formed for registered user",
 
          do_request_json_for( $user,
             method => "GET",
-            uri    => "/r0/capabilities",
+            uri    => "/v3/capabilities",
          )->then( sub {
             my ( $body ) = @_;
             assert_json_keys( $body->{capabilities}, qw( m.room_versions m.change_password ));
@@ -15,7 +15,7 @@ test "GET /capabilities is present and well formed for registered user",
       };
 
 
-test "GET /r0/capabilities is not public",
+test "GET /v3/capabilities is not public",
    requires => [ $main::API_CLIENTS[0] ],
 
    do => sub {
@@ -23,7 +23,7 @@ test "GET /r0/capabilities is not public",
 
       $http->do_request_json(
          method => "GET",
-         uri    => "/r0/capabilities",
+         uri    => "/v3/capabilities",
       )->main::expect_http_401->then( sub {
          Future->done( 1 );
       })

--- a/tests/10apidoc/46push.pl
+++ b/tests/10apidoc/46push.pl
@@ -25,7 +25,7 @@ sub matrix_add_push_rule
 
    do_request_json_for( $user,
       method  => "PUT",
-      uri     => "/r0/pushrules/$scope/$kind/$rule_id",
+      uri     => "/v3/pushrules/$scope/$kind/$rule_id",
       params  => \%params,
       content => $rule_body,
    );
@@ -47,7 +47,7 @@ sub matrix_delete_push_rule
 
    do_request_json_for( $user,
       method  => "DELETE",
-      uri     => "/r0/pushrules/$scope/$kind/$rule_id",
+      uri     => "/v3/pushrules/$scope/$kind/$rule_id",
    );
 }
 
@@ -68,7 +68,7 @@ sub matrix_set_push_rule_enabled
 
    do_request_json_for( $user,
       method  => "PUT",
-      uri     => "/r0/pushrules/$scope/$kind/$rule_id/enabled",
+      uri     => "/v3/pushrules/$scope/$kind/$rule_id/enabled",
       content => { enabled => $enabled },
    );
 }
@@ -90,7 +90,7 @@ sub matrix_set_push_rule_actions
 
    do_request_json_for( $user,
       method  => "PUT",
-      uri     => "/r0/pushrules/$scope/$kind/$rule_id/actions",
+      uri     => "/v3/pushrules/$scope/$kind/$rule_id/actions",
       content => { actions => $actions },
    );
 }
@@ -113,7 +113,7 @@ sub matrix_get_push_rule
 
    do_request_json_for( $user,
       method  => "GET",
-      uri     => "/r0/pushrules/$scope/$kind/$rule_id",
+      uri     => "/v3/pushrules/$scope/$kind/$rule_id",
    );
 }
 
@@ -132,7 +132,7 @@ sub matrix_get_push_rules
    # Trailing slash indicates retrieving ALL push rules for this user
    do_request_json_for( $user,
       method  => "GET",
-      uri     => "/r0/pushrules/",
+      uri     => "/v3/pushrules/",
    )->on_done( sub {
       my ( $body ) = @_;
 

--- a/tests/11register.pl
+++ b/tests/11register.pl
@@ -15,7 +15,7 @@ sub gen_client_secret {
    validate_email(
       $http, $address,
       id_server => $id_server,
-      path => "/r0/account/3pid/email/requestToken",
+      path => "/v3/account/3pid/email/requestToken",
    )->then( sub {
       my ( $sid, $client_secret ) = @_;
    });
@@ -74,7 +74,7 @@ push our @EXPORT, qw( validate_email );
    validate_msisdn(
       $http, $phone_number, $country_code,
       id_server => $id_server,
-      path => "/r0/account/3pid/msisdn/requestToken",
+      path => "/v3/account/3pid/msisdn/requestToken",
    )->then( sub {
       my ( $sid, $client_secret ) = @_;
    });
@@ -215,14 +215,14 @@ sub add_email_for_user {
    validate_email(
       $user->http, $address,
       id_server => $id_server,
-      path => "/r0/account/3pid/email/requestToken",
+      path => "/v3/account/3pid/email/requestToken",
    )->then( sub {
       my ( $sid, $client_secret ) = @_;
 
       # now tell the HS to add the 3pid
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/r0/account/3pid",
+         uri    => "/v3/account/3pid",
          content => {
             three_pid_creds => {
                id_server       => $id_server->name,
@@ -270,7 +270,7 @@ multi_test "Register with a recaptcha",
 
          $http->do_request_json(
             method  => "POST",
-            uri     => "/r0/register",
+            uri     => "/v3/register",
             content => {
                username => $localpart,
                password => "my secret",
@@ -314,7 +314,7 @@ test "registration is idempotent, without username specified",
       # Start a session
       $http->do_request_json(
          method => "POST",
-         uri    => "/r0/register",
+         uri    => "/v3/register",
 
          content => {
             password => "sUp3rs3kr1t",
@@ -331,7 +331,7 @@ test "registration is idempotent, without username specified",
          # Now register a user
          $http->do_request_json(
             method => "POST",
-            uri    => "/r0/register",
+            uri    => "/v3/register",
 
             content => {
                password => "sUp3rs3kr1t",
@@ -352,7 +352,7 @@ test "registration is idempotent, without username specified",
          # now try to register again with the same session
          $http->do_request_json(
             method => "POST",
-            uri    => "/r0/register",
+            uri    => "/v3/register",
 
             content => {
                password => "sUp3rs3kr1t",
@@ -386,7 +386,7 @@ test "registration is idempotent, with username specified",
       # Start a session
       $http->do_request_json(
          method => "POST",
-         uri    => "/r0/register",
+         uri    => "/v3/register",
 
          content => {
             username => $localpart,
@@ -404,7 +404,7 @@ test "registration is idempotent, with username specified",
          # Now register a user
          $http->do_request_json(
             method => "POST",
-            uri    => "/r0/register",
+            uri    => "/v3/register",
 
             content => {
                username => $localpart,
@@ -424,7 +424,7 @@ test "registration is idempotent, with username specified",
          # now try to register again with the same session
          $http->do_request_json(
             method => "POST",
-            uri    => "/r0/register",
+            uri    => "/v3/register",
 
             content => {
                username => $localpart,
@@ -464,7 +464,7 @@ test "registration remembers parameters",
 
       $http->do_request_json(
          method => "POST",
-         uri    => "/r0/register",
+         uri    => "/v3/register",
 
          content => {
             username => $localpart,
@@ -483,7 +483,7 @@ test "registration remembers parameters",
 
          $http->do_request_json(
             method => "POST",
-            uri    => "/r0/register",
+            uri    => "/v3/register",
 
             content => {
                auth     => {
@@ -528,7 +528,7 @@ test "registration accepts non-ascii passwords",
 
       $http->do_request_json(
          method => "POST",
-         uri    => "/r0/register",
+         uri    => "/v3/register",
 
          content => {
             username => $localpart,
@@ -547,7 +547,7 @@ test "registration accepts non-ascii passwords",
 
          $http->do_request_json(
             method => "POST",
-            uri    => "/r0/register",
+            uri    => "/v3/register",
 
             content => {
                auth     => {
@@ -574,7 +574,7 @@ test "registration with inhibit_login inhibits login",
 
       $http->do_request_json(
          method => "POST",
-         uri    => "/r0/register",
+         uri    => "/v3/register",
 
          content => {
             username => $localpart,
@@ -592,7 +592,7 @@ test "registration with inhibit_login inhibits login",
 
          $http->do_request_json(
             method => "POST",
-            uri    => "/r0/register",
+            uri    => "/v3/register",
 
             content => {
                auth     => {
@@ -631,7 +631,7 @@ test "Can register using an email address",
 
       $http->do_request_json(
          method => "POST",
-         uri    => "/r0/register",
+         uri    => "/v3/register",
 
          content => {
             username => $localpart,
@@ -663,14 +663,14 @@ test "Can register using an email address",
             $http,
             $email_address,
             id_server => $id_server,
-            path => "/r0/register/email/requestToken",
+            path => "/v3/register/email/requestToken",
          )->then( sub {
             my ( $sid_email, $client_secret ) = @_;
 
             # attempt to register with the 3pid
             $http->do_request_json(
                method => "POST",
-               uri    => "/r0/register",
+               uri    => "/v3/register",
                content => {
                   auth => {
                      type           => "m.login.email.identity",

--- a/tests/12login/01threepid-and-password.pl
+++ b/tests/12login/01threepid-and-password.pl
@@ -14,7 +14,7 @@ test "Can login with 3pid and password using m.login.password",
       ->then( sub {
          $http->do_request_json(
             method => "POST",
-            uri    => "/r0/login",
+            uri    => "/v3/login",
 
             content => {
                type     => "m.login.password",

--- a/tests/12login/02cas.pl
+++ b/tests/12login/02cas.pl
@@ -10,7 +10,7 @@ test "login types include SSO",
 
       $http->do_request_json(
          method => "GET",
-         uri => "/r0/login",
+         uri => "/v3/login",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -37,7 +37,7 @@ test "/login/cas/redirect redirects if the old m.login.cas login type is listed"
 
       $http->do_request(
          method => "GET",
-         uri    => "/r0/login/cas/redirect",
+         uri    => "/v3/login/cas/redirect",
          params => {
             redirectUrl => $REDIRECT_URL,
          },

--- a/tests/13logout.pl
+++ b/tests/13logout.pl
@@ -16,7 +16,7 @@ test "Can logout current device",
          do_request_json_for(
             $other_login,
             method => "GET",
-            uri => "/r0/devices",
+            uri => "/v3/devices",
          );
       })->then( sub {
          my ( $devices ) = @_;
@@ -28,7 +28,7 @@ test "Can logout current device",
 
          do_request_json_for( $user,
             method => "POST",
-            uri    => "/r0/logout",
+            uri    => "/v3/logout",
             content => {},
          )
       })->then( sub {
@@ -44,7 +44,7 @@ test "Can logout current device",
          do_request_json_for(
             $other_login,
             method => "GET",
-            uri => "/r0/devices",
+            uri => "/v3/devices",
          );
       })->then( sub {
          my ( $devices ) = @_;
@@ -74,7 +74,7 @@ test "Can logout all devices",
 
          do_request_json_for( $user,
             method => "POST",
-            uri    => "/r0/logout/all",
+            uri    => "/v3/logout/all",
             content => {},
          )
       })->then( sub {
@@ -104,7 +104,7 @@ test "Request to logout with invalid an access token is rejected",
 
       $http->do_request_json(
          method  => "POST",
-         uri     => "/r0/logout",
+         uri     => "/v3/logout",
          content => {},
          params  => { access_token => "an/invalid/token" },
       )->main::expect_http_401->then( sub {
@@ -124,7 +124,7 @@ test "Request to logout without an access token is rejected",
 
       $http->do_request_json(
          method  => "POST",
-         uri     => "/r0/logout",
+         uri     => "/v3/logout",
          content => {},
       )->main::expect_http_401->then( sub {
          my ( $resp ) = @_;

--- a/tests/14account/01change-password.pl
+++ b/tests/14account/01change-password.pl
@@ -15,7 +15,7 @@ sub matrix_set_password
 
    do_request_json_for( $user,
       method => "POST",
-      uri    => "/r0/account/password",
+      uri    => "/v3/account/password",
       content => {
          auth => {
             type => "m.login.password",
@@ -39,7 +39,7 @@ test "After changing password, can't log in with old password",
       matrix_set_password( $user, $password, "my new password" )->then( sub {
          $user->http->do_request_json(
             method => "POST",
-            uri    => "/r0/login",
+            uri    => "/v3/login",
 
             content => {
                type     => "m.login.password",
@@ -66,7 +66,7 @@ test "After changing password, can log in with new password",
       matrix_set_password( $user, $password, "my new password" )->then( sub {
          $user->http->do_request_json(
             method => "POST",
-            uri    => "/r0/login",
+            uri    => "/v3/login",
 
             content => {
                type     => "m.login.password",
@@ -131,7 +131,7 @@ test "After changing password, different sessions can optionally be kept",
       })->then( sub {
          do_request_json_for( $user,
             method => "POST",
-            uri    => "/r0/account/password",
+            uri    => "/v3/account/password",
             content => {
                auth => {
                   type           => "m.login.password",
@@ -162,7 +162,7 @@ test "Pushers created with a different access token are deleted on password chan
 
          do_request_json_for( $other_login,
             method  => "POST",
-            uri     => "/r0/pushers/set",
+            uri     => "/v3/pushers/set",
             content => {
                profile_tag         => "tag",
                kind                => "http",
@@ -181,7 +181,7 @@ test "Pushers created with a different access token are deleted on password chan
       })->then( sub {
          do_request_json_for( $user,
             method  => "GET",
-            uri     => "/r0/pushers",
+            uri     => "/v3/pushers",
          );
       })->then( sub {
          my ( $body ) = @_;
@@ -201,7 +201,7 @@ test "Pushers created with a the same access token are not deleted on password c
 
       do_request_json_for( $user,
          method  => "POST",
-         uri     => "/r0/pushers/set",
+         uri     => "/v3/pushers/set",
          content => {
             profile_tag         => "tag",
             kind                => "http",
@@ -219,7 +219,7 @@ test "Pushers created with a the same access token are not deleted on password c
       })->then( sub {
          do_request_json_for( $user,
             method  => "GET",
-            uri     => "/r0/pushers",
+            uri     => "/v3/pushers",
          );
       })->then( sub {
          my ( $body ) = @_;

--- a/tests/14account/02deactivate.pl
+++ b/tests/14account/02deactivate.pl
@@ -9,7 +9,7 @@ sub matrix_deactivate_account
 
    do_request_json_for( $user,
       method  => "POST",
-      uri     => "/r0/account/deactivate",
+      uri     => "/v3/account/deactivate",
       content => {
          auth => {
             type     => "m.login.password",
@@ -67,7 +67,7 @@ test "After deactivating account, can't log in with password",
       ->then( sub {
          do_request_json_for( $user,
             method  => "POST",
-            uri     => "/r0/login",
+            uri     => "/v3/login",
             content => {
                type     => "m.login.password",
                identifier => {
@@ -97,7 +97,7 @@ test "After deactivating account, can't log in with an email",
       })->then( sub {
          do_request_json_for( $user,
             method  => "POST",
-            uri     => "/r0/login",
+            uri     => "/v3/login",
             content => {
                identifier => {
                   "type"    => "m.id.thirdparty",

--- a/tests/21presence-events.pl
+++ b/tests/21presence-events.pl
@@ -1,5 +1,5 @@
 # Eventually this will be changed; see SPEC-53
-my $PRESENCE_LIST_URI = "/r0/presence/list/:user_id";
+my $PRESENCE_LIST_URI = "/v3/presence/list/:user_id";
 
 
 test "initialSync sees my presence status",

--- a/tests/30rooms/03members-remote.pl
+++ b/tests/30rooms/03members-remote.pl
@@ -38,7 +38,7 @@ test "Remote users can join room by alias",
       flush_events_for( $user )->then( sub {
          do_request_json_for( $user,
             method => "POST",
-            uri    => "/r0/join/$room_alias",
+            uri    => "/v3/join/$room_alias",
 
             content => {},
          );

--- a/tests/30rooms/05aliases.pl
+++ b/tests/30rooms/05aliases.pl
@@ -24,7 +24,7 @@ test "Room aliases can contain Unicode",
 
       do_request_json_for( $user,
          method => "PUT",
-         uri    => "/r0/directory/room/$room_alias",
+         uri    => "/v3/directory/room/$room_alias",
 
          content => { room_id => $room_id },
       );
@@ -37,7 +37,7 @@ test "Room aliases can contain Unicode",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/r0/directory/room/$room_alias",
+         uri    => "/v3/directory/room/$room_alias",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -60,7 +60,7 @@ test "Remote room alias queries can handle Unicode",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/r0/directory/room/$room_alias",
+         uri    => "/v3/directory/room/$room_alias",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -234,13 +234,13 @@ test "Regular users can add and delete aliases when m.room.aliases is restricted
       })->then( sub {
          do_request_json_for( $other_user,
             method => "PUT",
-            uri    => "/r0/directory/room/$alias",
+            uri    => "/v3/directory/room/$alias",
             content => { room_id => $room_id },
          );
       })->then( sub {
          do_request_json_for( $other_user,
             method => "DELETE",
-            uri    => "/r0/directory/room/$alias",
+            uri    => "/v3/directory/room/$alias",
             content => {},
          );
       });
@@ -252,13 +252,13 @@ sub _test_can_create_and_delete_alias {
 
    do_request_json_for( $user,
       method => "PUT",
-      uri    => "/r0/directory/room/$alias",
+      uri    => "/v3/directory/room/$alias",
 
       content => { room_id => $room_id },
    )->then( sub {
       do_request_json_for( $user,
         method => "DELETE",
-        uri    => "/r0/directory/room/$alias",
+        uri    => "/v3/directory/room/$alias",
 
         content => {},
       )
@@ -277,7 +277,7 @@ test "Deleting a non-existent alias should return a 404",
       do_request_json_for(
          $user,
          method => "DELETE",
-         uri    => "/r0/directory/room/$room_alias",
+         uri    => "/v3/directory/room/$room_alias",
          content => {},
       )->main::expect_m_not_found;
    };
@@ -291,13 +291,13 @@ test "Users can't delete other's aliases",
 
       do_request_json_for( $user,
          method => "PUT",
-         uri    => "/r0/directory/room/$room_alias",
+         uri    => "/v3/directory/room/$room_alias",
 
          content => { room_id => $room_id },
       )->then( sub {
          do_request_json_for( $other_user,
            method => "DELETE",
-           uri    => "/r0/directory/room/$room_alias",
+           uri    => "/v3/directory/room/$room_alias",
 
            content => {},
          )->main::expect_http_403;
@@ -325,14 +325,14 @@ test "Users with sufficient power-level can delete other's aliases",
       })->then( sub {
          do_request_json_for( $user,
            method => "PUT",
-           uri    => "/r0/directory/room/$room_alias",
+           uri    => "/v3/directory/room/$room_alias",
 
            content => { room_id => $room_id },
          )
       })->then( sub {
          do_request_json_for( $other_user,
            method => "DELETE",
-           uri    => "/r0/directory/room/$room_alias",
+           uri    => "/v3/directory/room/$room_alias",
 
            content => {},
          )
@@ -343,7 +343,7 @@ test "Users with sufficient power-level can delete other's aliases",
          do_request_json_for(
             $user,
             method => "GET",
-            uri  => "/r0/directory/room/$room_alias",
+            uri  => "/v3/directory/room/$room_alias",
          );
       })->main::expect_http_404;
    };
@@ -363,7 +363,7 @@ test "Can delete canonical alias",
 
          do_request_json_for( $creator,
             method => "PUT",
-            uri    => "/r0/directory/room/$room_alias",
+            uri    => "/v3/directory/room/$room_alias",
 
             content => { room_id => $room_id },
          )
@@ -375,7 +375,7 @@ test "Can delete canonical alias",
       })->then( sub {
          do_request_json_for( $creator,
            method => "DELETE",
-           uri    => "/r0/directory/room/$room_alias",
+           uri    => "/v3/directory/room/$room_alias",
 
            content => {},
          )
@@ -407,14 +407,14 @@ test "Alias creators can delete alias with no ops",
 
          do_request_json_for( $other_user,
             method => "PUT",
-            uri    => "/r0/directory/room/$room_alias",
+            uri    => "/v3/directory/room/$room_alias",
 
             content => { room_id => $room_id },
          )
       })->then( sub {
          do_request_json_for( $other_user,
            method => "DELETE",
-           uri    => "/r0/directory/room/$room_alias",
+           uri    => "/v3/directory/room/$room_alias",
 
            content => {},
          )
@@ -436,7 +436,7 @@ test "Alias creators can delete canonical alias with no ops",
 
          do_request_json_for( $other_user,
             method => "PUT",
-            uri    => "/r0/directory/room/$room_alias",
+            uri    => "/v3/directory/room/$room_alias",
 
             content => { room_id => $room_id },
          )
@@ -448,7 +448,7 @@ test "Alias creators can delete canonical alias with no ops",
       })->then( sub {
          do_request_json_for( $other_user,
            method => "DELETE",
-           uri    => "/r0/directory/room/$room_alias",
+           uri    => "/v3/directory/room/$room_alias",
 
            content => {},
          )
@@ -474,7 +474,7 @@ test "Only room members can list aliases of a room",
          do_request_json_for(
             $other_user,
             method => "GET",
-            uri  => "/r0/rooms/$room_id/aliases",
+            uri  => "/v3/rooms/$room_id/aliases",
          );
       })->then( sub {
          my ( $res ) = @_;
@@ -484,7 +484,7 @@ test "Only room members can list aliases of a room",
          do_request_json_for(
             $third_user,
             method => "GET",
-            uri  => "/r0/rooms/$room_id/aliases",
+            uri  => "/v3/rooms/$room_id/aliases",
          );
       })->main::expect_http_403;
    };

--- a/tests/30rooms/07ban.pl
+++ b/tests/30rooms/07ban.pl
@@ -12,7 +12,7 @@ test "Banned user is kicked and may not rejoin until unbanned",
 
       do_request_json_for( $creator,
          method => "POST",
-         uri    => "/r0/rooms/$room_id/ban",
+         uri    => "/v3/rooms/$room_id/ban",
 
          content => { user_id => $banned_user->user_id, reason => "testing" },
       )->then( sub {
@@ -34,28 +34,28 @@ test "Banned user is kicked and may not rejoin until unbanned",
       })->then( sub {
          do_request_json_for( $creator,
             method => "POST",
-            uri    => "/r0/rooms/$room_id/invite",
+            uri    => "/v3/rooms/$room_id/invite",
 
             content => { user_id => $banned_user->user_id },
          )->main::expect_http_403;  # Must be unbanned first
       })->then( sub {
          do_request_json_for( $creator,
             method => "POST",
-            uri    => "/r0/rooms/$room_id/kick",
+            uri    => "/v3/rooms/$room_id/kick",
 
             content => { user_id => $banned_user->user_id },
          )->main::expect_http_403;  # Must be unbanned first
       })->then( sub {
          do_request_json_for( $creator,
             method => "POST",
-            uri    => "/r0/rooms/$room_id/unban",
+            uri    => "/v3/rooms/$room_id/unban",
 
             content => { user_id => $banned_user->user_id },
          );
       })->then( sub {
          do_request_json_for( $banned_user,
             method => "POST",
-            uri    => "/r0/rooms/$room_id/join",
+            uri    => "/v3/rooms/$room_id/join",
 
             content => {},
          );
@@ -75,7 +75,7 @@ test "Remote banned user is kicked and may not rejoin until unbanned",
 
       do_request_json_for( $creator,
          method => "POST",
-         uri    => "/r0/rooms/$room_id/ban",
+         uri    => "/v3/rooms/$room_id/ban",
 
          content => { user_id => $banned_user->user_id, reason => "testing" },
       )->then( sub {
@@ -111,7 +111,7 @@ test "Remote banned user is kicked and may not rejoin until unbanned",
          # Must be unbanned first
          do_request_json_for( $creator,
             method => "POST",
-            uri    => "/r0/rooms/$room_id/invite",
+            uri    => "/v3/rooms/$room_id/invite",
 
             content => { user_id => $banned_user->user_id },
          )->main::check_http_code(
@@ -122,7 +122,7 @@ test "Remote banned user is kicked and may not rejoin until unbanned",
          # Must be unbanned first
          do_request_json_for( $creator,
             method => "POST",
-            uri    => "/r0/rooms/$room_id/kick",
+            uri    => "/v3/rooms/$room_id/kick",
 
             content => { user_id => $banned_user->user_id },
          )->main::check_http_code(

--- a/tests/30rooms/08levels.pl
+++ b/tests/30rooms/08levels.pl
@@ -77,7 +77,7 @@ test_powerlevel "'ban' event respects room powerlevel",
 
       do_request_json_for( $test_user,
          method => "POST",
-         uri    => "/r0/rooms/$room_id/ban",
+         uri    => "/v3/rooms/$room_id/ban",
 
          content => { user_id => '@random_dude:test', reason => "testing" },
       );

--- a/tests/30rooms/10redactions.pl
+++ b/tests/30rooms/10redactions.pl
@@ -37,7 +37,7 @@ sub matrix_redact_event
 
    do_request_json_for( $user,
       method => "POST",
-      uri    => "/r0/rooms/$room_id/redact/$esc_event_id",
+      uri    => "/v3/rooms/$room_id/redact/$esc_event_id",
       content => \%params,
    )->then( sub {
       my ( $body ) = @_;
@@ -102,7 +102,7 @@ test "POST /rooms/:room_id/redact/:event_id as power user redacts message",
 
          do_request_json_for( $creator,
             method => "POST",
-            uri    => "/r0/rooms/$room_id/redact/$to_redact",
+            uri    => "/v3/rooms/$room_id/redact/$to_redact",
             content => {},
          );
       });
@@ -123,7 +123,7 @@ test "POST /rooms/:room_id/redact/:event_id as original message sender redacts m
 
          do_request_json_for( $sender,
                method => "POST",
-               uri    => "/r0/rooms/$room_id/redact/$to_redact",
+               uri    => "/v3/rooms/$room_id/redact/$to_redact",
                content => {},
          );
       });
@@ -144,7 +144,7 @@ test "POST /rooms/:room_id/redact/:event_id as random user does not redact messa
 
          do_request_json_for( $redactor,
                method => "POST",
-               uri    => "/r0/rooms/$room_id/redact/$to_redact",
+               uri    => "/v3/rooms/$room_id/redact/$to_redact",
                content => {},
          )->main::expect_http_403;
       });
@@ -189,7 +189,7 @@ test "Redaction of a redaction redacts the redaction reason",
          # fetch the redaction and check the reason is in place
          do_request_json_for( $creator,
             method  => "GET",
-            uri     => "/r0/rooms/$room_id/event/${ \uri_escape( $redaction_id ) }",
+            uri     => "/v3/rooms/$room_id/event/${ \uri_escape( $redaction_id ) }",
          );
       })->then( sub {
          my ( $event ) = @_;
@@ -205,7 +205,7 @@ test "Redaction of a redaction redacts the redaction reason",
 
          do_request_json_for( $creator,
             method  => "GET",
-            uri     => "/r0/rooms/$room_id/event/${ \uri_escape( $redaction_id ) }",
+            uri     => "/v3/rooms/$room_id/event/${ \uri_escape( $redaction_id ) }",
          );
       })->then( sub {
          my ( $event ) = @_;

--- a/tests/30rooms/11leaving.pl
+++ b/tests/30rooms/11leaving.pl
@@ -161,7 +161,7 @@ test "Can get rooms/{roomId}/members for a departed room (SPEC-216)",
 
         do_request_json_for( $user,
             method => "GET",
-            uri => "/r0/rooms/$room_id/members",
+            uri => "/v3/rooms/$room_id/members",
         )->then( sub {
             my ( $body ) = @_;
 

--- a/tests/30rooms/12thirdpartyinvite.pl
+++ b/tests/30rooms/12thirdpartyinvite.pl
@@ -21,7 +21,7 @@ test "Can invite existing 3pid",
 
          do_request_json_for( $inviter,
             method => "POST",
-            uri    => "/r0/rooms/$room_id/invite",
+            uri    => "/v3/rooms/$room_id/invite",
 
             content => {
                id_server       => $id_server->name,
@@ -68,7 +68,7 @@ test "Can invite existing 3pid with no ops into a private room",
 
          do_request_json_for( $inviter,
             method => "POST",
-            uri    => "/r0/rooms/$room_id/invite",
+            uri    => "/v3/rooms/$room_id/invite",
 
             content => {
                id_server       => $id_server->name,
@@ -495,7 +495,7 @@ sub do_3pid_invite {
 
    do_request_json_for( $inviter,
       method  => "POST",
-      uri     => "/r0/rooms/$room_id/invite",
+      uri     => "/v3/rooms/$room_id/invite",
       content => {
          id_server       => $id_server->name,
          id_access_token => $id_server->get_access_token,

--- a/tests/30rooms/13guestaccess.pl
+++ b/tests/30rooms/13guestaccess.pl
@@ -90,7 +90,7 @@ test "Guest user calling /events doesn't tightloop",
       })->then( sub {
          do_request_json_for( $guest_user,
             method => "GET",
-            uri    => "/r0/rooms/$room_id/initialSync",
+            uri    => "/v3/rooms/$room_id/initialSync",
          );
       })->then( sub {
          my ( $sync_body ) = @_;
@@ -157,7 +157,7 @@ test "Guest user can set display names",
    do => sub {
       my ( $guest_user, $user, $room_id ) = @_;
 
-      my $displayname_uri = "/r0/profile/:user_id/displayname";
+      my $displayname_uri = "/v3/profile/:user_id/displayname";
 
       matrix_set_room_guest_access( $user, $room_id, "can_join" )->then( sub {
          # we use join_room_synced as a proxy for ensuring that the join event
@@ -201,7 +201,7 @@ test "Guest user can set display names",
                }),
                do_request_json_for( $guest_user,
                   method => "GET",
-                  uri    => "/r0/rooms/$room_id/state/m.room.member/:user_id",
+                  uri    => "/v3/rooms/$room_id/state/m.room.member/:user_id",
                )->then( sub {
                   my ( $body ) = @_;
                   log_if_fail "Iteration $iter: /state result", $body;
@@ -277,7 +277,7 @@ test "Guest user can upgrade to fully featured user",
       my ( $local_part ) = $guest_user->user_id =~ m/^@([^:]+):/g;
       $http->do_request_json(
          method  => "POST",
-         uri     => "/r0/register",
+         uri     => "/v3/register",
          content => {
             username => $local_part,
             password => "SIR_Arthur_David",
@@ -286,7 +286,7 @@ test "Guest user can upgrade to fully featured user",
       )->followed_by( sub {
          $http->do_request_json(
             method  => "POST",
-            uri     => "/r0/register",
+            uri     => "/v3/register",
             content => {
                username     => $local_part,
                password     => "SIR_Arthur_David",
@@ -317,7 +317,7 @@ test "Guest user cannot upgrade other users",
       my ( $local_part1 ) = $guest_user1->user_id =~ m/^@([^:]+):/g;
       $http->do_request_json(
          method  => "POST",
-         uri     => "/r0/register",
+         uri     => "/v3/register",
          content => {
             username => $local_part1,
             password => "SIR_Arthur_David",
@@ -374,7 +374,7 @@ test "GET /publicRooms lists rooms",
             $iter++;
             $http->do_request_json(
                method => "GET",
-               uri    => "/r0/publicRooms",
+               uri    => "/v3/publicRooms",
             )->then( sub {
                my ( $body ) = @_;
 
@@ -464,7 +464,7 @@ test "GET /publicRooms includes avatar URLs",
          repeat_until_true {
             $http->do_request_json(
                method => "GET",
-               uri    => "/r0/publicRooms",
+               uri    => "/v3/publicRooms",
             )->then( sub {
                my ( $body ) = @_;
 
@@ -569,7 +569,7 @@ sub guest_user_fixture
 
          $http->do_request_json(
             method  => "POST",
-            uri     => "/r0/register",
+            uri     => "/v3/register",
             content => {},
             params  => {
                kind => "guest",

--- a/tests/30rooms/15kick.pl
+++ b/tests/30rooms/15kick.pl
@@ -11,7 +11,7 @@ test "Users cannot kick users from a room they are not in",
 
       do_request_json_for( $creator,
          method => "POST",
-         uri    => "/r0/rooms/$room_id/kick",
+         uri    => "/v3/rooms/$room_id/kick",
 
          content => { user_id => $fake_user_id, reason => "testing" },
       )->main::expect_http_403; # 403 for kicking a user who isn't in the room
@@ -29,7 +29,7 @@ test "Users cannot kick users who have already left a room",
 
         do_request_json_for( $creator,
            method => "POST",
-           uri    => "/r0/rooms/$room_id/kick",
+           uri    => "/v3/rooms/$room_id/kick",
 
            content => { user_id => $kicked_user->user_id, reason => "testing" },
         )->then( sub {
@@ -48,7 +48,7 @@ test "Users cannot kick users who have already left a room",
         })->then( sub {
             do_request_json_for( $creator,
                 method => "POST",
-                uri    => "/r0/rooms/$room_id/kick",
+                uri    => "/v3/rooms/$room_id/kick",
 
                 content => { user_id => $kicked_user->user_id, reason => "testing" },
             )->main::expect_http_403; # 403 for kicking a user who isn't in the room anymore

--- a/tests/30rooms/20typing.pl
+++ b/tests/30rooms/20typing.pl
@@ -18,7 +18,7 @@ sub matrix_typing
 
    do_request_json_for( $user,
       method => "PUT",
-      uri    => "/r0/rooms/$room_id/typing/:user_id",
+      uri    => "/v3/rooms/$room_id/typing/:user_id",
       content => \%params,
    );
 }

--- a/tests/30rooms/22profile.pl
+++ b/tests/30rooms/22profile.pl
@@ -5,7 +5,7 @@ foreach my $datum (qw( displayname avatar_url )) {
       do => sub {
          my ( $user, $room_id ) = @_;
 
-         my $uri = "/r0/profile/:user_id/$datum";
+         my $uri = "/v3/profile/:user_id/$datum";
 
          do_request_json_for( $user,
             method => "GET",
@@ -26,7 +26,7 @@ foreach my $datum (qw( displayname avatar_url )) {
          })->then( sub {
             do_request_json_for( $user,
                method => "GET",
-               uri    => "/r0/rooms/$room_id/state/m.room.member/:user_id",
+               uri    => "/v3/rooms/$room_id/state/m.room.member/:user_id",
             )
          })->then( sub {
             my ( $body ) = @_;

--- a/tests/30rooms/30history-visibility.pl
+++ b/tests/30rooms/30history-visibility.pl
@@ -193,7 +193,7 @@ foreach my $i (
                Future->needs_all(
                   do_request_json_for( $user,
                      method  => "POST",
-                     uri     => "/r0/rooms/$room_id/receipt/m.read/${ \uri_escape( $sent_event_id ) }",
+                     uri     => "/v3/rooms/$room_id/receipt/m.read/${ \uri_escape( $sent_event_id ) }",
                      content => {},
                   ),
 
@@ -214,7 +214,7 @@ foreach my $i (
                Future->needs_all(
                   do_request_json_for( $user,
                      method  => "PUT",
-                     uri     => "/r0/rooms/$room_id/typing/:user_id",
+                     uri     => "/v3/rooms/$room_id/typing/:user_id",
                      content => {
                         typing => JSON::true,
                         timeout => 5000 * $TIMEOUT_FACTOR,
@@ -257,7 +257,7 @@ foreach my $i (
 
          do_request_json_for( $nonjoined_user,
             method => "GET",
-            uri    => "/r0/rooms/$room_id/state",
+            uri    => "/v3/rooms/$room_id/state",
          );
       },
    );
@@ -278,7 +278,7 @@ foreach my $i (
 
          do_request_json_for( $nonjoined_user,
             method => "GET",
-            uri    => "/r0/rooms/$room_id/state/m.room.member/".$user->user_id,
+            uri    => "/v3/rooms/$room_id/state/m.room.member/".$user->user_id,
          );
       },
    );
@@ -371,7 +371,7 @@ foreach my $i (
          })->then( sub {
             do_request_json_for( $nonjoined_user,
                method => "GET",
-               uri    => "/r0/rooms/$room_id/state/m.room.member/".$user->user_id,
+               uri    => "/v3/rooms/$room_id/state/m.room.member/".$user->user_id,
             );
          });
       },

--- a/tests/30rooms/31forget.pl
+++ b/tests/30rooms/31forget.pl
@@ -9,7 +9,7 @@ sub matrix_forget_room
 
    do_request_json_for( $user,
       method => "POST",
-      uri    => "/r0/rooms/$room_id/forget",
+      uri    => "/v3/rooms/$room_id/forget",
 
       content => {},
    )->then_done(1);
@@ -112,7 +112,7 @@ test "Can forget room you've been kicked from",
       })->then( sub {
          do_request_json_for( $creator,
             method => "POST",
-            uri    => "/r0/rooms/$room_id/kick",
+            uri    => "/v3/rooms/$room_id/kick",
 
             content => { user_id => $user->user_id },
          );

--- a/tests/30rooms/40joinedapis.pl
+++ b/tests/30rooms/40joinedapis.pl
@@ -30,7 +30,7 @@ test "/joined_rooms returns only joined rooms",
       )->then( sub {
          do_request_json_for( $user,
             method => "GET",
-            uri => "/r0/joined_rooms",
+            uri => "/v3/joined_rooms",
          )
       })->then( sub {
          my ( $body ) = @_;
@@ -92,7 +92,7 @@ test "/joined_members return joined members",
 
             do_request_json_for( $user,
                method => "GET",
-               uri => "/r0/rooms/$room_id/joined_members",
+               uri => "/v3/rooms/$room_id/joined_members",
             )->then( sub {
                my ( $body ) = @_;
 

--- a/tests/30rooms/50context.pl
+++ b/tests/30rooms/50context.pl
@@ -13,7 +13,7 @@ test "/context/ on joined room works",
 
          do_request_json_for( $user,
             method  => "GET",
-            uri     => "/r0/rooms/$room_id/context/${ \uri_escape( $event_id ) }",
+            uri     => "/v3/rooms/$room_id/context/${ \uri_escape( $event_id ) }",
          );
       })->then( sub {
          my ( $body ) = @_;
@@ -37,7 +37,7 @@ test "/context/ on non world readable room does not work",
 
          do_request_json_for( $other_user,
             method  => "GET",
-            uri     => "/r0/rooms/$room_id/context/${ \uri_escape( $event_id ) }",
+            uri     => "/v3/rooms/$room_id/context/${ \uri_escape( $event_id ) }",
          );
       })->main::expect_http_403;
    };
@@ -75,7 +75,7 @@ test "/context/ returns correct number of events",
 
          do_request_json_for( $user,
             method  => "GET",
-            uri     => "/r0/rooms/$room_id/context/${ \uri_escape( $event_middle_id ) }",
+            uri     => "/v3/rooms/$room_id/context/${ \uri_escape( $event_middle_id ) }",
             params    => {
                limit => 2,
             }
@@ -120,7 +120,7 @@ test "/context/ with lazy_load_members filter works",
 
          do_request_json_for( $user,
             method  => "GET",
-            uri     => "/r0/rooms/$room_id/context/${ \uri_escape( $event_id ) }",
+            uri     => "/v3/rooms/$room_id/context/${ \uri_escape( $event_id ) }",
             params  => {
                limit => 2,
                filter  => '{ "lazy_load_members" : true }',

--- a/tests/30rooms/51event.pl
+++ b/tests/30rooms/51event.pl
@@ -4,7 +4,7 @@ use URI::Escape qw( uri_escape );
 
    my $event = matrix_get_event( $user, $room_id, $event_id ) -> get;
 
-Makes a /_matrix/client/r0/rooms/{roomId}/event/{eventId} request. Returns the event.
+Makes a /_matrix/client/v3/rooms/{roomId}/event/{eventId} request. Returns the event.
 
 =cut
 
@@ -15,7 +15,7 @@ sub matrix_get_event
    return do_request_json_for(
       $user,
       method  => "GET",
-      uri     => "/r0/rooms/${ \uri_escape( $room_id ) }/event/${ \uri_escape( $event_id ) }",
+      uri     => "/v3/rooms/${ \uri_escape( $room_id ) }/event/${ \uri_escape( $event_id ) }",
    );
 }
 
@@ -34,7 +34,7 @@ test "/event/ on joined room works",
 
          do_request_json_for( $user,
             method  => "GET",
-            uri     => "/r0/rooms/$room_id/event/${ \uri_escape( $event_id ) }",
+            uri     => "/v3/rooms/$room_id/event/${ \uri_escape( $event_id ) }",
          )->then( sub {
             my ( $body ) = @_;
 
@@ -61,7 +61,7 @@ test "/event/ on non world readable room does not work",
 
          do_request_json_for( $other_user,
             method  => "GET",
-            uri     => "/r0/rooms/$room_id/event/${ \uri_escape( $event_id ) }",
+            uri     => "/v3/rooms/$room_id/event/${ \uri_escape( $event_id ) }",
          );
       })->main::expect_http_404;
    };
@@ -101,13 +101,13 @@ test "/event/ does not allow access to events before the user joined",
          # we shouldn't be able to get the event before we joined.
          do_request_json_for( $other_user,
             method  => "GET",
-            uri     => "/r0/rooms/$room_id/event/${ \uri_escape( $event_id_1 ) }",
+            uri     => "/v3/rooms/$room_id/event/${ \uri_escape( $event_id_1 ) }",
          );
       })->main::expect_http_404->then( sub {
          # we should be able to get the event after we joined.
          do_request_json_for( $other_user,
             method  => "GET",
-            uri     => "/r0/rooms/$room_id/event/${ \uri_escape( $event_id_2 ) }",
+            uri     => "/v3/rooms/$room_id/event/${ \uri_escape( $event_id_2 ) }",
          );
       })->then( sub {
          my ( $body ) = @_;

--- a/tests/30rooms/52members.pl
+++ b/tests/30rooms/52members.pl
@@ -11,7 +11,7 @@ test "Can get rooms/{roomId}/members",
 
          do_request_json_for( $user1,
             method => "GET",
-            uri => "/r0/rooms/$room_id/members",
+            uri => "/v3/rooms/$room_id/members",
          );
       })->then( sub {
          my ( $body ) = @_;
@@ -58,7 +58,7 @@ test "Can get rooms/{roomId}/members at a given point",
       })->then( sub {
          do_request_json_for( $user1,
             method => "GET",
-            uri => "/r0/rooms/$room_id/members",
+            uri => "/v3/rooms/$room_id/members",
             params => {
                at => $at_token
             }
@@ -91,7 +91,7 @@ test "Can filter rooms/{roomId}/members",
       })->then( sub {
          do_request_json_for( $user1,
             method => "GET",
-            uri => "/r0/rooms/$room_id/members",
+            uri => "/v3/rooms/$room_id/members",
             params => {
                not_membership => 'leave',
             }
@@ -104,7 +104,7 @@ test "Can filter rooms/{roomId}/members",
 
          do_request_json_for( $user1,
             method => "GET",
-            uri => "/r0/rooms/$room_id/members",
+            uri => "/v3/rooms/$room_id/members",
             params => {
                membership => 'leave',
             }
@@ -117,7 +117,7 @@ test "Can filter rooms/{roomId}/members",
 
          do_request_json_for( $user1,
             method => "GET",
-            uri => "/r0/rooms/$room_id/members",
+            uri => "/v3/rooms/$room_id/members",
             params => {
                membership => 'join',
             }

--- a/tests/30rooms/60version_upgrade.pl
+++ b/tests/30rooms/60version_upgrade.pl
@@ -48,7 +48,7 @@ sub upgrade_room {
    do_request_json_for(
       $user,
       method  => "POST",
-      uri     => "/r0/rooms/$room_id/upgrade",
+      uri     => "/v3/rooms/$room_id/upgrade",
       content => {
          new_version => $new_version,
       },
@@ -242,7 +242,7 @@ foreach my $vis ( qw( public private ) ) {
          do_request_json_for(
             $creator,
             method   => "PUT",
-            uri      => "/r0/directory/list/room/$room_id",
+            uri      => "/v3/directory/list/room/$room_id",
             content  => {
                visibility => $vis,
             },
@@ -258,7 +258,7 @@ foreach my $vis ( qw( public private ) ) {
             do_request_json_for(
                $creator,
                method   => "GET",
-               uri      => "/r0/directory/list/room/$new_room_id",
+               uri      => "/v3/directory/list/room/$new_room_id",
             );
          })->then( sub {
             my ( $response ) = @_;
@@ -431,7 +431,7 @@ test "/upgrade preserves the power level of the upgrading user in old and new ro
          do_request_json_for(
             $upgrader,
             method  => "GET",
-            uri     => "/r0/rooms/$url_encoded_new_room_id/state/m.room.power_levels/",
+            uri     => "/v3/rooms/$url_encoded_new_room_id/state/m.room.power_levels/",
             content => {},
          );
       })->then( sub {
@@ -449,7 +449,7 @@ test "/upgrade preserves the power level of the upgrading user in old and new ro
          do_request_json_for(
             $upgrader,
             method => "GET",
-            uri    => "/r0/rooms/$url_encoded_old_room_id/state/m.room.power_levels/",
+            uri    => "/v3/rooms/$url_encoded_old_room_id/state/m.room.power_levels/",
             content => {},
          );
       })->then( sub {
@@ -663,13 +663,13 @@ test "/upgrade moves aliases to the new room",
       do_request_json_for(
          $creator,
          method => "PUT",
-         uri    => "/r0/directory/room/$room_alias_1",
+         uri    => "/v3/directory/room/$room_alias_1",
          content => { room_id => $room_id },
       )->then( sub {
          do_request_json_for(
             $creator,
             method => "PUT",
-            uri    => "/r0/directory/room/$room_alias_2",
+            uri    => "/v3/directory/room/$room_alias_2",
             content => { room_id => $room_id },
          );
       })->then( sub {
@@ -716,7 +716,7 @@ test "/upgrade moves aliases to the new room",
          do_request_json_for(
             $creator,
             method => "GET",
-            uri    => "/r0/directory/room/$room_alias_1",
+            uri    => "/v3/directory/room/$room_alias_1",
          )->then( sub {
             my ( $body ) = @_;
 
@@ -725,7 +725,7 @@ test "/upgrade moves aliases to the new room",
             do_request_json_for(
                $creator,
                method => "GET",
-               uri    => "/r0/directory/room/$room_alias_2",
+               uri    => "/v3/directory/room/$room_alias_2",
             );
          })->then( sub {
             my ( $body ) = @_;
@@ -763,7 +763,7 @@ test "/upgrade moves remote aliases to the new room",
          do_request_json_for(
             $remote_user,
             method => "PUT",
-            uri    => "/r0/directory/room/$remote_room_alias",
+            uri    => "/v3/directory/room/$remote_room_alias",
             content => { room_id => $room_id },
          );
       })->then( sub {
@@ -788,7 +788,7 @@ test "/upgrade moves remote aliases to the new room",
             do_request_json_for(
                $remote_user,
                method => "GET",
-               uri    => "/r0/directory/room/$remote_room_alias",
+               uri    => "/v3/directory/room/$remote_room_alias",
             )->then( sub {
                my ( $body ) = @_;
 
@@ -817,7 +817,7 @@ test "/upgrade preserves direct room state",
       do_request_json_for(
          $creator,
          method => "PUT",
-         uri    => "/r0/user/$user_id/account_data/m.direct",
+         uri    => "/v3/user/$user_id/account_data/m.direct",
          content => { $user_id => [$room_id] },
       )->then( sub {
          upgrade_room_synced(
@@ -847,7 +847,7 @@ test "/upgrade preserves room federation ability",
 
       do_request_json_for( $creator,
          method => "POST",
-         uri    => "/r0/createRoom",
+         uri    => "/v3/createRoom",
 
          content => {
             creation_content => {
@@ -869,7 +869,7 @@ test "/upgrade preserves room federation ability",
 
          do_request_json_for( $creator,
             method => "GET",
-            uri    => "/r0/rooms/$new_room_id/state/m.room.create",
+            uri    => "/v3/rooms/$new_room_id/state/m.room.create",
          )
       })->then( sub {
          my ( $state ) = @_;
@@ -1052,7 +1052,7 @@ test "Local and remote users' homeservers remove a room from their public direct
       })->then(sub {
          do_request_json_for( $remote_joiner,
             method => "PUT",
-            uri    => "/r0/directory/list/room/$room_id",
+            uri    => "/v3/directory/list/room/$room_id",
 
             content => {
                visibility => "public",
@@ -1075,7 +1075,7 @@ test "Local and remote users' homeservers remove a room from their public direct
          retry_until_success {
             do_request_json_for( $creator,
                method => "GET",
-               uri    => "/r0/publicRooms",
+               uri    => "/v3/publicRooms",
             )->then( sub {
                # Check public rooms list for local user
                my ( $body ) = @_;
@@ -1101,7 +1101,7 @@ test "Local and remote users' homeservers remove a room from their public direct
          retry_until_success {
             do_request_json_for( $remote_joiner,
                method => "GET",
-               uri    => "/r0/publicRooms",
+               uri    => "/v3/publicRooms",
             )->then( sub {
             # Check public rooms list for remote user
                my ( $body ) = @_;

--- a/tests/30rooms/70publicroomslist.pl
+++ b/tests/30rooms/70publicroomslist.pl
@@ -46,7 +46,7 @@ test "Name/topic keys are correct",
          retry_until_success {
             $http->do_request_json(
                method => "GET",
-               uri    => "/r0/publicRooms",
+               uri    => "/v3/publicRooms",
             )->then( sub {
                my ( $body ) = @_;
 
@@ -128,7 +128,7 @@ test "Can get remote public room list",
 
          do_request_json_for( $remote_user,
             method => "GET",
-            uri    => "/r0/publicRooms",
+            uri    => "/v3/publicRooms",
 
             params => { server => $first_home_server },
          )
@@ -174,7 +174,7 @@ test "Can paginate public room list",
 
          do_request_json_for( $user,
             method => "GET",
-            uri    => "/r0/publicRooms",
+            uri    => "/v3/publicRooms",
          )
       })->then( sub {
          my ( $body ) = @_;
@@ -188,7 +188,7 @@ test "Can paginate public room list",
          try_repeat {
             do_request_json_for( $user,
                method => "POST",
-               uri    => "/r0/publicRooms",
+               uri    => "/v3/publicRooms",
 
                content => { limit => 3, since => $next_batch },
             )->then( sub {
@@ -223,7 +223,7 @@ test "Can paginate public room list",
          try_repeat {
             do_request_json_for( $user,
                method => "POST",
-               uri    => "/r0/publicRooms",
+               uri    => "/v3/publicRooms",
 
                content => { limit => 3, since => $prev_batch },
             )->then( sub {
@@ -273,7 +273,7 @@ test "Can search public room list",
          retry_until_success {
             do_request_json_for( $local_user,
                method => "POST",
-               uri    => "/r0/publicRooms",
+               uri    => "/v3/publicRooms",
 
                content => {
                   filter => {
@@ -319,7 +319,7 @@ test "Asking for a remote rooms list, but supplying the local server's name, ret
          retry_until_success {
             do_request_json_for( $local_user,
                method => "POST",
-               uri    => "/r0/publicRooms",
+               uri    => "/v3/publicRooms",
 
                # Ask the local server for a remote room list, but supply the local server's server_name
                # Server should return the local public rooms list

--- a/tests/31sync/01filter.pl
+++ b/tests/31sync/01filter.pl
@@ -14,7 +14,7 @@ sub matrix_create_filter
 
    do_request_json_for( $user,
       method  => "POST",
-      uri     => "/r0/user/:user_id/filter",
+      uri     => "/v3/user/:user_id/filter",
       content => $filter,
    )->then( sub {
       my ( $body ) = @_;
@@ -56,7 +56,7 @@ test "Can download filter",
 
          do_request_json_for( $user,
             method  => "GET",
-            uri     => "/r0/user/:user_id/filter/$filter_id",
+            uri     => "/v3/user/:user_id/filter/$filter_id",
          )
       })->then( sub {
          my ( $body ) = @_;

--- a/tests/31sync/10archived-ban.pl
+++ b/tests/31sync/10archived-ban.pl
@@ -6,7 +6,7 @@ sub ban_user_synced
       do => sub {
          do_request_json_for( $banner,
             method => "POST",
-            uri    => "/r0/rooms/$room_id/ban",
+            uri    => "/v3/rooms/$room_id/ban",
             content => { user_id => $bannee->user_id, reason => "testing" },
          );
       },
@@ -123,7 +123,7 @@ test "Newly banned rooms appear in the leave section of incremental sync",
       })->then( sub {
          do_request_json_for( $user_a,
             method => "POST",
-            uri    => "/r0/rooms/$room_id/ban",
+            uri    => "/v3/rooms/$room_id/ban",
             content => { user_id => $user_b->user_id, reason => "testing" },
          );
       })->then( sub {

--- a/tests/31sync/17peeking.pl
+++ b/tests/31sync/17peeking.pl
@@ -12,7 +12,7 @@ test "Local users can peek into world_readable rooms by room ID",
       matrix_set_room_history_visibility( $user, $room_id, "world_readable" )->then(sub {
          do_request_json_for( $peeking_user,
             method => "POST",
-            uri    => "/r0/peek/$room_id",
+            uri    => "/v3/peek/$room_id",
             content => {},
          )
       })->then( sub {
@@ -88,7 +88,7 @@ for my $visibility (qw(shared invited joined)) {
          matrix_set_room_history_visibility( $user, $room_id, $visibility )->then(sub {
             do_request_json_for( $peeking_user,
                method => "POST",
-               uri    => "/r0/peek/$room_id",
+               uri    => "/v3/peek/$room_id",
                content => {},
             );
          })->main::expect_http_403()
@@ -116,7 +116,7 @@ test "Local users can peek by room alias",
       matrix_set_room_history_visibility( $user, $room_id, "world_readable" )->then(sub {
          do_request_json_for( $peeking_user,
             method => "POST",
-            uri    => "/r0/peek/#$room_alias_name:".$user->http->server_name,
+            uri    => "/v3/peek/#$room_alias_name:".$user->http->server_name,
             content => {},
          )
       })->then(sub {
@@ -155,7 +155,7 @@ test "Peeked rooms only turn up in the sync for the device who peeked them",
          $peeking_user_device2 = $_[0];
          do_request_json_for( $peeking_user,
             method => "POST",
-            uri    => "/r0/peek/$room_id",
+            uri    => "/v3/peek/$room_id",
             content => {},
          )
       })->then(sub {

--- a/tests/32room-versions.pl
+++ b/tests/32room-versions.pl
@@ -229,7 +229,7 @@ foreach my $version ( @{ (SyTest::Federation::Client::SUPPORTED_ROOM_VERSIONS) }
             do_request_json_for(
                $remote,
                method => "POST",
-               uri    => "/r0/rooms/$room_id/redact/$to_redact",
+               uri    => "/v3/rooms/$room_id/redact/$to_redact",
                content => {},
              );
          })->then( sub {

--- a/tests/41end-to-end-keys/01-upload-key.pl
+++ b/tests/41end-to-end-keys/01-upload-key.pl
@@ -12,7 +12,7 @@ test "Can upload device keys",
 
       do_request_json_for( $user,
          method  => "POST",
-         uri     => "/r0/keys/upload",
+         uri     => "/v3/keys/upload",
          content => {
             device_keys => {
                user_id => $user->user_id,
@@ -58,7 +58,7 @@ test "Rejects invalid device keys",
       # algorithms, keys and signatures are required fields, but missing
       do_request_json_for( $user,
          method  => "POST",
-         uri     => "/r0/keys/upload",
+         uri     => "/v3/keys/upload",
          content => {
             device_keys => {
                user_id => $user->user_id,
@@ -86,7 +86,7 @@ test "Should reject keys claiming to belong to a different user",
       do_request_json_for(
          $user,
          method  => "POST",
-         uri     => "/r0/keys/upload",
+         uri     => "/v3/keys/upload",
          content => {
             device_keys => {
                user_id => "\@50-e2e-alice:localhost:8480",
@@ -200,7 +200,7 @@ sub matrix_put_e2e_keys
 
    do_request_json_for( $user,
       method => "POST",
-      uri    => "/r0/keys/upload",
+      uri    => "/v3/keys/upload",
 
       content => {
          device_keys => \%device_keys,
@@ -224,7 +224,7 @@ sub matrix_get_e2e_keys {
 
    do_request_json_for( $from_user,
        method  => "POST",
-       uri     => "/r0/keys/query",
+       uri     => "/v3/keys/query",
        content => {
           device_keys => {
              $target_user_id => $devices // []

--- a/tests/41end-to-end-keys/03-one-time-keys.pl
+++ b/tests/41end-to-end-keys/03-one-time-keys.pl
@@ -9,7 +9,7 @@ multi_test "Can claim one time key using POST",
 
       do_request_json_for( $user,
          method  => "POST",
-         uri     => "/r0/keys/upload",
+         uri     => "/v3/keys/upload",
          content => {
             one_time_keys => {
                "test_algorithm:test_id", "iDBFAwt4T0ntzaZXwEevrKfmelFUMj8KS6n6kYhBPzU"
@@ -19,7 +19,7 @@ multi_test "Can claim one time key using POST",
       ->then( sub {
          do_request_json_for( $user,
             method  => "POST",
-            uri     => "/r0/keys/claim",
+            uri     => "/v3/keys/claim",
             content => {
                one_time_keys => {
                   $user->user_id => {
@@ -51,7 +51,7 @@ multi_test "Can claim one time key using POST",
          # a second claim should give no keys
          do_request_json_for( $user,
             method  => "POST",
-            uri     => "/r0/keys/claim",
+            uri     => "/v3/keys/claim",
             content => {
                one_time_keys => {
                   $user->user_id => {

--- a/tests/41end-to-end-keys/05-one-time-key-federation.pl
+++ b/tests/41end-to-end-keys/05-one-time-key-federation.pl
@@ -9,7 +9,7 @@ multi_test "Can claim remote one time key using POST",
 
       do_request_json_for( $user,
          method  => "POST",
-         uri     => "/r0/keys/upload",
+         uri     => "/v3/keys/upload",
          content => {
             one_time_keys => {
                "test_algorithm:test_id", "kUuAFk05Ig0RjwDimSYHOXKro8BRB14G0efxVOq73VU"
@@ -19,7 +19,7 @@ multi_test "Can claim remote one time key using POST",
       ->then( sub {
          do_request_json_for( $remote_user,
             method  => "POST",
-            uri     => "/r0/keys/claim",
+            uri     => "/v3/keys/claim",
             content => {
                one_time_keys => {
                   $user->user_id => {
@@ -51,7 +51,7 @@ multi_test "Can claim remote one time key using POST",
          # a second claim should give no keys
          do_request_json_for( $remote_user,
             method  => "POST",
-            uri     => "/r0/keys/claim",
+            uri     => "/v3/keys/claim",
             content => {
                one_time_keys => {
                   $user->user_id => {

--- a/tests/41end-to-end-keys/06-device-lists.pl
+++ b/tests/41end-to-end-keys/06-device-lists.pl
@@ -73,7 +73,7 @@ test "Local device key changes appear in v2 /sync",
       })->then( sub {
          do_request_json_for( $user2,
             method  => "POST",
-            uri     => "/r0/keys/upload",
+            uri     => "/v3/keys/upload",
             content => {
                device_keys => {
                   user_id   => $user2->user_id,
@@ -385,7 +385,7 @@ test "If remote user leaves room we no longer receive device updates",
          # sanity check: make sure that we've got the right update
          do_request_json_for( $creator,
             method => "POST",
-            uri    => "/r0/keys/query",
+            uri    => "/v3/keys/query",
 
             content => {
                device_keys => { $remote_leaver->user_id => [ $remote_leaver->device_id ] },
@@ -481,7 +481,7 @@ test "Local device key changes appear in /keys/changes",
 
          do_request_json_for( $user2,
             method  => "POST",
-            uri     => "/r0/keys/upload",
+            uri     => "/v3/keys/upload",
             content => {
                device_keys => {
                   user_id   => $user2->user_id,
@@ -501,7 +501,7 @@ test "Local device key changes appear in /keys/changes",
 
          do_request_json_for( $user1,
             method => "GET",
-            uri => "/r0/keys/changes",
+            uri => "/v3/keys/changes",
             params => {
                from => $from_token,
                to => $to_token,
@@ -549,7 +549,7 @@ test "New users appear in /keys/changes",
 
          do_request_json_for( $user1,
             method => "GET",
-            uri    => "/r0/keys/changes",
+            uri    => "/v3/keys/changes",
 
             params => {
                from => $from_token,
@@ -615,7 +615,7 @@ test "If remote user leaves room, changes device and rejoins we see update in /k
 
          do_request_json_for( $creator,
             method => "GET",
-            uri    => "/r0/keys/changes",
+            uri    => "/v3/keys/changes",
 
             params => {
                from => $from_token,
@@ -672,7 +672,7 @@ test "Get left notifs in sync and /keys/changes when other user leaves",
       })->then( sub {
          do_request_json_for( $creator,
             method => "GET",
-            uri    => "/r0/keys/changes",
+            uri    => "/v3/keys/changes",
 
             params => {
                from => $from_token,
@@ -726,7 +726,7 @@ test "Get left notifs for other users in sync and /keys/changes when user leaves
       })->then( sub {
          do_request_json_for( $creator,
             method => "GET",
-            uri    => "/r0/keys/changes",
+            uri    => "/v3/keys/changes",
 
             params => {
                from => $from_token,
@@ -797,7 +797,7 @@ test "If user leaves room, remote user changes device and rejoins we see update 
 
          do_request_json_for( $creator,
             method => "GET",
-            uri    => "/r0/keys/changes",
+            uri    => "/v3/keys/changes",
 
             params => {
                from => $from_token,

--- a/tests/41end-to-end-keys/07-backup.pl
+++ b/tests/41end-to-end-keys/07-backup.pl
@@ -60,7 +60,7 @@ test "Can update backup version",
          do_request_json_for(
             $user,
             method  => "PUT",
-            uri     => "/r0/room_keys/version/$version",
+            uri     => "/v3/room_keys/version/$version",
             content => {
                algorithm => "m.megolm_backup.v1",
                auth_data => "adifferentopaquestring",
@@ -384,7 +384,7 @@ test "Deleted & recreated backups are empty",
          # get all keys
          do_request_json_for( $user,
             method  => "GET",
-            uri     => "/r0/room_keys/keys",
+            uri     => "/v3/room_keys/keys",
             params  => {
                version => $content->{version},
             }
@@ -424,7 +424,7 @@ sub matrix_create_key_backup {
 
    do_request_json_for( $user,
       method  => "POST",
-      uri     => "/r0/room_keys/version",
+      uri     => "/v3/room_keys/version",
       content => {
          algorithm => "m.megolm_backup.v1",
          auth_data => "anopaquestring",
@@ -445,7 +445,7 @@ sub matrix_delete_key_backup {
 
    do_request_json_for( $user,
       method  => "DELETE",
-      uri     => "/r0/room_keys/version/$version",
+      uri     => "/v3/room_keys/version/$version",
    );
 }
 
@@ -462,7 +462,7 @@ version if version is omitted
 sub matrix_get_key_backup_info {
    my ( $user, $version ) = @_;
 
-   my $url = "/r0/room_keys/version";
+   my $url = "/v3/room_keys/version";
 
    if (defined($version)) {
       $url .= "/$version";
@@ -486,7 +486,7 @@ sub matrix_backup_keys {
    my ( $user, $room_id, $session_id, $version, $content ) = @_;
    do_request_json_for( $user,
       method  => "PUT",
-      uri     => "/r0/room_keys/keys/$room_id/$session_id",
+      uri     => "/v3/room_keys/keys/$room_id/$session_id",
       params  => {
          version => $version,
       },
@@ -508,11 +508,11 @@ sub matrix_get_backup_key {
    my $uri;
 
    if ( defined $session_id ) {
-      $uri = "/r0/room_keys/keys/$room_id/$session_id";
+      $uri = "/v3/room_keys/keys/$room_id/$session_id";
    } elsif ( defined $room_id ) {
-      $uri = "/r0/room_keys/keys/$room_id";
+      $uri = "/v3/room_keys/keys/$room_id";
    } else {
-      $uri = "/r0/room_keys/keys";
+      $uri = "/v3/room_keys/keys";
    }
 
    do_request_json_for( $user,

--- a/tests/42tags.pl
+++ b/tests/42tags.pl
@@ -14,7 +14,7 @@ sub matrix_add_tag
 
    do_request_json_for( $user,
       method  => "PUT",
-      uri     => "/r0/user/:user_id/rooms/$room_id/tags/$tag",
+      uri     => "/v3/user/:user_id/rooms/$room_id/tags/$tag",
       content => $content
    );
 }
@@ -34,7 +34,7 @@ sub matrix_remove_tag
 
    do_request_json_for( $user,
       method  => "DELETE",
-      uri     => "/r0/user/:user_id/rooms/$room_id/tags/$tag",
+      uri     => "/v3/user/:user_id/rooms/$room_id/tags/$tag",
       content => {}
    );
 }
@@ -54,7 +54,7 @@ sub matrix_list_tags
 
    do_request_json_for( $user,
       method  => "GET",
-      uri     => "/r0/user/:user_id/rooms/$room_id/tags",
+      uri     => "/v3/user/:user_id/rooms/$room_id/tags",
    )->then( sub {
       my ( $body ) = @_;
 

--- a/tests/43search.pl
+++ b/tests/43search.pl
@@ -17,7 +17,7 @@ test "Can search for an event by body",
 
          do_request_json_for( $user,
             method  => "POST",
-            uri     => "/r0/search",
+            uri     => "/v3/search",
             content => {
                search_categories => {
                   room_events => {
@@ -87,7 +87,7 @@ test "Can get context around search results",
       }, foreach => [ 1 .. 7 ] )->then( sub {
          do_request_json_for( $user,
             method  => "POST",
-            uri    => "/r0/search",
+            uri    => "/v3/search",
             content => $search_query,
          );
       })->then( sub {
@@ -149,7 +149,7 @@ test "Can back-paginate search results",
         }, foreach => [ 0 .. 19 ] )->then( sub {
             do_request_json_for( $user,
                                  method  => "POST",
-                                 uri     => "/r0/search",
+                                 uri     => "/v3/search",
                                  content => $search_query,
             );
         })->then( sub {
@@ -176,7 +176,7 @@ test "Can back-paginate search results",
 
             do_request_json_for( $user,
                                  method  => "POST",
-                                 uri     => "/r0/search",
+                                 uri     => "/v3/search",
                                  params  => { next_batch => $next_batch },
                                  content => $search_query,
             );
@@ -204,7 +204,7 @@ test "Can back-paginate search results",
 
             do_request_json_for( $user,
                                  method  => "POST",
-                                 uri     => "/r0/search",
+                                 uri     => "/v3/search",
                                  params  => { next_batch => $next_batch },
                                  content => $search_query,
             );
@@ -260,7 +260,7 @@ test "Search works across an upgraded room and its predecessor",
 
          do_request_json_for( $user,
             method  => "POST",
-            uri     => "/r0/search",
+            uri     => "/v3/search",
             content => {
                search_categories => {
                   room_events => {
@@ -334,7 +334,7 @@ foreach my $ordering_type ( qw ( rank recent ) ) {
          })->then( sub {
             do_request_json_for( $user,
                method  => "POST",
-               uri     => "/r0/search",
+               uri     => "/v3/search",
                content => {
                   search_categories => {
                      room_events => {

--- a/tests/45openid.pl
+++ b/tests/45openid.pl
@@ -6,7 +6,7 @@ test "Can generate a openid access_token that can be exchanged for information a
 
       do_request_json_for( $user,
          method  => "POST",
-         uri     => "/r0/user/:user_id/openid/request_token",
+         uri     => "/v3/user/:user_id/openid/request_token",
          content => {},
       )->then( sub {
          my ( $body ) = @_;

--- a/tests/46direct/01directmessage.pl
+++ b/tests/46direct/01directmessage.pl
@@ -13,7 +13,7 @@ sub matrix_send_device_message
 
    do_request_json_for( $user,
       method  => "PUT",
-      uri     => "/r0/sendToDevice/$type/$txn_id",
+      uri     => "/v3/sendToDevice/$type/$txn_id",
       content => \%params,
    );
 }

--- a/tests/48admin.pl
+++ b/tests/48admin.pl
@@ -46,7 +46,7 @@ test "/whois",
 
          do_request_json_for( $user,
             method => "GET",
-            uri    => "/r0/admin/whois/".$user->user_id,
+            uri    => "/v3/admin/whois/".$user->user_id,
          )
       })->then( sub {
          my ( $body ) = @_;
@@ -411,7 +411,7 @@ multi_test "Shutdown room",
       ->then( sub {
          do_request_json_for( $user,
             method => "GET",
-            uri    => "/r0/directory/room/$room_alias",
+            uri    => "/v3/directory/room/$room_alias",
          );
       })->then( sub {
          my ( $body ) = @_;

--- a/tests/50federation/10query-profile.pl
+++ b/tests/50federation/10query-profile.pl
@@ -23,7 +23,7 @@ test "Outbound federation can query profile data",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/r0/profile/\@user:$local_server_name/displayname",
+         uri    => "/v3/profile/\@user:$local_server_name/displayname",
       )->then( sub {
          my ( $body ) = @_;
          log_if_fail "Query response", $body;
@@ -48,7 +48,7 @@ test "Inbound federation can query profile data",
 
       do_request_json_for( $user,
          method => "PUT",
-         uri    => "/r0/profile/:user_id/displayname",
+         uri    => "/v3/profile/:user_id/displayname",
 
          content => {
             displayname => $dname,

--- a/tests/50federation/11query-directory.pl
+++ b/tests/50federation/11query-directory.pl
@@ -22,7 +22,7 @@ test "Outbound federation can query room alias directory",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/r0/directory/room/$room_alias",
+         uri    => "/v3/directory/room/$room_alias",
       )->then( sub {
          my ( $body ) = @_;
          log_if_fail "Query response", $body;
@@ -60,7 +60,7 @@ test "Inbound federation can query room alias directory",
 
          do_request_json_for( $user,
             method => "PUT",
-            uri    => "/r0/directory/room/$room_alias",
+            uri    => "/v3/directory/room/$room_alias",
 
             content => {
                room_id => $room_id,

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -136,7 +136,7 @@ foreach my $versionprefix ( qw( v1 v2 ) ) {
 
             do_request_json_for( $user,
                method => "POST",
-               uri    => "/r0/join/$room_alias",
+               uri    => "/v3/join/$room_alias",
 
                content => {},
             )->then( sub {
@@ -198,7 +198,7 @@ test "Outbound federation passes make_join failures through to the client",
 
          do_request_json_for( $user,
             method => "POST",
-            uri    => "/r0/join/$room_alias",
+            uri    => "/v3/join/$room_alias",
 
             content => {},
          )->main::expect_http_400
@@ -800,7 +800,7 @@ test "Outbound federation correctly handles unsupported room versions",
 
          do_request_json_for( $user,
             method => "POST",
-            uri    => "/r0/join/$room_alias",
+            uri    => "/v3/join/$room_alias",
 
             content => {},
          )->main::expect_http_400
@@ -901,7 +901,7 @@ test "Outbound federation rejects send_join responses with no m.room.create even
 
          do_request_json_for( $user,
             method => "POST",
-            uri    => "/r0/join/$room_alias",
+            uri    => "/v3/join/$room_alias",
 
             content => {},
          )->main::expect_http_error()->then( sub {
@@ -984,7 +984,7 @@ test "Outbound federation rejects m.room.create events with an unknown room vers
 
          do_request_json_for( $user,
             method => "POST",
-            uri    => "/r0/join/$room_alias",
+            uri    => "/v3/join/$room_alias",
 
             content => {},
          )->main::expect_http_error()->then( sub {
@@ -1078,7 +1078,7 @@ test "Event with an invalid signature in the send_join response should not cause
 
          do_request_json_for( $user,
             method => "POST",
-            uri    => "/r0/join/$room_alias",
+            uri    => "/v3/join/$room_alias",
 
             content => {},
          )->then( sub {

--- a/tests/50federation/31room-send.pl
+++ b/tests/50federation/31room-send.pl
@@ -20,7 +20,7 @@ test "Outbound federation can send events",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/r0/join/$room_alias",
+         uri    => "/v3/join/$room_alias",
 
          content => {},
       )->then( sub {

--- a/tests/50federation/34room-backfill.pl
+++ b/tests/50federation/34room-backfill.pl
@@ -60,7 +60,7 @@ test "Outbound federation can backfill events",
 
          do_request_json_for( $user,
             method => "POST",
-            uri    => "/r0/join/$room_alias",
+            uri    => "/v3/join/$room_alias",
 
             content => {},
          )->then( sub {
@@ -413,7 +413,7 @@ test "Backfilled events whose prev_events are in a different room do not allow c
             do_request_json_for(
                $creator_user,
                method => "GET",
-               uri    => "/r0/rooms/$room2_id/messages",
+               uri    => "/v3/rooms/$room2_id/messages",
                params => {
                   dir  => "b",
                   from => $prev_batch,

--- a/tests/50federation/37public-rooms.pl
+++ b/tests/50federation/37public-rooms.pl
@@ -20,7 +20,7 @@ test "Inbound federation can get public room list",
 
         do_request_json_for( $creator,
            method   => "PUT",
-           uri      => "/r0/directory/list/room/$room_id",
+           uri      => "/v3/directory/list/room/$room_id",
            content  => {
              visibility => "public",
           },

--- a/tests/50federation/39redactions.pl
+++ b/tests/50federation/39redactions.pl
@@ -59,7 +59,7 @@ test "Inbound federation ignores redactions from invalid servers room > v3",
          # re-check the original event
          do_request_json_for( $creator,
             method  => "GET",
-            uri     => "/r0/rooms/$room_id/event/${ \uri_escape( $msg_event_id ) }",
+            uri     => "/v3/rooms/$room_id/event/${ \uri_escape( $msg_event_id ) }",
          );
       })->then( sub {
          my ( $ev ) = @_;
@@ -80,7 +80,7 @@ test "Inbound federation ignores redactions from invalid servers room > v3",
          # if we now fetch the event, it should be redacted by the redaction event
          do_request_json_for( $creator,
             method  => "GET",
-            uri     => "/r0/rooms/$room_id/event/${ \uri_escape( $msg_event_id ) }",
+            uri     => "/v3/rooms/$room_id/event/${ \uri_escape( $msg_event_id ) }",
          );
       })->then( sub {
          my ( $ev ) = @_;
@@ -108,7 +108,7 @@ test "Inbound federation ignores redactions from invalid servers room > v3",
          # re-check the original event
          do_request_json_for( $creator,
             method  => "GET",
-            uri     => "/r0/rooms/$room_id/event/${ \uri_escape( $msg_event_id ) }",
+            uri     => "/v3/rooms/$room_id/event/${ \uri_escape( $msg_event_id ) }",
          );
       })->then( sub {
          my ( $ev ) = @_;

--- a/tests/50federation/40devicelists.pl
+++ b/tests/50federation/40devicelists.pl
@@ -19,7 +19,7 @@ test "Local device key changes get to remote servers",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/r0/join/$room_alias",
+         uri    => "/v3/join/$room_alias",
 
          content => {},
       )->then( sub {
@@ -126,7 +126,7 @@ test "Server correctly handles incoming m.device_list_update",
       })->then( sub {
          do_request_json_for( $user,
             method  => "POST",
-            uri     => "/r0/keys/query",
+            uri     => "/v3/keys/query",
             content => {
                device_keys => {
                   $creator_id => [ "random_device_id" ],
@@ -166,7 +166,7 @@ test "Server correctly handles incoming m.device_list_update",
       })->then( sub {
          do_request_json_for( $user,
             method  => "POST",
-            uri     => "/r0/keys/query",
+            uri     => "/v3/keys/query",
             content => {
                device_keys => {
                   $creator_id => [ "random_device_id" ],
@@ -238,7 +238,7 @@ test "Server correctly resyncs when client query keys and there is no remote cac
          }),
          do_request_json_for( $user,
             method  => "POST",
-            uri     => "/r0/keys/query",
+            uri     => "/v3/keys/query",
             content => {
                device_keys => {
                   $federated_user_id => [],
@@ -300,7 +300,7 @@ test "Server correctly resyncs when server leaves and rejoins a room",
          }),
          do_request_json_for( $user,
             method  => "POST",
-            uri     => "/r0/keys/query",
+            uri     => "/v3/keys/query",
             content => {
                device_keys => {
                   $federated_user_id => [],
@@ -375,7 +375,7 @@ test "Server correctly resyncs when server leaves and rejoins a room",
             }),
             do_request_json_for( $user,
                method  => "POST",
-               uri     => "/r0/keys/query",
+               uri     => "/v3/keys/query",
                content => {
                   device_keys => {
                      $federated_user_id => [],
@@ -422,13 +422,13 @@ test "Local device key changes get to remote servers with correct prev_id",
 
       do_request_json_for( $user1,
          method => "POST",
-         uri    => "/r0/join/$room_alias",
+         uri    => "/v3/join/$room_alias",
 
          content => {},
       )->then( sub {
          do_request_json_for( $user2,
             method => "POST",
-            uri    => "/r0/join/$room_alias",
+            uri    => "/v3/join/$room_alias",
 
             content => {},
          )
@@ -593,7 +593,7 @@ test "Device list doesn't change if remote server is down",
       })->then( sub {
          do_request_json_for( $local_user,
             method  => "POST",
-            uri     => "/r0/keys/query",
+            uri     => "/v3/keys/query",
             content => {
                device_keys => {
                   $outbound_client_user => []
@@ -641,7 +641,7 @@ test "Device list doesn't change if remote server is down",
       })->then( sub {
          do_request_json_for( $local_user,
             method  => "POST",
-            uri     => "/r0/keys/query",
+            uri     => "/v3/keys/query",
             content => {
                device_keys => {
                   $outbound_client_user => []
@@ -736,7 +736,7 @@ test "If a device list update goes missing, the server resyncs on the next one",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/r0/join/$room_alias",
+         uri    => "/v3/join/$room_alias",
 
          content => {},
       )->then( sub {
@@ -811,7 +811,7 @@ test "If a device list update goes missing, the server resyncs on the next one",
       })->then( sub {
          do_request_json_for( $user,
             method  => "POST",
-            uri     => "/r0/keys/query",
+            uri     => "/v3/keys/query",
             content => {
                device_keys => {
                   $creator_id => [ $device_id ],

--- a/tests/51media/01unicode.pl
+++ b/tests/51media/01unicode.pl
@@ -59,7 +59,7 @@ sub upload_test_content
 
    $user->http->do_request(
       method       => "POST",
-      full_uri     => "/_matrix/media/r0/upload",
+      full_uri     => "/_matrix/media/v3/upload",
       content      => "Test media file",
       content_type => "text/plain",
 
@@ -99,7 +99,7 @@ sub get_media
 
    $http->do_request(
       method   => "GET",
-      full_uri => "/_matrix/media/r0/download/$content_id",
+      full_uri => "/_matrix/media/v3/download/$content_id",
    )->then( sub {
       my ( $body, $response ) = @_;
 
@@ -228,7 +228,7 @@ test "Can download specifying a different Unicode file name",
 
       $http->do_request(
          method   => "GET",
-         full_uri => "/_matrix/media/r0/download/$content_id/$alt_filename_encoded",
+         full_uri => "/_matrix/media/v3/download/$content_id/$alt_filename_encoded",
       )->then( sub {
          my ( $body, $response ) = @_;
 

--- a/tests/51media/03ascii.pl
+++ b/tests/51media/03ascii.pl
@@ -72,7 +72,7 @@ test "Can download specifying a different ASCII file name",
 
       $http->do_request(
          method   => "GET",
-         full_uri => "/_matrix/media/r0/download/$content_id/also_ascii",
+         full_uri => "/_matrix/media/v3/download/$content_id/also_ascii",
       )->then( sub {
          my ( $body, $response ) = @_;
 
@@ -108,7 +108,7 @@ test "Can fetch images in room",
       })->then( sub {
          do_request_json_for( $user,
             method => "GET",
-            uri    => "/r0/rooms/$room_id/messages",
+            uri    => "/v3/rooms/$room_id/messages",
             params => {
                filter => '{"contains_url":true}',
                dir    => 'b',

--- a/tests/51media/10thumbnail.pl
+++ b/tests/51media/10thumbnail.pl
@@ -43,7 +43,7 @@ sub upload_test_image
    # Because we're POST'ing non-JSON
    return $user->http->do_request(
       method => "POST",
-      full_uri => "/_matrix/media/r0/upload",
+      full_uri => "/_matrix/media/v3/upload",
       params => {
          access_token => $user->access_token,
       },
@@ -64,7 +64,7 @@ sub fetch_and_validate_thumbnail
 
    return $http->do_request(
       method => "GET",
-      full_uri => "/_matrix/media/r0/thumbnail/" .
+      full_uri => "/_matrix/media/v3/thumbnail/" .
          join( "", $mxc_uri->authority, $mxc_uri->path ),
       params => {
          width  => 32,

--- a/tests/51media/20urlpreview.pl
+++ b/tests/51media/20urlpreview.pl
@@ -66,7 +66,7 @@ multi_test "Test URL preview",
 
          $user->http->do_request(
             method   => "GET",
-            full_uri => "/_matrix/media/r0/preview_url",
+            full_uri => "/_matrix/media/v3/preview_url",
             params   => {
                url          => $test_server_info->client_location . "/test.html",
                access_token => $user->access_token,

--- a/tests/51media/30config.pl
+++ b/tests/51media/30config.pl
@@ -5,7 +5,7 @@ test "Can read configuration endpoint",
         my ( $http, $user ) = @_;
         $http->do_request_json(
             method   => "GET",
-            full_uri => "/_matrix/media/r0/config",
+            full_uri => "/_matrix/media/v3/config",
             params => {
                 access_token => $user->access_token,
             }

--- a/tests/51media/48admin-quarantine.pl
+++ b/tests/51media/48admin-quarantine.pl
@@ -17,7 +17,7 @@ multi_test "Can quarantine media in rooms",
       # Because we're POST'ing non-JSON
       $user->http->do_request(
          method => "POST",
-         full_uri => "/_matrix/media/r0/upload",
+         full_uri => "/_matrix/media/v3/upload",
          params => {
             access_token => $user->access_token,
          },
@@ -51,13 +51,13 @@ multi_test "Can quarantine media in rooms",
       ->then( sub {
          $user->http->do_request(
             method   => "GET",
-            full_uri => "/_matrix/media/r0/download/$content_id",
+            full_uri => "/_matrix/media/v3/download/$content_id",
          )->main::expect_http_404;
       })->SyTest::pass_on_done( "404 on getting quarantined local media" )
       ->then( sub {
          $user->http->do_request(
             method => "GET",
-            full_uri => "/_matrix/media/r0/thumbnail/$content_id",
+            full_uri => "/_matrix/media/v3/thumbnail/$content_id",
             params => {
                width  => 32,
                height => 32,
@@ -68,13 +68,13 @@ multi_test "Can quarantine media in rooms",
       ->then( sub {
          $remote_user->http->do_request(
             method   => "GET",
-            full_uri => "/_matrix/media/r0/download/$content_id",
+            full_uri => "/_matrix/media/v3/download/$content_id",
          )->main::expect_http_404;
       })->SyTest::pass_on_done( "404 on getting quarantined remote media" )
       ->then( sub {
          $remote_user->http->do_request(
             method => "GET",
-            full_uri => "/_matrix/media/r0/thumbnail/$content_id",
+            full_uri => "/_matrix/media/v3/thumbnail/$content_id",
             params => {
                width  => 32,
                height => 32,

--- a/tests/52user-directory/01public.pl
+++ b/tests/52user-directory/01public.pl
@@ -27,7 +27,7 @@ test "User appears in user directory",
          repeat_until_true {
             do_request_json_for( $searching_user,
                method  => "POST",
-               uri     => "/r0/user_directory/search",
+               uri     => "/v3/user_directory/search",
                content => {
                   search_term => $displayname,
                }
@@ -498,7 +498,7 @@ sub matrix_get_user_dir_synced
       repeat_until_true {
          do_request_json_for( $searching_user,
             method  => "POST",
-            uri     => "/r0/user_directory/search",
+            uri     => "/v3/user_directory/search",
             content => {
                search_term => $random_id,
             }
@@ -514,7 +514,7 @@ sub matrix_get_user_dir_synced
    })->then( sub {
       do_request_json_for( $user,
          method  => "POST",
-         uri     => "/r0/user_directory/search",
+         uri     => "/v3/user_directory/search",
          content => {
             search_term => $search_term,
          }

--- a/tests/53groups/01create.pl
+++ b/tests/53groups/01create.pl
@@ -10,7 +10,7 @@ test "Create group",
 
       do_request_json_for( $user,
          method  => "POST",
-         uri     => "/r0/create_group",
+         uri     => "/v3/create_group",
          content => {
             localpart => $localpart,
             profile   => {
@@ -97,7 +97,7 @@ sub matrix_create_group
 
    do_request_json_for( $user,
       method  => "POST",
-      uri     => "/r0/create_group",
+      uri     => "/v3/create_group",
       content => {
          localpart => $localpart,
          profile   => { %opts },
@@ -124,7 +124,7 @@ sub matrix_add_group_rooms
 
    do_request_json_for( $user,
       method  => "PUT",
-      uri     => "/r0/groups/$group_id/admin/rooms/$room_id",
+      uri     => "/v3/groups/$group_id/admin/rooms/$room_id",
       content => {},
    );
 }
@@ -145,7 +145,7 @@ sub matrix_remove_group_rooms
 
    do_request_json_for( $user,
       method  => "DELETE",
-      uri     => "/r0/groups/$group_id/admin/rooms/$room_id",
+      uri     => "/v3/groups/$group_id/admin/rooms/$room_id",
    );
 }
 

--- a/tests/53groups/02read.pl
+++ b/tests/53groups/02read.pl
@@ -142,7 +142,7 @@ sub matrix_get_group_profile
 
    do_request_json_for( $user,
       method  => "GET",
-      uri     => "/r0/groups/$group_id/profile",
+      uri     => "/v3/groups/$group_id/profile",
    );
 }
 
@@ -152,7 +152,7 @@ sub matrix_get_group_users
 
    do_request_json_for( $user,
       method => "GET",
-      uri    => "/r0/groups/$group_id/users",
+      uri    => "/v3/groups/$group_id/users",
    );
 }
 
@@ -175,7 +175,7 @@ sub matrix_get_group_rooms
 
    do_request_json_for( $user,
       method => "GET",
-      uri    => "/r0/groups/$group_id/rooms",
+      uri    => "/v3/groups/$group_id/rooms",
    );
 }
 
@@ -195,6 +195,6 @@ sub matrix_get_group_summary
 
    do_request_json_for( $user,
       method => "GET",
-      uri    => "/r0/groups/$group_id/summary",
+      uri    => "/v3/groups/$group_id/summary",
    );
 }

--- a/tests/53groups/03local.pl
+++ b/tests/53groups/03local.pl
@@ -118,7 +118,7 @@ sub matrix_invite_group_user
 
    do_request_json_for( $inviter,
       method  => "PUT",
-      uri     => "/r0/groups/$group_id/admin/users/invite/$invitee_id",
+      uri     => "/v3/groups/$group_id/admin/users/invite/$invitee_id",
       content => {},
    );
 }
@@ -140,7 +140,7 @@ sub matrix_remove_group_user
 
    do_request_json_for( $inviter,
       method  => "PUT",
-      uri     => "/r0/groups/$group_id/admin/users/remove/$invitee_id",
+      uri     => "/v3/groups/$group_id/admin/users/remove/$invitee_id",
       content => {},
    );
 }
@@ -160,7 +160,7 @@ sub matrix_accept_group_invite
 
    do_request_json_for( $user,
       method  => "PUT",
-      uri     => "/r0/groups/$group_id/self/accept_invite",
+      uri     => "/v3/groups/$group_id/self/accept_invite",
       content => {},
    );
 }
@@ -180,7 +180,7 @@ sub matrix_join_group
 
    do_request_json_for( $user,
       method  => "PUT",
-      uri     => "/r0/groups/$group_id/self/join",
+      uri     => "/v3/groups/$group_id/self/join",
       content => {},
    );
 }
@@ -200,7 +200,7 @@ sub matrix_leave_group
 
    do_request_json_for( $user,
       method  => "PUT",
-      uri     => "/r0/groups/$group_id/self/leave",
+      uri     => "/v3/groups/$group_id/self/leave",
       content => {},
    );
 }
@@ -223,7 +223,7 @@ sub matrix_get_joined_groups
 
    do_request_json_for( $user,
       method => "GET",
-      uri    => "/r0/joined_groups",
+      uri    => "/v3/joined_groups",
    );
 }
 
@@ -253,6 +253,6 @@ sub matrix_get_invited_group_users
 
     do_request_json_for( $user,
         method => "GET",
-        uri    => "/r0/groups/$group_id/invited_users"
+        uri    => "/v3/groups/$group_id/invited_users"
     )
 }

--- a/tests/53groups/05categories.pl
+++ b/tests/53groups/05categories.pl
@@ -106,7 +106,7 @@ sub matrix_add_category_to_group
 
    do_request_json_for( $user,
       method  => "PUT",
-      uri     => "/r0/groups/$group_id/categories/$category_id",
+      uri     => "/v3/groups/$group_id/categories/$category_id",
       content => \%opts,
    );
 }
@@ -117,7 +117,7 @@ sub matrix_get_group_category
 
    do_request_json_for( $user,
       method  => "GET",
-      uri     => "/r0/groups/$group_id/categories/$category_id",
+      uri     => "/v3/groups/$group_id/categories/$category_id",
    );
 }
 
@@ -127,7 +127,7 @@ sub matrix_remove_category_from_group
 
    do_request_json_for( $user,
       method  => "DELETE",
-      uri     => "/r0/groups/$group_id/categories/$category_id",
+      uri     => "/v3/groups/$group_id/categories/$category_id",
    );
 }
 
@@ -137,6 +137,6 @@ sub matrix_get_group_categories
 
    do_request_json_for( $user,
       method  => "GET",
-      uri     => "/r0/groups/$group_id/categories/",
+      uri     => "/v3/groups/$group_id/categories/",
    );
 }

--- a/tests/53groups/05roles.pl
+++ b/tests/53groups/05roles.pl
@@ -106,7 +106,7 @@ sub matrix_add_role_to_group
 
    do_request_json_for( $user,
       method  => "PUT",
-      uri     => "/r0/groups/$group_id/roles/$role_id",
+      uri     => "/v3/groups/$group_id/roles/$role_id",
       content => \%opts,
    );
 }
@@ -117,7 +117,7 @@ sub matrix_get_group_role
 
    do_request_json_for( $user,
       method  => "GET",
-      uri     => "/r0/groups/$group_id/roles/$role_id",
+      uri     => "/v3/groups/$group_id/roles/$role_id",
    );
 }
 
@@ -127,7 +127,7 @@ sub matrix_remove_role_from_group
 
    do_request_json_for( $user,
       method  => "DELETE",
-      uri     => "/r0/groups/$group_id/roles/$role_id",
+      uri     => "/v3/groups/$group_id/roles/$role_id",
    );
 }
 
@@ -137,6 +137,6 @@ sub matrix_get_group_roles
 
    do_request_json_for( $user,
       method  => "GET",
-      uri     => "/r0/groups/$group_id/roles/",
+      uri     => "/v3/groups/$group_id/roles/",
    );
 }

--- a/tests/53groups/06summaries.pl
+++ b/tests/53groups/06summaries.pl
@@ -469,7 +469,7 @@ sub matrix_add_room_to_group_summary
 
    do_request_json_for( $user,
       method  => "PUT",
-      uri     => "/r0/groups/$group_id/summary/rooms/$room_id",
+      uri     => "/v3/groups/$group_id/summary/rooms/$room_id",
       content => \%opts,
    );
 }
@@ -480,7 +480,7 @@ sub matrix_add_room_to_group_summary_category
 
    do_request_json_for( $user,
       method  => "PUT",
-      uri     => "/r0/groups/$group_id/summary/categories/$category_id/rooms/$room_id",
+      uri     => "/v3/groups/$group_id/summary/categories/$category_id/rooms/$room_id",
       content => \%opts,
    );
 }
@@ -491,7 +491,7 @@ sub matrix_remove_room_from_group_summary_category
 
    do_request_json_for( $user,
       method  => "DELETE",
-      uri     => "/r0/groups/$group_id/summary/categories/$category_id/rooms/$room_id",
+      uri     => "/v3/groups/$group_id/summary/categories/$category_id/rooms/$room_id",
    );
 }
 
@@ -502,7 +502,7 @@ sub matrix_remove_room_from_group_summary
 
    do_request_json_for( $user,
       method  => "DELETE",
-      uri     => "/r0/groups/$group_id/summary/rooms/$room_id",
+      uri     => "/v3/groups/$group_id/summary/rooms/$room_id",
    );
 }
 
@@ -514,7 +514,7 @@ sub matrix_add_user_to_group_summary
 
    do_request_json_for( $user,
       method  => "PUT",
-      uri     => "/r0/groups/$group_id/summary/users/$user_id",
+      uri     => "/v3/groups/$group_id/summary/users/$user_id",
       content => \%opts,
    );
 }
@@ -525,7 +525,7 @@ sub matrix_add_user_to_group_summary_role
 
    do_request_json_for( $user,
       method  => "PUT",
-      uri     => "/r0/groups/$group_id/summary/roles/$role_id/users/$user_id",
+      uri     => "/v3/groups/$group_id/summary/roles/$role_id/users/$user_id",
       content => \%opts,
    );
 }
@@ -536,7 +536,7 @@ sub matrix_remove_user_from_group_summary_role
 
    do_request_json_for( $user,
       method  => "DELETE",
-      uri     => "/r0/groups/$group_id/summary/roles/$role_id/users/$user_id",
+      uri     => "/v3/groups/$group_id/summary/roles/$role_id/users/$user_id",
    );
 }
 
@@ -547,6 +547,6 @@ sub matrix_remove_user_from_group_summary
 
    do_request_json_for( $user,
       method  => "DELETE",
-      uri     => "/r0/groups/$group_id/summary/users/$user_id",
+      uri     => "/v3/groups/$group_id/summary/users/$user_id",
    );
 }

--- a/tests/53groups/11publicise.pl
+++ b/tests/53groups/11publicise.pl
@@ -79,7 +79,7 @@ sub matrix_update_group_publicity
 
    do_request_json_for( $user,
       method  => "PUT",
-      uri     => "/r0/groups/$group_id/self/update_publicity",
+      uri     => "/v3/groups/$group_id/self/update_publicity",
       content => {
          publicise => $publicise ? JSON::true : JSON::false,
       },
@@ -94,7 +94,7 @@ sub matrix_get_group_publicity
 
    do_request_json_for( $user,
       method => "GET",
-      uri    => "/r0/publicised_groups/$other_user_id",
+      uri    => "/v3/publicised_groups/$other_user_id",
    );
 }
 
@@ -104,7 +104,7 @@ sub matrix_bulk_get_group_publicity
 
    do_request_json_for( $user,
       method  => "POST",
-      uri     => "/r0/publicised_groups",
+      uri     => "/v3/publicised_groups",
       content => {
          user_ids => [ map { $_->user_id } @users ],
       }

--- a/tests/53groups/12joinable.pl
+++ b/tests/53groups/12joinable.pl
@@ -120,7 +120,7 @@ sub matrix_set_group_join_policy
 
    do_request_json_for( $user,
       method  => "PUT",
-      uri     => "/r0/groups/$group_id/settings/m.join_policy",
+      uri     => "/v3/groups/$group_id/settings/m.join_policy",
       content => {
          "m.join_policy" => {
              "type" => $join_policy,

--- a/tests/54identity.pl
+++ b/tests/54identity.pl
@@ -60,7 +60,7 @@ test "Can bind and unbind 3PID via homeserver",
 
          do_request_json_for( $user,
             method => "POST",
-            uri    => "/r0/account/3pid/delete",
+            uri    => "/v3/account/3pid/delete",
             content => {
                medium  => $medium,
                address => $address,
@@ -91,7 +91,7 @@ test "Can unbind 3PID via homeserver when bound out of band",
 
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/r0/account/3pid/delete",
+         uri    => "/v3/account/3pid/delete",
          content => {
             medium    => $medium,
             address   => $address,

--- a/tests/60app-services/01as-create.pl
+++ b/tests/60app-services/01as-create.pl
@@ -10,7 +10,7 @@ test "AS can create a user",
 
       do_request_json_for( $as_user,
          method => "POST",
-         uri    => "/r0/register",
+         uri    => "/v3/register",
 
          content => {
             username => "astest-01create-0-$TEST_RUN_ID",
@@ -35,7 +35,7 @@ test "AS can create a user with an underscore",
 
       do_request_json_for( $as_user,
          method => "POST",
-         uri    => "/r0/register",
+         uri    => "/v3/register",
 
          content => {
             username => "_astest-01create-0-$TEST_RUN_ID",
@@ -61,7 +61,7 @@ test "AS can create a user with inhibit_login",
 
       do_request_json_for( $as_user,
          method => "POST",
-         uri    => "/r0/register",
+         uri    => "/v3/register",
 
          content => {
             username => "astest-01create-1-$TEST_RUN_ID",
@@ -90,7 +90,7 @@ test "AS cannot create users outside its own namespace",
 
       do_request_json_for( $as_user,
          method => "POST",
-         uri    => "/r0/register",
+         uri    => "/v3/register",
 
          content => {
             username => "a-different-user",
@@ -121,7 +121,7 @@ test "AS can make room aliases",
 
       do_request_json_for( $as_user,
          method => "PUT",
-         uri    => "/r0/directory/room/$room_alias",
+         uri    => "/v3/directory/room/$room_alias",
 
          content => {
             room_id => $room_id,
@@ -131,7 +131,7 @@ test "AS can make room aliases",
 
          do_request_json_for( $as_user,
             method => "GET",
-            uri    => "/r0/directory/room/$room_alias",
+            uri    => "/v3/directory/room/$room_alias",
          )
       })->then( sub {
          my ( $body ) = @_;
@@ -158,7 +158,7 @@ test "Regular users cannot create room aliases within the AS namespace",
 
       do_request_json_for( $user,
          method => "PUT",
-         uri    => "/r0/directory/room/$room_alias",
+         uri    => "/v3/directory/room/$room_alias",
 
          content => {
             room_id => $room_id,
@@ -175,7 +175,7 @@ sub matrix_register_as_ghost
 
    do_request_json_for( $as_user,
       method => "POST",
-      uri    => "/r0/register",
+      uri    => "/v3/register",
 
       content => {
          username => $user_id,

--- a/tests/60app-services/02ghost.pl
+++ b/tests/60app-services/02ghost.pl
@@ -31,7 +31,7 @@ multi_test "AS-ghosted users can use rooms via AS",
 
          do_request_json_for( $as_user,
             method => "POST",
-            uri    => "/r0/rooms/$room_id/join",
+            uri    => "/v3/rooms/$room_id/join",
             params => {
                user_id => $ghost->user_id,
             },
@@ -58,7 +58,7 @@ multi_test "AS-ghosted users can use rooms via AS",
 
             do_request_json_for( $as_user,
                method => "POST",
-               uri    => "/r0/rooms/$room_id/send/m.room.message",
+               uri    => "/v3/rooms/$room_id/send/m.room.message",
                params => {
                   user_id => $ghost->user_id,
                },
@@ -166,7 +166,7 @@ test "Ghost user must register before joining room",
 
       do_request_json_for( $as_user,
          method => "POST",
-         uri    => "/r0/rooms/$room_id/join",
+         uri    => "/v3/rooms/$room_id/join",
          params => {
             user_id => "@".$unregistered_as_user_localpart.":".$hs_info->server_name,
          },
@@ -179,7 +179,7 @@ test "Ghost user must register before joining room",
 
       do_request_json_for( $as_user,
          method => "POST",
-         uri    => "/r0/register",
+         uri    => "/v3/register",
 
          content => {
             username => $unregistered_as_user_localpart,
@@ -204,7 +204,7 @@ test "AS can set avatar for ghosted users",
 
       $http->do_request_json(
          method => "GET",
-         uri    => "/r0/profile/$user_id/avatar_url",
+         uri    => "/v3/profile/$user_id/avatar_url",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -223,7 +223,7 @@ test "AS can set avatar for ghosted users",
       do_request_json_for(
          $as_user,
          method => "PUT",
-         uri    => "/r0/profile/$user_id/avatar_url",
+         uri    => "/v3/profile/$user_id/avatar_url",
          params => {
             user_id => $user_id,
          },
@@ -247,7 +247,7 @@ test "AS can set displayname for ghosted users",
 
       $http->do_request_json(
          method => "GET",
-         uri    => "/r0/profile/$user_id/displayname",
+         uri    => "/v3/profile/$user_id/displayname",
       )->then( sub {
          my ( $body ) = @_;
 
@@ -283,7 +283,7 @@ sub as_set_displayname_for_user {
    do_request_json_for(
       $as_user,
       method => "PUT",
-      uri    => "/r0/profile/$user_id/displayname",
+      uri    => "/v3/profile/$user_id/displayname",
       content => { displayname => $displayname },
       params => {
          user_id => $user_id,

--- a/tests/60app-services/03passive.pl
+++ b/tests/60app-services/03passive.pl
@@ -60,7 +60,7 @@ multi_test "Accesing an AS-hosted room alias asks the AS server",
 
             do_request_json_for( $as_user,
                method => "PUT",
-               uri    => "/r0/directory/room/$room_alias",
+               uri    => "/v3/directory/room/$room_alias",
 
                content => {
                   room_id => $room_id,
@@ -91,7 +91,7 @@ multi_test "Accesing an AS-hosted room alias asks the AS server",
 
          do_request_json_for( $local_user,
             method => "POST",
-            uri    => "/r0/join/$room_alias",
+            uri    => "/v3/join/$room_alias",
 
             content => {},
          )

--- a/tests/60app-services/04asuser.pl
+++ b/tests/60app-services/04asuser.pl
@@ -32,7 +32,7 @@ test "AS user (not ghost) can join room without registering, with user_id query 
       })->then( sub {
          do_request_json_for( $as_user,
             method => "POST",
-            uri    => "/r0/join/$room_id",
+            uri    => "/v3/join/$room_id",
 
             params => {
                user_id => $as_user->user_id,

--- a/tests/60app-services/06publicroomlist.pl
+++ b/tests/60app-services/06publicroomlist.pl
@@ -14,7 +14,7 @@ sub get_room_list_synced
    repeat_until_true {
       do_request_json_for( $user,
          method => "POST",
-         uri    => "/r0/publicRooms",
+         uri    => "/v3/publicRooms",
 
          content => $content,
       )->then( sub {
@@ -50,7 +50,7 @@ test "AS can publish rooms in their own list",
 
          do_request_json_for( $as_user,
             method => "PUT",
-            uri    => "/r0/directory/list/appservice/$network_id/$room_id",
+            uri    => "/v3/directory/list/appservice/$network_id/$room_id",
 
             content => {
                visibility => "public",
@@ -95,7 +95,7 @@ test "AS can publish rooms in their own list",
 
          do_request_json_for( $as_user,
             method => "DELETE",
-            uri    => "/r0/directory/list/appservice/$network_id/$room_id",
+            uri    => "/v3/directory/list/appservice/$network_id/$room_id",
          )
       })->then( sub {
          get_room_list_synced( $local_user,
@@ -137,7 +137,7 @@ test "AS and main public room lists are separate",
 
          do_request_json_for( $as_user,
             method => "PUT",
-            uri    => "/r0/directory/list/appservice/$network_id/$room_id",
+            uri    => "/v3/directory/list/appservice/$network_id/$room_id",
 
             content => {
                visibility => "public",
@@ -146,7 +146,7 @@ test "AS and main public room lists are separate",
       })->then( sub {
          do_request_json_for( $local_user,
             method => "PUT",
-            uri    => "/r0/directory/list/room/$room_id",
+            uri    => "/v3/directory/list/room/$room_id",
 
             content => {
                visibility => "public",
@@ -179,14 +179,14 @@ test "AS and main public room lists are separate",
 
          do_request_json_for( $local_user,
             method => "POST",
-            uri    => "/r0/publicRooms",
+            uri    => "/v3/publicRooms",
 
             content => { include_all_networks => "true", limit => 1000000 }
          )
       })->then( sub {
          do_request_json_for( $as_user,
             method => "DELETE",
-            uri    => "/r0/directory/list/appservice/$network_id/$room_id",
+            uri    => "/v3/directory/list/appservice/$network_id/$room_id",
          )
       })->then( sub {
          get_room_list_synced( $local_user,

--- a/tests/60app-services/07deactivate.pl
+++ b/tests/60app-services/07deactivate.pl
@@ -7,7 +7,7 @@ test "AS can deactivate a user",
       do_request_json_for(
          $as_user,
          method  => "POST",
-         uri     => "/r0/account/deactivate",
+         uri     => "/v3/account/deactivate",
          params  => { user_id => $ghost->user_id },
          content => {},
       );

--- a/tests/61push/01message-pushed.pl
+++ b/tests/61push/01message-pushed.pl
@@ -7,7 +7,7 @@ sub matrix_set_pusher {
    do_request_json_for(
       $user,
       method  => "POST",
-      uri     => "/r0/pushers/set",
+      uri     => "/v3/pushers/set",
       content => {
          profile_tag         => "tag",
          kind                => "http",
@@ -385,7 +385,7 @@ test "Rooms with canonical alias are correctly named in pushed",
 
          do_request_json_for( $bob,
             method => "PUT",
-            uri    => "/r0/directory/room/$room_alias",
+            uri    => "/v3/directory/room/$room_alias",
 
             content => { room_id => $room_id },
          )
@@ -424,7 +424,7 @@ test "Rooms with many users are correctly pushed",
       })->then( sub {
          do_request_json_for( $bob,
             method => "PUT",
-            uri    => "/r0/directory/room/$room_alias",
+            uri    => "/v3/directory/room/$room_alias",
 
             content => { room_id => $room_id },
          )
@@ -490,7 +490,7 @@ test "Don't get pushed for rooms you've muted",
       })->then( sub {
          do_request_json_for( $alice,
             method  => "PUT",
-            uri     => "/r0/pushrules/global/room/$room_id",
+            uri     => "/v3/pushrules/global/room/$room_id",
             content => { actions => [ "dont_notify" ] },
          )
       })->then( sub {

--- a/tests/61push/02add_rules.pl
+++ b/tests/61push/02add_rules.pl
@@ -34,13 +34,13 @@ sub check_add_push_rule
       # Trailing slash indicates retrieving ALL push rules for this scope/kind
       do_request_json_for( $user,
          method  => "GET",
-         uri     => "/r0/pushrules/$scope/$kind/",
+         uri     => "/v3/pushrules/$scope/$kind/",
       )->on_done( $check_rule_list );
    })->then( sub {
       # Trailing slash indicates retrieving ALL push rules for this scope
        do_request_json_for( $user,
          method  => "GET",
-         uri     => "/r0/pushrules/$scope/",
+         uri     => "/v3/pushrules/$scope/",
       )->on_done( sub {
          my ( $body ) = @_;
 
@@ -58,7 +58,7 @@ sub check_add_push_rule
       # Check that the rule is enabled.
       do_request_json_for( $user,
          method  => "GET",
-         uri     => "/r0/pushrules/$scope/$kind/$rule_id/enabled",
+         uri     => "/v3/pushrules/$scope/$kind/$rule_id/enabled",
       )->on_done( sub {
          my ( $body ) = @_;
 
@@ -68,7 +68,7 @@ sub check_add_push_rule
       # Check that the actions match.
       do_request_json_for( $user,
          method  => "GET",
-         uri     => "/r0/pushrules/$scope/$kind/$rule_id/actions",
+         uri     => "/v3/pushrules/$scope/$kind/$rule_id/actions",
       )->on_done( sub {
          my ( $body ) = @_;
 

--- a/tests/61push/05_set_actions.pl
+++ b/tests/61push/05_set_actions.pl
@@ -8,7 +8,7 @@ sub check_change_action {
       # Check that the actions match.
       do_request_json_for( $user,
          method  => "GET",
-         uri     => "/r0/pushrules/$scope/$kind/$rule_id/actions",
+         uri     => "/v3/pushrules/$scope/$kind/$rule_id/actions",
       )->on_done( sub {
          my ( $body ) = @_;
 

--- a/tests/61push/06_get_pusher.pl
+++ b/tests/61push/06_get_pusher.pl
@@ -17,7 +17,7 @@ test "Can fetch a user's pushers",
       # create a pusher
       do_request_json_for( $alice,
          method  => "POST",
-         uri     => "/r0/pushers/set",
+         uri     => "/v3/pushers/set",
          content => {
             profile_tag         => $profile_tag,
             kind                => "http",
@@ -35,7 +35,7 @@ test "Can fetch a user's pushers",
       )->then( sub {
          do_request_json_for( $alice,
             method  => "GET",
-            uri     => "/r0/pushers",
+            uri     => "/v3/pushers",
          );
       })->then( sub {
          my ( $body ) = @_;

--- a/tests/61push/07_set_enabled.pl
+++ b/tests/61push/07_set_enabled.pl
@@ -9,7 +9,7 @@ sub check_change_enabled
       # Check that the actions match.
       do_request_json_for( $user,
          method  => "GET",
-         uri     => "/r0/pushrules/$scope/$kind/$rule_id/enabled",
+         uri     => "/v3/pushrules/$scope/$kind/$rule_id/enabled",
       )->on_done( sub {
          my ( $body ) = @_;
 

--- a/tests/61push/08_rejected_pushers.pl
+++ b/tests/61push/08_rejected_pushers.pl
@@ -7,7 +7,7 @@ sub create_pusher
 
    do_request_json_for( $user,
       method  => "POST",
-      uri     => "/r0/pushers/set",
+      uri     => "/v3/pushers/set",
       content => {
          profile_tag         => "tag1",
          kind                => "http",
@@ -83,7 +83,7 @@ multi_test "Test that rejected pushers are removed.",
          retry_until_success {
             do_request_json_for( $alice,
                method  => "GET",
-               uri     => "/r0/pushers",
+               uri     => "/v3/pushers",
             )->then( sub {
                my ( $body ) = @_;
 
@@ -113,7 +113,7 @@ multi_test "Test that rejected pushers are removed.",
          retry_until_success {
             do_request_json_for( $alice,
                method  => "GET",
-               uri     => "/r0/pushers",
+               uri     => "/v3/pushers",
             )->then( sub {
                my ( $body ) = @_;
 

--- a/tests/61push/09_notifications_api.pl
+++ b/tests/61push/09_notifications_api.pl
@@ -47,7 +47,7 @@ test "Notifications can be viewed with GET /notifications",
             )->then(sub {
                do_request_json_for( $user1,
                   method  => "GET",
-                  uri     => "/unstable/notifications",
+                  uri     => "/v3/notifications",
                )->then( sub {
                   my ( $body ) = @_;
 
@@ -89,7 +89,7 @@ test "Notifications can be viewed with GET /notifications",
          retry_until_success {
             do_request_json_for( $user1,
                method  => "GET",
-               uri     => "/unstable/notifications",
+               uri     => "/v3/notifications",
             )->then( sub {
                my ( $body ) = @_;
 

--- a/tests/61push/80torture.pl
+++ b/tests/61push/80torture.pl
@@ -36,7 +36,7 @@ foreach my $test_put ( @$TO_CHECK_PUT ) {
 
          do_request_json_for( $user,
             method  => "PUT",
-            uri     => "/r0/pushrules$path",
+            uri     => "/v3/pushrules$path",
             content => $rule,
          )->main::expect_http_400;
       };
@@ -62,7 +62,7 @@ foreach my $test_get ( @$TO_CHECK_GET_400 ) {
 
          do_request_json_for( $user,
             method  => "GET",
-            uri     => "/r0/pushrules$path",
+            uri     => "/v3/pushrules$path",
          )->main::expect_http_400;
       };
 };
@@ -82,7 +82,7 @@ foreach my $test_get ( @$TO_CHECK_GET_404 ) {
 
          do_request_json_for( $user,
             method  => "GET",
-            uri     => "/r0/pushrules$path",
+            uri     => "/v3/pushrules$path",
          )->main::expect_http_404;
       };
 };

--- a/tests/80torture/03events.pl
+++ b/tests/80torture/03events.pl
@@ -8,7 +8,7 @@ test "GET /initialSync with non-numeric 'limit'",
 
       do_request_json_for( $user,
          method => "GET",
-         uri    => "/r0/initialSync",
+         uri    => "/v3/initialSync",
 
          params => { limit => "hello" },
       )->main::expect_http_4xx;
@@ -68,7 +68,7 @@ test "Event size limits",
       Future->needs_all(
          do_request_json_for( $user,
             method  => "POST",
-            uri     => "/r0/rooms/$room_id/send/m.room.message",
+            uri     => "/v3/rooms/$room_id/send/m.room.message",
             content => {
                msgtype => "m.text",
                body    => "A" x 70000,
@@ -77,7 +77,7 @@ test "Event size limits",
 
          do_request_json_for( $user,
             method  => "PUT",
-            uri     => "/r0/rooms/$room_id/state/oooooooh",
+            uri     => "/v3/rooms/$room_id/state/oooooooh",
             content => {
                key => "O" x 70000,
             }

--- a/tests/80torture/20json.pl
+++ b/tests/80torture/20json.pl
@@ -10,7 +10,7 @@ test "Invalid JSON integers",
       Future->needs_all(
          do_request_json_for( $user,
             method  => "POST",
-            uri     => "/r0/rooms/$room_id/send/sytest.dummy",
+            uri     => "/v3/rooms/$room_id/send/sytest.dummy",
             content => {
                msgtype => "sytest.dummy",
                body    => 9007199254740992,  # 2 ** 53
@@ -19,7 +19,7 @@ test "Invalid JSON integers",
 
          do_request_json_for( $user,
             method  => "POST",
-            uri     => "/r0/rooms/$room_id/send/sytest.dummy",
+            uri     => "/v3/rooms/$room_id/send/sytest.dummy",
             content => {
                msgtype => "sytest.dummy",
                body    => -9007199254740992,  # -2 ** 53
@@ -39,7 +39,7 @@ test "Invalid JSON floats",
 
       do_request_json_for( $user,
          method  => "POST",
-         uri     => "/r0/rooms/$room_id/send/sytest.dummy",
+         uri     => "/v3/rooms/$room_id/send/sytest.dummy",
          content => {
             msgtype => "sytest.dummy",
             body    => 1.1,
@@ -67,7 +67,7 @@ test "Invalid JSON special values",
          # Try some Perl magic values.
          do_request_json_for( $user,
             method  => "POST",
-            uri     => "/r0/rooms/$room_id/send/sytest.dummy",
+            uri     => "/v3/rooms/$room_id/send/sytest.dummy",
             content => {
                msgtype => "sytest.dummy",
                body    => "NaN" + 0,
@@ -76,7 +76,7 @@ test "Invalid JSON special values",
 
          do_request_json_for( $user,
             method  => "POST",
-            uri     => "/r0/rooms/$room_id/send/sytest.dummy",
+            uri     => "/v3/rooms/$room_id/send/sytest.dummy",
             content => {
                msgtype => "sytest.dummy",
                body    => "inf" + 0,
@@ -85,7 +85,7 @@ test "Invalid JSON special values",
 
          do_request_json_for( $user,
             method  => "POST",
-            uri     => "/r0/rooms/$room_id/send/sytest.dummy",
+            uri     => "/v3/rooms/$room_id/send/sytest.dummy",
             content => {
                msgtype => "sytest.dummy",
                body    => "-inf" + 0,
@@ -95,7 +95,7 @@ test "Invalid JSON special values",
          # Try some Python magic values.
          $user->http->do_request(
             method       => "POST",
-            uri          => "/r0/rooms/$room_id/send/sytest.dummy",
+            uri          => "/v3/rooms/$room_id/send/sytest.dummy",
             params       => {
                access_token => $user->access_token,
             },
@@ -105,7 +105,7 @@ test "Invalid JSON special values",
 
          $user->http->do_request(
             method       => "POST",
-            uri          => "/r0/rooms/$room_id/send/sytest.dummy",
+            uri          => "/v3/rooms/$room_id/send/sytest.dummy",
             params       => {
                access_token => $user->access_token,
             },
@@ -115,7 +115,7 @@ test "Invalid JSON special values",
 
          $user->http->do_request(
             method       => "POST",
-            uri          => "/r0/rooms/$room_id/send/sytest.dummy",
+            uri          => "/v3/rooms/$room_id/send/sytest.dummy",
             params       => {
                access_token => $user->access_token,
             },

--- a/tests/90jira/SYN-328.pl
+++ b/tests/90jira/SYN-328.pl
@@ -14,7 +14,7 @@ multi_test "Typing notifications don't leak",
 
          do_request_json_for( $creator,
             method => "PUT",
-            uri    => "/r0/rooms/$room_id/typing/:user_id",
+            uri    => "/v3/rooms/$room_id/typing/:user_id",
 
             content => { typing => JSON::true, timeout => 30000 * $TIMEOUT_FACTOR }, # msec
          );

--- a/tests/90jira/SYN-343.pl
+++ b/tests/90jira/SYN-343.pl
@@ -20,7 +20,7 @@ multi_test "Non-present room members cannot ban others",
 
          do_request_json_for( $testuser,
             method => "POST",
-            uri    => "/r0/rooms/$room_id/ban",
+            uri    => "/v3/rooms/$room_id/ban",
 
             content => { user_id => '@random_dude:test', reason => "testing" },
          )->main::expect_http_403

--- a/tests/90jira/SYN-390.pl
+++ b/tests/90jira/SYN-390.pl
@@ -6,20 +6,20 @@ multi_test "Getting push rules doesn't corrupt the cache SYN-390",
 
       do_request_json_for( $user,
          method  => "PUT",
-         uri     => "/r0/pushrules/global/sender/%40a_user%3Amatrix.org",
+         uri     => "/v3/pushrules/global/sender/%40a_user%3Amatrix.org",
          content => { "actions" => ["dont_notify"] }
       )->SyTest::pass_on_done("Set push rules for user" )
       ->then( sub {
 
          do_request_json_for( $user,
             method => "GET",
-            uri    => "/r0/pushrules/",
+            uri    => "/v3/pushrules/",
          )->SyTest::pass_on_done("Got push rules the first time" )
       })->then( sub {
 
          do_request_json_for( $user,
             method => "GET",
-            uri    => "/r0/pushrules/",
+            uri    => "/v3/pushrules/",
          )->SyTest::pass_on_done("Got push rules the second time" )
       })->then_done(1);
    }


### PR DESCRIPTION
This PR moves client API calls onto `/v3` endpoints instead of `/r0`, `/unstable` etc.