### PR TITLE
Prevent GHA workflow failing for Dendrite

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -122,6 +122,10 @@ jobs:
   dendrite:
     runs-on: ubuntu-latest
     name: "Dendrite: ${{ matrix.label }}"
+
+    # Sytests often fail against Dendrite, so don't fail the whole job.
+    continue-on-error: true
+  
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -120,12 +120,12 @@ jobs:
             /logs/**/*.log*
 
   dendrite:
+    # dendrite is currently flaky, so disable the tests for now
+    if: false
+  
     runs-on: ubuntu-latest
     name: "Dendrite: ${{ matrix.label }}"
 
-    # Sytests often fail against Dendrite, so don't fail the whole job.
-    continue-on-error: true
-  
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Sytest appears to fail against Dendrite, so let's disable it for now.