### PR TITLE
Retry `/whois` to allow for propagation/persistence delay

### DIFF
--- a/tests/48admin.pl
+++ b/tests/48admin.pl
@@ -40,30 +40,34 @@ test "/whois",
       # tightly control the actions taken by that user.
       # Conceivably this API may change based on the number of API calls the
       # user made, for instance.
+
       matrix_register_user( $http, "admin" )
       ->then( sub {
          ( $user ) = @_;
 
-         do_request_json_for( $user,
-            method => "GET",
-            uri    => "/v3/admin/whois/".$user->user_id,
-         )
-      })->then( sub {
-         my ( $body ) = @_;
+         retry_until_success {
+            sleep 1;
+            do_request_json_for( $user,
+               method => "GET",
+               uri    => "/v3/admin/whois/".$user->user_id,
+            )->then( sub {
+               my ( $body ) = @_;
 
-         assert_json_keys( $body, qw( devices user_id ) );
-         assert_eq( $body->{user_id}, $user->user_id, "user_id" );
-         assert_json_object( $body->{devices} );
+               assert_json_keys( $body, qw( devices user_id ) );
+               assert_eq( $body->{user_id}, $user->user_id, "user_id" );
+               assert_json_object( $body->{devices} );
 
-         foreach my $value ( values %{ $body->{devices} } ) {
-            assert_json_keys( $value, "sessions" );
-            assert_json_list( $value->{sessions} );
-            assert_json_keys( $value->{sessions}[0], "connections" );
-            assert_json_list( $value->{sessions}[0]{connections} );
-            assert_json_keys( $value->{sessions}[0]{connections}[0], qw( ip last_seen user_agent ) );
+               foreach my $value ( values %{ $body->{devices} } ) {
+                  assert_json_keys( $value, "sessions" );
+                  assert_json_list( $value->{sessions} );
+                  assert_json_keys( $value->{sessions}[0], "connections" );
+                  assert_json_list( $value->{sessions}[0]{connections} );
+                  assert_json_keys( $value->{sessions}[0]{connections}[0], qw( ip last_seen user_agent ) );
+               }
+
+               Future->done( 1 );
+            });
          }
-
-         Future->done( 1 );
       });
    };
 


### PR DESCRIPTION
Might solve #1180?

Motivated by https://github.com/matrix-org/synapse/pull/12251, which moves the client IP persistence to a different worker than the one that handles `/whois`, so there is a propagation delay (when it's on the same worker, the information is enriched with unpersisted IPs).