### PR TITLE
De-flake `Read markers appear in initial v2 /sync`

### DIFF
--- a/tests/31sync/14read-markers.pl
+++ b/tests/31sync/14read-markers.pl
@@ -47,11 +47,12 @@ test "Read markers appear in initial v2 /sync",
             return unless @{ $account_data } == 1;
             my $read_marker = $account_data->[0];
 
-            $read_marker->{type} eq "m.fully_read" or die "Unexpected event type";
+            $read_marker->{type} eq "m.fully_read"
+               or die "Unexpected event type";
             $read_marker->{content}{event_id} eq $event_id
                or die "Expected to see a marker for $event_id";
 
-            return Future->done(1);
+            Future->done(1);
          })
       })
    };

--- a/tests/31sync/14read-markers.pl
+++ b/tests/31sync/14read-markers.pl
@@ -35,26 +35,25 @@ test "Read markers appear in initial v2 /sync",
 
          matrix_advance_room_read_marker_synced( $user, $room_id, $event_id );
       })->then( sub {
-         matrix_sync( $user );
-      })->then( sub {
-         my ( $body ) = @_;
+         await_sync( $user, check => sub {
+            my ( $body ) = @_;
 
-         my $room = $body->{rooms}{join}{$room_id};
+            return unless $body->{rooms}{join}{$room_id};
+            my $room = $body->{rooms}{join}{$room_id};
 
-         my $account_data = $room->{account_data}{events};
+            return unless $room->{account_data}{events};
+            my $account_data = $room->{account_data}{events};
 
-         @{ $account_data } == 1 or die "Expected a m.fully_read event";
+            return unless @{ $account_data } == 1;
+            my $read_marker = $account_data->[0];
 
-         log_if_fail "Account data:", $account_data;
+            $read_marker->{type} eq "m.fully_read" or die "Unexpected event type";
+            $read_marker->{content}{event_id} eq $event_id
+               or die "Expected to see a marker for $event_id";
 
-         my $read_marker = $account_data->[0];
-
-         $read_marker->{type} eq "m.fully_read" or die "Unexpected event type";
-         $read_marker->{content}{event_id} eq $event_id
-            or die "Expected to see a marker for $event_id";
-
-         Future->done(1);
-      });
+            return Future->done(1);
+         })
+      })
    };
 
 


### PR DESCRIPTION
It was not `await_sync`ing.