### PR TITLE
Respect poetry lockfile in Synapse container, if present

### DIFF
--- a/docker/synapse.Dockerfile
+++ b/docker/synapse.Dockerfile
@@ -20,4 +20,8 @@ RUN /venv/bin/pip install -q --no-cache-dir lxml psycopg2 coverage codecov
 # and test
 RUN /venv/bin/pip uninstall -q --no-cache-dir -y matrix-synapse
 
+# Pre-install test dependencies installed by `scripts/synapse_sytest.sh`.
+RUN /venv/bin/pip install -q --no-cache-dir \
+        lxml psycopg2 coverage codecov tap.py coverage_enable_subprocess
+
 ENTRYPOINT [ "/bin/bash", "/bootstrap.sh", "synapse" ]

--- a/docker/synapse.Dockerfile
+++ b/docker/synapse.Dockerfile
@@ -9,6 +9,20 @@ RUN apt-get -qq update && apt-get -qq install -y \
 
 RUN ${PYTHON_VERSION} -m pip install -q --no-cache-dir poetry==1.1.12
 
+# As part of the Docker build, we attempt to pre-install Synapse's dependencies
+# in the hope that it speeds up the real install of Synapse. To make this work,
+# we have to reuse the same virtual env both times. There are three ways to do
+# this with poetry:
+#  1. Ensure that the Synapse source directory lives in the same path both
+#     times. Poetry creates and reuses a virtual env based off the package name
+#     ("matrix-synapse") and directory path.
+#  2. Configure `virtualenvs.in-project` to `true`. This makes poetry create or
+#     use a virtual env at `./.venv` in the source directory.
+#  3. Run poetry with a virtual env already active. Poetry will use the active
+#     virtual env, if there is one.
+# We use the second option and make `.venv` a symlink.
+RUN poetry config virtualenvs.in-project true
+
 # /src is where we expect Synapse to be
 RUN mkdir /src
 
@@ -17,6 +31,25 @@ RUN mkdir /src
 # These version numbers are arbitrary and were the latest at the time.
 RUN ${PYTHON_VERSION} -m pip download --dest /pypi-offline-cache \
         poetry-core==1.0.8 setuptools==60.10.0 wheel==0.37.1
+
+# TODO: Once poetry lands in the develop branch of Synapse, uncomment these
+#       lines and delete the pip version of the virtual env preparation.
+# Create the virtual env upfront so we don't need to keep reinstalling
+# dependencies.
+# RUN wget -q https://github.com/matrix-org/synapse/archive/develop.tar.gz \
+#         -O /synapse.tar.gz && \
+#     mkdir /synapse && \
+#     tar -C /synapse --strip-components=1 -xf synapse.tar.gz && \
+#     ln -s -T /venv /synapse/.venv && \
+#     cd /synapse && \
+#     poetry install -q --no-root --extras all && \
+#     # Finally clean up the poetry cache and the copy of Synapse.
+#     # This must be done in the same RUN command, otherwise intermediate layers
+#     # of the Docker image will contain all the unwanted files we think we've
+#     # deleted.
+#     rm -rf `poetry config cache-dir` && \
+#     rm -rf /synapse && \
+#     rm /synapse.tar.gz
 
 # Create the virutal env upfront so we don't need to keep reinstall dependencies
 # Manually upgrade pip to ensure it can locate Cryptography's binary wheels

--- a/docker/synapse.Dockerfile
+++ b/docker/synapse.Dockerfile
@@ -10,6 +10,11 @@ RUN apt-get -qq update && apt-get -qq install -y \
 # /src is where we expect Synapse to be
 RUN mkdir /src
 
+# Download a cache of build dependencies to support offline mode.
+# These version numbers are arbitrary and were the latest at the time.
+RUN ${PYTHON_VERSION} -m pip download --dest /pypi-offline-cache \
+        setuptools==60.10.0 wheel==0.37.1
+
 # Create the virutal env upfront so we don't need to keep reinstall dependencies
 # Manually upgrade pip to ensure it can locate Cryptography's binary wheels
 RUN ${PYTHON_VERSION} -m venv /venv && /venv/bin/pip install -U pip

--- a/docker/synapse.Dockerfile
+++ b/docker/synapse.Dockerfile
@@ -4,16 +4,19 @@ FROM matrixdotorg/sytest:${SYTEST_IMAGE_TAG}
 
 ARG PYTHON_VERSION=python3
 RUN apt-get -qq update && apt-get -qq install -y \
