### PR TITLE
Wait for the message to come down /sync before hitting /context

### DIFF
--- a/tests/30rooms/50context.pl
+++ b/tests/30rooms/50context.pl
@@ -10,7 +10,10 @@ test "/context/ on joined room works",
          body => "hello, world",
       )->then( sub {
          my ( $event_id ) = @_;
-
+         await_sync_timeline_contains( $user, $room_id, check => sub {
+            my ( $event ) = @_;
+            return $event->{event_id} eq $event_id;
+         });
          do_request_json_for( $user,
             method  => "GET",
             uri     => "/v3/rooms/$room_id/context/${ \uri_escape( $event_id ) }",
@@ -34,7 +37,10 @@ test "/context/ on non world readable room does not work",
          body => "hello, world",
       )->then( sub {
          my ( $event_id ) = @_;
-
+         await_sync_timeline_contains( $user, $room_id, check => sub {
+            my ( $event ) = @_;
+            return $event->{event_id} eq $event_id;
+         });
          do_request_json_for( $other_user,
             method  => "GET",
             uri     => "/v3/rooms/$room_id/context/${ \uri_escape( $event_id ) }",
@@ -72,6 +78,11 @@ test "/context/ returns correct number of events",
          ( $event_after_id ) = @_;
 
          log_if_fail "After event", $event_after_id;
+
+         await_sync_timeline_contains( $user, $room_id, check => sub {
+            my ( $event ) = @_;
+            return $event->{event_id} eq $event_after_id;
+         });
 
          do_request_json_for( $user,
             method  => "GET",
@@ -117,6 +128,11 @@ test "/context/ with lazy_load_members filter works",
          );
       })->then( sub {
          my ( $event_id ) = @_;
+
+         await_sync_timeline_contains( $user, $room_id, check => sub {
+            my ( $event ) = @_;
+            return $event->{event_id} eq $event_id;
+         });
 
          do_request_json_for( $user,
             method  => "GET",


### PR DESCRIPTION
This waits for the send messages to come down `/sync`, before actually hitting `/context`. This should deflake Dendrite for this tests.