### PR TITLE
Handle servers which send `/state` requests

### DIFF
--- a/lib/SyTest/Federation/Server.pm
+++ b/lib/SyTest/Federation/Server.pm
@@ -504,7 +504,7 @@ __PACKAGE__->mk_await_request_pair(
 );
 
 __PACKAGE__->mk_await_request_pair(
-   "v1", "state", [qw( :room_id )],
+   "v1", "state", [qw( :room_id ?event_id )],
 );
 
 __PACKAGE__->mk_await_request_pair(

--- a/tests/50federation/33room-get-missing-events.pl
+++ b/tests/50federation/33room-get-missing-events.pl
@@ -386,7 +386,7 @@ test "outliers whose auth_events are in a different room are correctly rejected"
             log_if_fail "/state request", \@params;
 
             my $resp = {
-               state => [ values( %initial_room2_state ) ],
+               pdus => [ values( %initial_room2_state ) ],
                auth_chain => [
                   map { $inbound_server->datastore->get_event( $_ ) } @{ $room2->event_ids_from_refs( $event_Q->{auth_events} ) },
                ],

--- a/tests/50federation/33room-get-missing-events.pl
+++ b/tests/50federation/33room-get-missing-events.pl
@@ -377,21 +377,49 @@ test "outliers whose auth_events are in a different room are correctly rejected"
             Future->done(1);
          }),
       )->then( sub {
-         # wait for S to turn up
-         await_sync_timeline_contains(
-            $creator_user, $room2->room_id, check => sub {
-               my ( $event ) = @_;
-               log_if_fail "Got event in room2", $event;
+         # the server may send a /state request; be prepared to answer that.
+         # (it may, alternatively, send individual /event requests)
+         my $state_req_fut = $inbound_server->await_request_v1_state(
+            $room2->{room_id}, $event_id_Q,
+         )->then( sub {
+            my ( $req, @params ) = @_;
+            log_if_fail "/state request", \@params;
 
-               my $event_id = $event->{event_id};
+            my $resp = {
+               state => [ values( %initial_room2_state ) ],
+               auth_chain => [
+                  map { $inbound_server->datastore->get_event( $_ ) } @{ $room2->event_ids_from_refs( $event_Q->{auth_events} ) },
+               ],
+            };
 
-               # if either Q or R show up, that's a problem
-               if( $event->{sender} eq $sytest_user_1 ) {
-                  die "Got an event $event_id from a user who shouldn't be a member";
-               }
+            log_if_fail "/state response", $resp;
+            $req->respond_json( $resp );
 
-               return $event_id eq $event_id_S;
-            },
+            # return a future which never completes, so that wait_any is not
+            # satisfied.
+            return Future->new();
+         });
+
+
+         # wait for either S to turn up in /sync, or $state_req_fut to fail.
+         Future->wait_any(
+            $state_req_fut,
+
+            await_sync_timeline_contains(
+               $creator_user, $room2->room_id, check => sub {
+                  my ( $event ) = @_;
+                  log_if_fail "Got event in room2", $event;
+
+                  my $event_id = $event->{event_id};
+
+                  # if either Q or R show up, that's a problem
+                  if( $event->{sender} eq $sytest_user_1 ) {
+                     die "Got an event $event_id from a user who shouldn't be a member";
+                  }
+
+                  return $event_id eq $event_id_S;
+               },
+            ),
          );
       })->then( sub {
          # finally, check that the state in room 2 looks correct.

--- a/tests/50federation/34room-backfill.pl
+++ b/tests/50federation/34room-backfill.pl
@@ -314,7 +314,7 @@ test "Backfilled events whose prev_events are in a different room do not allow c
 
          my %state  = %{ $room2->{current_state} };
          my $resp = {
-            state => [ values( %state ) ],
+            pdus => [ values( %state ) ],
 
             # XXX we're supposed to return the whole auth chain here,
             # not just Q's auth_events. It doesn't matter too much

--- a/tests/50federation/34room-backfill.pl
+++ b/tests/50federation/34room-backfill.pl
@@ -304,6 +304,34 @@ test "Backfilled events whose prev_events are in a different room do not allow c
 
       log_if_fail "events P, Q, R, S", [ $event_id_P, $event_id_Q, $event_id_R, $event_id_S ];
 
+      # the server may send a /state request; be prepared to answer that.
+      # (it may, alternatively, send individual /event requests)
+      my $state_req_fut = $inbound_server->await_request_v1_state(
+         $room2->{room_id}, $event_id_Q,
+      )->then( sub {
+         my ( $req, @params ) = @_;
+         log_if_fail "/state request (1)", \@params;
+
+         my %state  = %{ $room2->{current_state} };
+         my $resp = {
+            state => [ values( %state ) ],
+
+            # XXX we're supposed to return the whole auth chain here,
+            # not just Q's auth_events. It doesn't matter too much
+            # here though.
+            auth_chain => [
+               map { $inbound_server->datastore->get_event( $_ ) } @{ $room2->event_ids_from_refs( $event_Q->{auth_events} ) },
+            ],
+         };
+
+         log_if_fail "/state response (1)", $resp;
+         $req->respond_json( $resp );
+
+         # return a future which never completes, so that wait_any is not
+         # satisfied.
+         return Future->new();
+      });
+
       Future->needs_all(
          # kick things off by sending S over federation
          $outbound_client->send_event(
@@ -338,7 +366,7 @@ test "Backfilled events whose prev_events are in a different room do not allow c
             $room2_id, $event_id_Q,
          )->then( sub {
             my ( $req, @params ) = @_;
-            log_if_fail "/state_ids request", \@params;
+            log_if_fail "/state_ids request (1)", \@params;
 
             my %state  = %{ $room2->{current_state} };
             my $resp = {
@@ -352,7 +380,7 @@ test "Backfilled events whose prev_events are in a different room do not allow c
                auth_chain_ids => $room2->event_ids_from_refs( $event_Q->{auth_events} ),
             };
 
-            log_if_fail "/state_ids response", $resp;
+            log_if_fail "/state_ids response (1)", $resp;
             $req->respond_json( $resp );
             Future->done(1);
          }),
@@ -363,14 +391,18 @@ test "Backfilled events whose prev_events are in a different room do not allow c
             destination => $synapse_server_name,
          );
       })->then( sub {
-         # wait for S to arrive
          log_if_fail "Awating arrival of event S $event_id_S in room $room2_id";
 
-         await_sync_timeline_contains(
-            $creator_user, $room2_id,
-            check => sub {
-               $_[0]->{event_id} eq $event_id_S
-            },
+         # wait for either S to turn up in /sync, or $state_req_fut to fail.
+         Future->wait_any(
+            $state_req_fut,
+
+            await_sync_timeline_contains(
+               $creator_user, $room2_id,
+               check => sub {
+                  $_[0]->{event_id} eq $event_id_S
+               },
+              ),
          );
       })->then( sub {
          my $filter = $json->encode( { room => { timeline => { limit => 2 }}} );
@@ -392,7 +424,7 @@ test "Backfilled events whose prev_events are in a different room do not allow c
             $room2_id, $event_id_Q,
          )->then( sub {
             my ( $req, @params ) = @_;
-            log_if_fail "/state_ids request", \@params;
+            log_if_fail "/state_ids request (2)", \@params;
 
             my %state  = %{ $room2->{current_state} };
             my $resp = {
@@ -402,47 +434,51 @@ test "Backfilled events whose prev_events are in a different room do not allow c
                auth_chain_ids => $room2->event_ids_from_refs( $event_Q->{auth_events} ),
             };
 
-            log_if_fail "/state_ids response", $resp;
+            log_if_fail "/state_ids response (2)", $resp;
             $req->respond_json( $resp );
-            Future->done(1);
+
+            # return a future which never completes, so that wait_any is not
+            # satisfied.
+            return Future->new();
          });
 
          # now back-paginate, and provide event Q when the
          # server backfills.
-         Future->needs_all(
-            do_request_json_for(
-               $creator_user,
-               method => "GET",
-               uri    => "/v3/rooms/$room2_id/messages",
-               params => {
-                  dir  => "b",
-                  from => $prev_batch,
-               },
-            )->on_done(sub {
-               my ( $resp ) = @_;
-               log_if_fail "Pagination request completed", $resp;
-            }),
+         Future->wait_any(
+            $state_ids_fut,
 
-            $inbound_server->await_request_backfill( $room2_id )->then( sub {
-               my ( $req, @params ) = @_;
+            Future->needs_all(
+               do_request_json_for(
+                  $creator_user,
+                  method => "GET",
+                  uri    => "/v3/rooms/$room2_id/messages",
+                  params => {
+                     dir  => "b",
+                     from => $prev_batch,
+                  },
+               )->on_done(sub {
+                  my ( $resp ) = @_;
+                  log_if_fail "Pagination request completed", $resp;
+               }),
 
-               log_if_fail "Incoming /backfill request", \@params;
+               $inbound_server->await_request_backfill( $room2_id )->then( sub {
+                  my ( $req, @params ) = @_;
 
-               $req->respond_json( {
-                  origin           => $inbound_server->server_name,
-                  origin_server_ts => $inbound_server->time_ms,
-                  pdus             => [
-                     $event_Q,
-                  ],
-               });
-               Future->done;
-            }),
+                  log_if_fail "Incoming /backfill request", \@params;
+
+                  $req->respond_json( {
+                     origin           => $inbound_server->server_name,
+                     origin_server_ts => $inbound_server->time_ms,
+                     pdus             => [
+                        $event_Q,
+                     ],
+                  });
+                  Future->done;
+               }),
+            ),
          )->then( sub {
              my ( $messages ) = @_;
              log_if_fail "/messages result", $messages;
-
-             # cancel the state_ids responder, if it didn't get used.
-             $state_ids_fut->cancel();
 
              # ensure that P does not feature in the list.
              die 'too few events' if @{$messages->{chunk}} < 2;

--- a/tests/50federation/36state.pl
+++ b/tests/50federation/36state.pl
@@ -541,7 +541,7 @@ test "Outbound federation requests missing prev_events and then asks for /state_
                log_if_fail "/state request", \@params;
 
                my $resp = {
-                  state => [ values( %room_state_at_y ) ],
+                  pdus => [ values( %room_state_at_y ) ],
                   auth_chain => [
                      map { $inbound_server->datastore->get_auth_chain_events( $room->id_for_event( $_ )) }
                         values( %room_state_at_y )
@@ -782,7 +782,7 @@ test "Federation handles empty auth_events in state_ids sanely",
                log_if_fail "/state request", \@params;
 
                my $resp = {
-                  state => [ values( %{ $room->{current_state} } ) ],
+                  pdus => [ values( %{ $room->{current_state} } ) ],
                   auth_chain => [],
                };
 


### PR DESCRIPTION
Some server implementations may make `/state` requests when there is a large
amount of state to sync up; add code to handle that.