### PR TITLE
Join room synced for room summary tests

### DIFF
--- a/tests/31sync/16room-summary.pl
+++ b/tests/31sync/16room-summary.pl
@@ -23,7 +23,7 @@ test "Unnamed room comes with a name summary",
          ( $room_id ) = @_;
          matrix_join_room_synced( $bob, $room_id );
       })->then( sub {
-         matrix_join_room( $charlie, $room_id );
+         matrix_join_room_synced( $charlie, $room_id );
       })->then( sub {
          matrix_sync( $alice, filter => $filter_id );
       })->then( sub {
@@ -70,7 +70,7 @@ test "Named room comes with just joined member count summary",
       })->then( sub {
          matrix_join_room_synced( $bob, $room_id );
       })->then( sub {
-         matrix_join_room( $charlie, $room_id );
+         matrix_join_room_synced( $charlie, $room_id );
       })->then( sub {
          matrix_sync( $alice, filter => $filter_id );
       })->then( sub {


### PR DESCRIPTION
This ensures the user is actually joined to the room and doesn't flake on Dendrite.