### PR TITLE
Fix `Calling ->then in void context` warning

### DIFF
--- a/tests/50federation/32room-getevent.pl
+++ b/tests/50federation/32room-getevent.pl
@@ -60,14 +60,14 @@ test "Inbound federation redacts events from erased users",
       my ( $outbound_client, $creator, $user_id, $room, $remaining_user ) = @_;
       my $first_home_server = $creator->server_name;
       my $room_id = $room->room_id;
-      matrix_join_room($remaining_user, $room_id);
-
       my $message_id;
 
-      # have the creator send a message into the room, which we will try to
-      # fetch.
-      matrix_send_room_text_message( $creator, $room_id, body => "body1" )
+      matrix_join_room( $remaining_user, $room_id )
       ->then( sub {
+         # have the creator send a message into the room, which we will try to
+         # fetch.
+         matrix_send_room_text_message( $creator, $room_id, body => "body1" );
+      })->then( sub {
          ( $message_id ) = @_;
 
          $outbound_client->do_request_json(


### PR DESCRIPTION
PR #1205 added a call to `matrix_join_room`, but did not await the result, which resulted in a bunch of warnings:

```
 ** Calling ->then in void context at tests/10apidoc/33room-members.pl line 82.
 ** IO::Async::Future=HASH(0x557d6befbf40) IO::Async::Future=HASH(0x557d6befbf40) lost a sequence Future at /home/rav/lib/perl5/Net/Async/HTTP/Connection.pm line 472.
```

Waiting for the join to complete before proceeding fixes the warnings.