### PR TITLE
PUT redaction endpoints

### DIFF
--- a/tests/30rooms/10redactions.pl
+++ b/tests/30rooms/10redactions.pl
@@ -28,16 +28,22 @@ Makes a /redact request
 
 =cut
 
+sub random_transaction_id
+{
+   join "", map { chr 65 + rand 26 } 1 .. 20;
+}
+
 sub matrix_redact_event
 {
    my ( $user, $room_id, $event_id, %params ) = @_;
 
    $room_id = uri_escape( $room_id );
    my $esc_event_id = uri_escape( $event_id );
+   my $txn_id = random_transaction_id();
 
    do_request_json_for( $user,
-      method => "POST",
-      uri    => "/v3/rooms/$room_id/redact/$esc_event_id",
+      method => "PUT",
+      uri    => "/v3/rooms/$room_id/redact/$esc_event_id/$txn_id",
       content => \%params,
    )->then( sub {
       my ( $body ) = @_;
@@ -87,7 +93,7 @@ sub matrix_redact_event_synced
 
 push @EXPORT, qw( matrix_redact_event_synced );
 
-test "POST /rooms/:room_id/redact/:event_id as power user redacts message",
+test "PUT /rooms/:room_id/redact/:event_id/:txn_id as power user redacts message",
    requires => [ local_user_fixtures( 2 ),
                  qw( can_send_message )],
 
@@ -97,18 +103,19 @@ test "POST /rooms/:room_id/redact/:event_id as power user redacts message",
       make_room_and_message( [ $creator, $sender ], $sender )
       ->then( sub {
          my ( $room_id, $to_redact ) = @_;
+         my $txn_id = random_transaction_id();
 
          $to_redact = uri_escape( $to_redact );
 
          do_request_json_for( $creator,
-            method => "POST",
-            uri    => "/v3/rooms/$room_id/redact/$to_redact",
+            method => "PUT",
+            uri    => "/v3/rooms/$room_id/redact/$to_redact/$txn_id",
             content => {},
          );
       });
    };
 
-test "POST /rooms/:room_id/redact/:event_id as original message sender redacts message",
+test "PUT /rooms/:room_id/redact/:event_id/:txn_id as original message sender redacts message",
    requires => [ local_user_fixtures( 2 ),
                  qw( can_send_message )],
 
@@ -118,18 +125,19 @@ test "POST /rooms/:room_id/redact/:event_id as original message sender redacts m
       make_room_and_message( [ $creator, $sender ], $sender )
       ->then( sub {
          my ( $room_id, $to_redact ) = @_;
+         my $txn_id = random_transaction_id();
 
          $to_redact = uri_escape( $to_redact );
 
          do_request_json_for( $sender,
-               method => "POST",
-               uri    => "/v3/rooms/$room_id/redact/$to_redact",
+               method => "PUT",
+               uri    => "/v3/rooms/$room_id/redact/$to_redact/$txn_id",
                content => {},
          );
       });
    };
 
-test "POST /rooms/:room_id/redact/:event_id as random user does not redact message",
+test "PUT /rooms/:room_id/redact/:event_id/:txn_id as random user does not redact message",
    requires => [ local_user_fixtures( 3 ),
                  qw( can_send_message )],
 
@@ -139,18 +147,18 @@ test "POST /rooms/:room_id/redact/:event_id as random user does not redact messa
       make_room_and_message( [ $creator, $sender, $redactor ], $sender )
       ->then( sub {
          my ( $room_id, $to_redact ) = @_;
-
+         my $txn_id = random_transaction_id();
          $to_redact = uri_escape( $to_redact );
 
          do_request_json_for( $redactor,
-               method => "POST",
-               uri    => "/v3/rooms/$room_id/redact/$to_redact",
+               method => "PUT",
+               uri    => "/v3/rooms/$room_id/redact/$to_redact/$txn_id",
                content => {},
          )->main::expect_http_403;
       });
    };
 
-test "POST /redact disallows redaction of event in different room",
+test "PUT /redact disallows redaction of event in different room",
    requires => [ local_user_and_room_fixtures(), local_user_and_room_fixtures() ],
 
    do => sub {

--- a/tests/30rooms/10redactions.pl
+++ b/tests/30rooms/10redactions.pl
@@ -30,7 +30,7 @@ Makes a /redact request
 
 sub random_transaction_id
 {
-   join "", map { chr (65 + rand 26) } 1 .. 20;
+   join "", map { chr( 65 + rand 26 )} 1 .. 20;
 }
 
 sub matrix_redact_event
@@ -261,4 +261,3 @@ test "PUT /rooms/:room_id/redact/:event_id/:txn_id is idempotent",
          })
       })
    };
