### PR TITLE
Fix Synapse Dockerfile trying to install non-existant python3.x-pip

### DIFF
--- a/docker/synapse.Dockerfile
+++ b/docker/synapse.Dockerfile
@@ -5,7 +5,7 @@ FROM matrixdotorg/sytest:${SYTEST_IMAGE_TAG}
 ARG PYTHON_VERSION=python3
 RUN apt-get -qq update && apt-get -qq install -y \
     ${PYTHON_VERSION} ${PYTHON_VERSION}-dev ${PYTHON_VERSION}-venv \
-    ${PYTHON_VERSION}-pip eatmydata redis-server
+    python3-pip eatmydata redis-server
 
 RUN ${PYTHON_VERSION} -m pip install -q --no-cache-dir poetry==1.1.12
 


### PR DESCRIPTION
Unlike `-venv` and `-dev`, there are no `python3.{7,8,9,10}-pip` Debian
or Ubuntu packages. There is, however, always a `python3-pip` package.

For Debian, see https://packages.debian.org/search?keywords=python3-pip
and https://packages.debian.org/search?keywords=python3.8-pip

For Ubuntu, see https://packages.ubuntu.com/search?keywords=python3-pip
and https://packages.ubuntu.com/search?keywords=python3.8-pip

Signed-off-by: Sean Quah <seanq@element.io>

Fixes the Dockerfile change from #1220.