### PR TITLE
Wait for the room creation to come down /sync

### DIFF
--- a/tests/50federation/11query-directory.pl
+++ b/tests/50federation/11query-directory.pl
@@ -54,7 +54,7 @@ test "Inbound federation can query room alias directory",
 
       my $room_id;
 
-      matrix_create_room( $user )
+      matrix_create_room_synced( $user )
       ->then( sub {
          ( $room_id ) = @_;
 


### PR DESCRIPTION
Should fix the flakey test `Inbound federation can query room alias directory` on Dendrite.