### PR TITLE
Check that events to be created have required fields

### DIFF
--- a/lib/SyTest/Federation/Room.pm
+++ b/lib/SyTest/Federation/Room.pm
@@ -229,6 +229,9 @@ sub create_event
    my $self = shift;
    my %fields = @_;
 
+   defined $fields{$_} or croak "Every event needs a '$_' field"
+      for qw( type content sender );
+
    my @auth_events = grep { defined } (
       $self->get_current_state_event( "m.room.create" ),
       $self->get_current_state_event( "m.room.join_rules" ),


### PR DESCRIPTION
`DataStore::create_event` will complain if these fields are missing. By adding
a extra check here, we'll get a more useful error which gives us a better clue
about where the problem is.