### PR TITLE
Install correct extras in Synapse container at test time

### DIFF
--- a/docker/synapse.Dockerfile
+++ b/docker/synapse.Dockerfile
@@ -14,7 +14,6 @@ RUN mkdir /src
 # Manually upgrade pip to ensure it can locate Cryptography's binary wheels
 RUN ${PYTHON_VERSION} -m venv /venv && /venv/bin/pip install -U pip
 RUN /venv/bin/pip install -q --no-cache-dir matrix-synapse[all]
-RUN /venv/bin/pip install -q --no-cache-dir lxml psycopg2 coverage codecov
 
 # Uninstall matrix-synapse package so it doesn't collide with the version we try
 # and test
@@ -22,6 +21,6 @@ RUN /venv/bin/pip uninstall -q --no-cache-dir -y matrix-synapse
 
 # Pre-install test dependencies installed by `scripts/synapse_sytest.sh`.
 RUN /venv/bin/pip install -q --no-cache-dir \
-        lxml psycopg2 coverage codecov tap.py coverage_enable_subprocess
+        coverage codecov tap.py coverage_enable_subprocess
 
 ENTRYPOINT [ "/bin/bash", "/bootstrap.sh", "synapse" ]

--- a/scripts/synapse_sytest.sh
+++ b/scripts/synapse_sytest.sh
@@ -141,9 +141,9 @@ if [ -n "$OFFLINE" ]; then
 else
     # We've already created the virtualenv, but lets double check we have all
     # deps.
-    /venv/bin/pip install -q --upgrade --no-cache-dir "$SYNAPSE_SOURCE"[redis]
+    /venv/bin/pip install -q --upgrade --no-cache-dir "$SYNAPSE_SOURCE"[all]
     /venv/bin/pip install -q --upgrade --no-cache-dir \
-        lxml psycopg2 coverage codecov tap.py coverage_enable_subprocess
+        coverage codecov tap.py coverage_enable_subprocess
 
     # Make sure all Perl deps are installed -- this is done in the docker build
     # so will only install packages added since the last Docker build


### PR DESCRIPTION
Instead of relying on the version of extras installed at Docker build time
or through explicit `pip install`s, ensure that appropriate versions of
all extras are installed at test time. In particular, the url_preview
(which implies lxml), postgres (which implies psycopg2) and redis extras
are wanted.

Signed-off-by: Sean Quah <seanq@element.io>