-    ${PYTHON_VERSION} ${PYTHON_VERSION}-dev ${PYTHON_VERSION}-venv eatmydata \
-    redis-server
+    ${PYTHON_VERSION} ${PYTHON_VERSION}-dev ${PYTHON_VERSION}-venv \
+    ${PYTHON_VERSION}-pip eatmydata redis-server
+
+RUN ${PYTHON_VERSION} -m pip install -q --no-cache-dir poetry==1.1.12
 
 # /src is where we expect Synapse to be
 RUN mkdir /src
 
 # Download a cache of build dependencies to support offline mode.
+# `setuptools` and `wheel` are only required for pre-poetry Synapse versions.
 # These version numbers are arbitrary and were the latest at the time.
 RUN ${PYTHON_VERSION} -m pip download --dest /pypi-offline-cache \
-        setuptools==60.10.0 wheel==0.37.1
+        poetry-core==1.0.8 setuptools==60.10.0 wheel==0.37.1
 
 # Create the virutal env upfront so we don't need to keep reinstall dependencies
 # Manually upgrade pip to ensure it can locate Cryptography's binary wheels

--- a/docker/synapse.Dockerfile
+++ b/docker/synapse.Dockerfile
@@ -23,7 +23,7 @@ RUN ${PYTHON_VERSION} -m pip install -q --no-cache-dir poetry==1.1.12
 # We use the second option and make `.venv` a symlink.
 RUN poetry config virtualenvs.in-project true
 
-# /src is where we expect Synapse to be
+# /src is where we expect the Synapse source directory to be mounted
 RUN mkdir /src
 
 # Download a cache of build dependencies to support offline mode.

--- a/scripts/synapse_sytest.sh
+++ b/scripts/synapse_sytest.sh
@@ -133,11 +133,11 @@ if [ -n "$OFFLINE" ]; then
     # if we're in offline mode, just put synapse into the virtualenv, and
     # hope that the deps are up-to-date.
     #
-    # --no-use-pep517 works around what appears to be a pip issue
-    # (https://github.com/pypa/pip/issues/5402 possibly) where pip wants
-    # to reinstall any requirements for the build system, even if they are
-    # already installed.
-    /venv/bin/pip install --no-index --no-use-pep517 "$SYNAPSE_SOURCE"
+    # pip will want to install any requirements for the build system
+    # (https://github.com/pypa/pip/issues/5402), so we have to provide a
+    # directory of pre-downloaded build requirements.
+    /venv/bin/pip install --no-index --find-links /pypi-offline-cache \
+        "$SYNAPSE_SOURCE"
 else
     # We've already created the virtualenv, but lets double check we have all
     # deps.


### PR DESCRIPTION
Install pinned dependencies using poetry if a `poetry.lock` file is
present in the Synapse source directory, otherwise fall back to pip.

The Synapse container installs Synapse dependencies twice, once at
Docker build time and once at test time. The former installation is
intended to speed up the latter. To make this poetry-compatible, we
have to convince poetry to use the same virtual env both times. By
using the `virtualenvs.in-project` config option, we can get poetry to
use a virtual env at `./.venv`. The source directory is going to be a
mounted volume and writing into it is impolite, so we have to make a
copy of it. For simplicity, we ditch the tarball for non-poetry
installs and always make a copy.

To make offline mode work, we have to make a cached copy of a
`poetry-core` wheel available to pip. For simplicity, we do the same
thing for `setuptools` and `wheel` for pre-poetry Synapses.

Once Synapse develop has been converted to poetry, the TODO in
`docker/synapse.Dockerfile` can be resolved.

------------------------------------------------------------

NB: This blocks progress on poetry-izing Synapse, since some of the CI
steps can't be updated until the Synapse container includes poetry.

Can be reviewed commit by commit. The first commit is from #1219.

To test the container changes locally:
```sh
sudo docker build -f docker/synapse.Dockerfile docker
sudo docker run -it --env SYTEST_BRANCH=squah/pyproject-poetry-contribs --volume /home/squah/repos/synapse:/src ${hex-string-from-docker-build}
sudo docker run -it --env SYTEST_BRANCH=squah/pyproject-poetry-contribs --env OFFLINE=1 --volume /home/squah/repos/synapse:/src ${hex-string-from-docker-build}
sudo docker run -it --env SYTEST_BRANCH=squah/pyproject-poetry-contribs --volume /home/squah/repos/synapse-poetry:/src ${hex-string-from-docker-build}
sudo docker run -it --env SYTEST_BRANCH=squah/pyproject-poetry-contribs --env OFFLINE=1 --volume /home/squah/repos/synapse-poetry:/src ${hex-string-from-docker-build}
```