### PR TITLE
Update config in accordance with Synapse #12091

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -230,6 +230,7 @@ sub start
         },
 
         enable_registration => "true",
+        enable_registration_without_verification => "true",
         databases => \%db_configs,
         macaroon_secret_key => $macaroon_secret_key,
         registration_shared_secret => $registration_shared_secret,


### PR DESCRIPTION
Synapse PR matrix-org/synapse#12091, when merged, will cause Synapse to refuse to start if registration is enabled without any verification, unless the new config flag `enable_registration_without_verification` is set. This PR adds that flag to sytest's configuration so the homeserver will still start for testing. 