### PR TITLE
Enable registration again in Dendrite

### DIFF
--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -344,6 +344,7 @@ sub _start_monolith
       '--api-bind-address', $self->{bind_host} . ':1' . $self->unsecure_port,
       '--tls-cert', $self->{paths}{tls_cert},
       '--tls-key', $self->{paths}{tls_key},
+      '--really-enable-open-registration',
    );
 
    push(@command, '-api') if $ENV{'API'} == '1';

--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -123,6 +123,7 @@ sub _get_config
 
       client_api => {
          registration_shared_secret => "reg_secret",
+         registration_disabled => $JSON::false,
 
          $self->{recaptcha_config} ? (
             # here "true" gets written as a quote-less string, which in yaml is


### PR DESCRIPTION
We are disabling registration by default with https://github.com/matrix-org/dendrite/pull/2402, this PR ensures Sytest can still run as expected.