### PR TITLE
Resolve room alias in `matrix_create_room`

### DIFF
--- a/tests/10apidoc/30room-create.pl
+++ b/tests/10apidoc/30room-create.pl
@@ -317,15 +317,12 @@ sub matrix_create_room
       my ( $body ) = @_;
       my $room_id = $body->{room_id};
 
-      do_request_json_for( $user,
-         method => "GET",
-         uri    => "/v3/rooms/$room_id/aliases",
-      )-> then( sub {
-         my ( $aliases_body ) = @_;
-         my $room_alias = first { index($_, $opts{room_alias_name}) >= 0 } @{$aliases_body->{aliases}};
-
+      if (defined $opts{room_alias_name}) {
+         my $room_alias = sprintf( '#%s:%s', $opts{room_alias_name}, $user->server_name );
          Future->done($body->{room_id}, $room_alias);
-      })
+      } else {
+         Future->done($body->{room_id}, undef);
+      }
    });
 }
 

--- a/tests/10apidoc/30room-create.pl
+++ b/tests/10apidoc/30room-create.pl
@@ -315,22 +315,17 @@ sub matrix_create_room
       content => \%opts,
    )->then( sub {
       my ( $body ) = @_;
+      my $room_id = $body->{room_id};
 
-      if (defined $body->{room_alias}) {
-         Future->done( $body->{room_id}, $body->{room_alias});
-      } else {
-         my $room_id = $body->{room_id};
+      do_request_json_for( $user,
+         method => "GET",
+         uri    => "/v3/rooms/$room_id/aliases",
+      )-> then( sub {
+         my ( $aliases_body ) = @_;
+         my $room_alias = first { index($_, $opts{room_alias_name}) >= 0 } @{$aliases_body->{aliases}};
 
-         do_request_json_for( $user,
-            method => "GET",
-            uri    => "/v3/rooms/$room_id/aliases",
-         )-> then( sub {
-            my ( $aliases_body ) = @_;
-            my $room_alias = first { index($_, $opts{room_alias_name}) >= 0 } @{$aliases_body->{aliases}};
-
-            Future->done($body->{room_id}, $room_alias);
-         })
-      }
+         Future->done($body->{room_id}, $room_alias);
+      })
    });
 }
 

--- a/tests/10apidoc/30room-create.pl
+++ b/tests/10apidoc/30room-create.pl
@@ -317,12 +317,11 @@ sub matrix_create_room
       my ( $body ) = @_;
       my $room_id = $body->{room_id};
 
-      if (defined $opts{room_alias_name}) {
-         my $room_alias = sprintf( '#%s:%s', $opts{room_alias_name}, $user->server_name );
-         Future->done($body->{room_id}, $room_alias);
-      } else {
-         Future->done($body->{room_id}, undef);
+      my $room_alias;
+      if( defined $opts{room_alias_name} ) {
+         $room_alias = sprintf( '#%s:%s', $opts{room_alias_name}, $user->server_name );
       }
+      Future->done( $room_id, $room_alias );
    });
 }
 

--- a/tests/10apidoc/30room-create.pl
+++ b/tests/10apidoc/30room-create.pl
@@ -291,7 +291,7 @@ The resultant future completes with two values: the room_id from the
 /createRoom response; and the room_alias. room_alias will be loaded from 
 /createRoom (if it exists, which is non-standard and its use is deprecated) or
 it will find the alias by loading room's aliases, in case that it's missing
-from /crateRoom.
+from /createRoom.
 
 =cut
 

--- a/tests/10apidoc/30room-create.pl
+++ b/tests/10apidoc/30room-create.pl
@@ -1,5 +1,4 @@
 use JSON qw( decode_json );
-use List::Util qw( first );
 
 my $user_fixture = local_user_fixture();
 
@@ -288,10 +287,9 @@ The following options have defaults:
 commandline.
 
 The resultant future completes with two values: the room_id from the
-/createRoom response; and the room_alias. room_alias will be loaded from 
-/createRoom (if it exists, which is non-standard and its use is deprecated) or
-it will find the alias by loading room's aliases, in case that it's missing
-from /createRoom.
+/createRoom response; and the room_alias. If room_alias_name is present
+in %opts, an alias will be built with the given alias and user's server name.
+Othwerwise, it will return undef.
 
 =cut
 


### PR DESCRIPTION
The spec does not require `/createRoom` request to return room aliases
(https://spec.matrix.org/v1.2/client-server-api/#post_matrixclientv3createroom),
but `matrix_create_room` tries to read it from the response. This field
is deprecated and does not appear on the spec.

~~For those implementations which are not returning the alias, we will
issue a new request to load room's aliases in order to make this
function compatible.~~

We calculate what the alias should be, and return that instead.

Fixes: #1071 
Closes: https://github.com/matrix-org/sytest/pull/1112

Signed-off-by: Guillem Nieto <gnieto.talo@gmail.com>