### PR TITLE
Improve logging for process shutdown

### DIFF
--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -357,6 +357,7 @@ sub _start_monolith
 
    my $output = $self->{output};
    my $loop = $self->loop;
+   my $idx = $self->{hs_index};
 
    $output->diag( "Starting monolith server" );
    my @command = (
@@ -384,6 +385,7 @@ sub _start_monolith
       command => [ @command ],
       connect_host => $self->{bind_host},
       connect_port => $self->secure_port,
+      name => "dendrite-$idx-monolith",
    )->else( sub {
       die "Unable to start dendrite monolith: $_[0]\n";
    })->on_done( sub {

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -440,10 +440,12 @@ sub _start_synapse
 
    my $bind_host = $self->{bind_host};
    my @synapse_command = $self->_generate_base_synapse_command();
+   my $idx = $self->{hs_index};
 
    $self->_start_process_and_await_notify(
       setup => [ env => $env ],
       command => \@synapse_command,
+      name => "synapse-$idx-master",
    );
 }
 


### PR DESCRIPTION
Give the monolith processes names. This means that instead of logging

> ```
> # Killing process server
> # Killing process server
> ```

we instead log:

> ```
> # Killing process synapse-0-master
> # Killing process synapse-1-master
> ```

(Note that, in worker mode, we already give the processes names.)