### PR TITLE
Simplify `06-device-lists.pl`

### DIFF
--- a/tests/10apidoc/09synced.pl
+++ b/tests/10apidoc/09synced.pl
@@ -135,6 +135,7 @@ falling back to doing a full sync if that doesn't exist either.
 
 The C<update_next_batch> parameter determines whether or not to update the
 $user->sync_next_batch with the next token from the sync response.
+Defaults to 0 if not specified.
 
 =cut
 
@@ -143,7 +144,7 @@ sub await_sync {
 
    my $check = delete $params{check} or die "Must supply a 'check' param";
    $params{timeout} = $params{timeout} // 1000;
-   $params{update_next_batch} = $params{update_next_batch} // 0;
+   $params{update_next_batch} //= 0;
 
    my $next_batch = delete $params{since} // $user->sync_next_batch;
    if ( $next_batch ) {
@@ -153,7 +154,6 @@ sub await_sync {
    repeat {
       matrix_sync( $user,
          %params,
-         update_next_batch => $params{update_next_batch},
          set_presence      => "offline",
       )->then( sub {
          my ( $body ) = @_;

--- a/tests/10apidoc/09synced.pl
+++ b/tests/10apidoc/09synced.pl
@@ -133,6 +133,9 @@ The C<since> parameter can be specified to give a particular starting stream
 token. If not specified then it will default to using $user->sync_next_batch,
 falling back to doing a full sync if that doesn't exist either.
 
+The C<update_next_batch> parameter determines whether or not to update the
+$user->sync_next_batch with the next token from the sync response.
+
 =cut
 
 sub await_sync {
@@ -140,6 +143,7 @@ sub await_sync {
 
    my $check = delete $params{check} or die "Must supply a 'check' param";
    $params{timeout} = $params{timeout} // 1000;
+   $params{update_next_batch} = $params{update_next_batch} // 0;
 
    my $next_batch = delete $params{since} // $user->sync_next_batch;
    if ( $next_batch ) {
@@ -149,7 +153,7 @@ sub await_sync {
    repeat {
       matrix_sync( $user,
          %params,
-         update_next_batch => 0,
+         update_next_batch => $params{update_next_batch},
          set_presence      => "offline",
       )->then( sub {
          my ( $body ) = @_;

--- a/tests/41end-to-end-keys/06-device-lists.pl
+++ b/tests/41end-to-end-keys/06-device-lists.pl
@@ -108,20 +108,7 @@ test "Local new device changes appear in v2 /sync",
       })->then( sub {
          matrix_login_again_with_user( $user2 )
       })->then( sub {
-         retry_until_success {
-            matrix_sync_again( $user1, timeout => 1000 )
-            ->then( sub {
-               my ( $body ) = @_;
-
-               log_if_fail "Body", $body;
-
-               Future->done(
-                  $body->{device_lists} &&
-                  $body->{device_lists}{changed} &&
-                  any { $_ eq $user2->user_id } @{ $body->{device_lists}{changed} }
-               );
-            });
-         };
+         sync_until_user_in_device_list( $user1, $user2 );
       });
    };
 

--- a/tests/41end-to-end-keys/06-device-lists.pl
+++ b/tests/41end-to-end-keys/06-device-lists.pl
@@ -43,7 +43,7 @@ sub sync_until_user_in_device_list_id
       return unless any { $_ eq $wait_for_id } @{ $body->{device_lists}{$device_list} };
 
       log_if_fail "$msg: found $wait_for_id in $device_list";
-      return 1;
+      return Future->done( $body );
    });
 }
 

--- a/tests/41end-to-end-keys/06-device-lists.pl
+++ b/tests/41end-to-end-keys/06-device-lists.pl
@@ -34,18 +34,21 @@ sub sync_until_user_in_device_list_id
 
    log_if_fail "$msg: waiting for $wait_for_id in $device_list";
 
-   return await_sync( $syncing_user, check => sub {
-      my ( $body ) = @_;
-      log_if_fail "$msg: body", $body;
+   return await_sync( $syncing_user, 
+      update_next_batch => 1,
+      check => sub {
+         my ( $body ) = @_;
+         log_if_fail "$msg: body", $body;
 
-      return unless
-         $body->{device_lists} &&
-         $body->{device_lists}{$device_list} &&
-         any { $_ eq $wait_for_id } @{ $body->{device_lists}{$device_list} };
+         return unless
+            $body->{device_lists} &&
+            $body->{device_lists}{$device_list} &&
+            any { $_ eq $wait_for_id } @{ $body->{device_lists}{$device_list} };
 
-      log_if_fail "$msg: found $wait_for_id in $device_list";
-      return $body;
-   })->then(sub {
+         log_if_fail "$msg: found $wait_for_id in $device_list";
+         return $body;
+      },
+   )->then(sub {
       my ( $result ) = @_;
       log_if_fail "returning", $result;
       return Future->done( $result );

--- a/tests/41end-to-end-keys/06-device-lists.pl
+++ b/tests/41end-to-end-keys/06-device-lists.pl
@@ -459,8 +459,8 @@ test "Local device key changes appear in /keys/changes",
       })->then( sub {
          matrix_sync( $user1 );
       })->then( sub {
-         my ( $sync_request ) = @_;
-         $from_token = $sync_request->{next_batch};
+         my ( $sync_result ) = @_;
+         $from_token = $sync_result->{next_batch};
 
          do_request_json_for( $user2,
             method  => "POST",
@@ -478,8 +478,8 @@ test "Local device key changes appear in /keys/changes",
       })->then( sub {
          matrix_sync_again( $user1 );
       })->then( sub {
-         my ( $sync_request ) = @_;
-         $to_token = $sync_request->{next_batch};
+         my ( $sync_result ) = @_;
+         $to_token = $sync_result->{next_batch};
 
          do_request_json_for( $user1,
             method => "GET",
@@ -517,15 +517,15 @@ test "New users appear in /keys/changes",
 
          matrix_sync( $user1 );
       })->then( sub {
-         my ( $sync_request ) = @_;
-         $from_token = $sync_request->{next_batch};
+         my ( $sync_result ) = @_;
+         $from_token = $sync_result->{next_batch};
 
          matrix_join_room_synced( $user2, $room_id );
       })->then( sub {
          matrix_sync_again( $user1 );
       })->then( sub {
-         my ( $sync_request ) = @_;
-         $to_token = $sync_request->{next_batch};
+         my ( $sync_result ) = @_;
+         $to_token = $sync_result->{next_batch};
 
          do_request_json_for( $user1,
             method => "GET",

--- a/tests/41end-to-end-keys/06-device-lists.pl
+++ b/tests/41end-to-end-keys/06-device-lists.pl
@@ -38,9 +38,10 @@ sub sync_until_user_in_device_list_id
        my ( $body ) = @_;
        log_if_fail "$msg: body", $body;
 
-      return unless $body->{device_lists};
-      return unless $body->{device_lists}{$device_list};
-      return unless any { $_ eq $wait_for_id } @{ $body->{device_lists}{$device_list} };
+      return Future->done(0) unless
+         $body->{device_lists} &&
+         $body->{device_lists}{$device_list} &&
+         any { $_ eq $wait_for_id } @{ $body->{device_lists}{$device_list} };
 
       log_if_fail "$msg: found $wait_for_id in $device_list";
       return Future->done( $body );

--- a/tests/41end-to-end-keys/06-device-lists.pl
+++ b/tests/41end-to-end-keys/06-device-lists.pl
@@ -39,8 +39,8 @@ sub sync_until_user_in_device_list_id
        log_if_fail "$msg: body", $body;
 
       return unless $body->{device_lists};
-      return unless $body->{device_lists}{changed};
-      return unless any { $_ eq $wait_for_id } @{ $body->{device_lists}{changed} };
+      return unless $body->{device_lists}{$device_list};
+      return unless any { $_ eq $wait_for_id } @{ $body->{device_lists}{$device_list} };
 
       log_if_fail "$msg: found $wait_for_id in $device_list";
       return 1;

--- a/tests/41end-to-end-keys/06-device-lists.pl
+++ b/tests/41end-to-end-keys/06-device-lists.pl
@@ -48,11 +48,7 @@ sub sync_until_user_in_device_list_id
          log_if_fail "$msg: found $wait_for_id in $device_list";
          return $body;
       },
-   )->then(sub {
-      my ( $result ) = @_;
-      log_if_fail "returning", $result;
-      return Future->done( $result );
-   })
+   )
 }
 
 


### PR DESCRIPTION
Four changes:

1. `sync_until_user_in_device_list_id` now uses `await_sync`
2. `Local new device changes appear in v2 /sync` now uses `sync_until_user_in_device_list`
3. Clear sync token handling, which makes it obvious that we want the `next_batch` from the `await_sync` future
4. Add `update_next_batch` to update the creator's `sync_next_batch` so repeated calls to `sync_until_user_in_device_list` all do the right thing