-

--- a/tests/30rooms/10redactions.pl
+++ b/tests/30rooms/10redactions.pl
@@ -30,7 +30,7 @@ Makes a /redact request
 
 sub random_transaction_id
 {
-   join "", map { chr 65 + rand 26 } 1 .. 20;
+   join "", map { chr (65 + rand 26) } 1 .. 20;
 }
 
 sub matrix_redact_event
@@ -243,7 +243,8 @@ test "PUT /rooms/:room_id/redact/:event_id/:txn_id is idempotent",
             method => "PUT",
             uri    => "/v3/rooms/$room_id/redact/$to_redact/$txn_id",
             content => {},
-         )->then( sub {
+         )
+         ->then( sub {
             my ( $body ) = @_;
             $event_id_1 = $body->{event_id};
 
@@ -251,13 +252,13 @@ test "PUT /rooms/:room_id/redact/:event_id/:txn_id is idempotent",
                method => "PUT",
                uri    => "/v3/rooms/$room_id/redact/$to_redact/$txn_id",
                content => {},
-            )->then(sub {
-               my ( $body ) = @_;
-               $event_id_2 = $body->{event_id};
-               assert_eq( $event_id_1, $event_id_2 );
-
-               Future->done(1);
-            })
-         });
+            );
+         })
+         ->then(sub {
+            my ( $body ) = @_;
+            $event_id_2 = $body->{event_id};
+            assert_eq( $event_id_1, $event_id_2 );
+         })
       })
    };
+

--- a/tests/30rooms/10redactions.pl
+++ b/tests/30rooms/10redactions.pl
@@ -232,10 +232,12 @@ test "PUT /rooms/:room_id/redact/:event_id/:txn_id is idempotent",
       my ( $creator, $sender ) = @_;
       my $txn_id = random_transaction_id();
       my ( $event_id_1, $event_id_2 );
+      my $room_id;
+      my $to_redact;
 
       make_room_and_message( [ $creator, $sender ], $sender )
       ->then( sub {
-         my ( $room_id, $to_redact ) = @_;
+         ( $room_id, $to_redact ) = @_;
 
          $to_redact = uri_escape( $to_redact );
 
@@ -243,21 +245,19 @@ test "PUT /rooms/:room_id/redact/:event_id/:txn_id is idempotent",
             method => "PUT",
             uri    => "/v3/rooms/$room_id/redact/$to_redact/$txn_id",
             content => {},
-         )
-         ->then( sub {
-            my ( $body ) = @_;
-            $event_id_1 = $body->{event_id};
+         );
+      })->then( sub {
+         my ( $body ) = @_;
+         $event_id_1 = $body->{event_id};
 
-            do_request_json_for( $creator,
-               method => "PUT",
-               uri    => "/v3/rooms/$room_id/redact/$to_redact/$txn_id",
-               content => {},
-            );
-         })
-         ->then(sub {
-            my ( $body ) = @_;
-            $event_id_2 = $body->{event_id};
-            assert_eq( $event_id_1, $event_id_2 );
-         })
-      })
+         do_request_json_for( $creator,
+            method => "PUT",
+            uri    => "/v3/rooms/$room_id/redact/$to_redact/$txn_id",
+            content => {},
+         );
+      })->then( sub {
+         my ( $body ) = @_;
+         $event_id_2 = $body->{event_id};
+         assert_eq( $event_id_1, $event_id_2 );
+      });
    };


### PR DESCRIPTION
Sytest uses an endpoint for redaction which uses POST (instead
of PUT) and does not contain a transaction id. I've been reviewing the
latest spec version and I could only find the PUT version
(https://spec.matrix.org/v1.2/client-server-api/#put_matrixclientv3roomsroomidsendeventtypetxnid).

I've changed the endpoints to use the speced endpoint (both synapse and
dendrite seems to support both). I'm not certain about if this is an
issue on the spec or in sytest: Feel free to close this PR if the
previous behaviour is the expected one.

--- 

Additionally, I've added a test which checks that two redactions with the same transaction id generates a
single redaction event.
