### PR TITLE
Remove unused docker tag (go113) 

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,7 +26,7 @@ jobs:
           - base_image: debian:bookworm
             tag: bookworm
     steps:
-      - name: Set up QEMU
+        - name: Set up QEMU
         id: QEMU
         uses: docker/setup-qemu-action@v1
 
@@ -52,7 +52,7 @@ jobs:
           labels: "gitsha1=${{ github.sha }}"
           file: docker/base.Dockerfile
           build-args: "BASE_IMAGE=${{ matrix.base_image }}"
-          tags: herenotthere/sytest:${{ matrix.tag }}
+          tags: matrixdotorg/sytest:${{ matrix.tag }}
 
   build-dependent-images:
     needs: build-sytest-images
@@ -63,25 +63,25 @@ jobs:
         include:
           - sytest_image_tag: focal
             dockerfile: synapse
-            tags: "herenotthere/sytest-synapse:focal"
+            tags: "matrixdotorg/sytest-synapse:focal"
             build_args: "SYTEST_IMAGE_TAG=focal"
           - sytest_image_tag: buster
             dockerfile: synapse
-            tags: "herenotthere/sytest-synapse:buster"
+            tags: "matrixdotorg/sytest-synapse:buster"
             build_args: "SYTEST_IMAGE_TAG=buster"
           - sytest_image_tag: testing
             dockerfile: synapse
-            tags: "herenotthere/sytest-synapse:testing"
+            tags: "matrixdotorg/sytest-synapse:testing"
             build_args: "SYTEST_IMAGE_TAG=testing"
           - sytest_image_tag: bookworm
             dockerfile: synapse
-            tags: "herenotthere/sytest-synapse:bookworm-python3.10"
+            tags: "matrixdotorg/sytest-synapse:bookworm-python3.10"
             build_args: |
               SYTEST_IMAGE_TAG=bookworm
               PYTHON_VERSION=python3.10
           - sytest_image_tag: buster
             dockerfile: dendrite
-            tags: "herenotthere/sytest-dendrite:go118,herenotthere/sytest-dendrite:latest"
+            tags: "matrixdotorg/sytest-dendrite:go118,matrixdotorg/sytest-dendrite:latest"
             build_args: "SYTEST_IMAGE_TAG=buster"
 
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -81,7 +81,7 @@ jobs:
               PYTHON_VERSION=python3.10
           - sytest_image_tag: buster
             dockerfile: dendrite
-            tags: "matrixdotorg/sytest-dendrite:go113,matrixdotorg/sytest-dendrite:latest"
+            tags: "matrixdotorg/sytest-dendrite:latest"
             build_args: "SYTEST_IMAGE_TAG=buster"
 
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -81,7 +81,7 @@ jobs:
               PYTHON_VERSION=python3.10
           - sytest_image_tag: buster
             dockerfile: dendrite
-            tags: "matrixdotorg/sytest-dendrite:go118,matrixdotorg/sytest-dendrite:latest"
+            tags: "matrixdotorg/sytest-dendrite:go113,matrixdotorg/sytest-dendrite:latest"
             build_args: "SYTEST_IMAGE_TAG=buster"
 
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,7 +52,7 @@ jobs:
           labels: "gitsha1=${{ github.sha }}"
           file: docker/base.Dockerfile
           build-args: "BASE_IMAGE=${{ matrix.base_image }}"
-          tags: matrixdotorg/sytest:${{ matrix.tag }}
+          tags: herenotthere/sytest:${{ matrix.tag }}
 
   build-dependent-images:
     needs: build-sytest-images
@@ -63,25 +63,25 @@ jobs:
         include:
           - sytest_image_tag: focal
             dockerfile: synapse
-            tags: "matrixdotorg/sytest-synapse:focal"
+            tags: "herenotthere/sytest-synapse:focal"
             build_args: "SYTEST_IMAGE_TAG=focal"
           - sytest_image_tag: buster
             dockerfile: synapse
-            tags: "matrixdotorg/sytest-synapse:buster"
+            tags: "herenotthere/sytest-synapse:buster"
             build_args: "SYTEST_IMAGE_TAG=buster"
           - sytest_image_tag: testing
             dockerfile: synapse
-            tags: "matrixdotorg/sytest-synapse:testing"
+            tags: "herenotthere/sytest-synapse:testing"
             build_args: "SYTEST_IMAGE_TAG=testing"
           - sytest_image_tag: bookworm
             dockerfile: synapse
-            tags: "matrixdotorg/sytest-synapse:bookworm-python3.10"
+            tags: "herenotthere/sytest-synapse:bookworm-python3.10"
             build_args: |
               SYTEST_IMAGE_TAG=bookworm
               PYTHON_VERSION=python3.10
           - sytest_image_tag: buster
             dockerfile: dendrite
-            tags: "matrixdotorg/sytest-dendrite:go118,matrixdotorg/sytest-dendrite:latest"
+            tags: "herenotthere/sytest-dendrite:go118,herenotthere/sytest-dendrite:latest"
             build_args: "SYTEST_IMAGE_TAG=buster"
 
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,7 +26,7 @@ jobs:
           - base_image: debian:bookworm
             tag: bookworm
     steps:
-        - name: Set up QEMU
+      - name: Set up QEMU
         id: QEMU
         uses: docker/setup-qemu-action@v1
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,10 @@ jobs:
           - base_image: debian:bookworm
             tag: bookworm
     steps:
+      - name: Set up QEMU
+        id: QEMU
+        uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
@@ -81,6 +85,10 @@ jobs:
             build_args: "SYTEST_IMAGE_TAG=buster"
 
     steps:
+      - name: Set up QEMU
+        id: QEMU
+        uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,18 +1,16 @@
 # SyTest Docker Images
 
 These Dockerfiles create containers for running SyTest in various
-configurations. SyTest is not included in these images (see 
+configurations. SyTest is not included in these images (see
 [Selecting a checkout of SyTest](#selecting-a-sytest-checkout)),
 but its dependencies are.
 
 Included currently is:
 
 - `matrixdotorg/sytest` Base container with SyTest dependencies installed
-    - Tagged by underlying Debian/Ubuntu image: `focal`, `buster` or `testing`
+  - Tagged by underlying Debian/Ubuntu image: `focal`, `buster` or `testing`
 - `matrixdotorg/sytest-synapse`: Runs SyTest against Synapse
-    - Tagged by underlying Debian/Ubunutu image: `focal`, `buster` or `testing`
-- `matrixdotorg/sytest-dendrite:go113`: Runs SyTest against Dendrite on Go 1.13
-    - Currently uses Debian 10 (Buster) as its base image
+  - Tagged by underlying Debian/Ubunutu image: `focal`, `buster` or `testing`
 
 ## Target-specific details
 
@@ -30,29 +28,29 @@ docker run --rm -it -v /path/to/synapse\:/src:ro -v /path/to/where/you/want/logs
 
 The following environment variables can be set with `-e` to control the test run:
 
- * `POSTGRES`: set non-empty to test against a PostgreSQL database instead of SQLite.
- * `MULTI_POSTGRES`: set non-empty (along with `POSTGRES`) to test against multiple
-   PostgreSQL databases where the main store and state store are split.
- * `WORKERS`: set non-empty to test a worker-mode deployment rather than a
-   monolith. Requires `POSTGRES`.
- * `REDIS`: set non-empty to use redis replication rather than old
-   TCP. Requires `WORKERS`.
- * `OFFLINE`: set non-empty to avoid updating the python or perl dependencies.
- * `BLACKLIST`: set non-empty to change the default blacklist file to the
-   specified path relative to the Synapse directory
- * `TIMEOUT_FACTOR`: sets a number that test timeouts are multiplied by.
+- `POSTGRES`: set non-empty to test against a PostgreSQL database instead of SQLite.
+- `MULTI_POSTGRES`: set non-empty (along with `POSTGRES`) to test against multiple
+  PostgreSQL databases where the main store and state store are split.
+- `WORKERS`: set non-empty to test a worker-mode deployment rather than a
+  monolith. Requires `POSTGRES`.
+- `REDIS`: set non-empty to use redis replication rather than old
+  TCP. Requires `WORKERS`.
+- `OFFLINE`: set non-empty to avoid updating the python or perl dependencies.
+- `BLACKLIST`: set non-empty to change the default blacklist file to the
+  specified path relative to the Synapse directory
+- `TIMEOUT_FACTOR`: sets a number that test timeouts are multiplied by.
 
 Some examples of running Synapse in different configurations:
 
-* Running Synapse in worker mode using
-[TCP-replication](https://github.com/matrix-org/synapse/blob/master/docs/tcp_replication.md):
+- Running Synapse in worker mode using
+  [TCP-replication](https://github.com/matrix-org/synapse/blob/master/docs/tcp_replication.md):
 
   ```
   docker run --rm -it -e POSTGRES=1 -e WORKERS=1 -v /path/to/synapse\:/src:ro \
       -v /path/to/where/you/want/logs\:/logs matrixdotorg/sytest-synapse:buster
   ```
 
-* Running Synapse in worker mode using redis:
+- Running Synapse in worker mode using redis:
 
   ```
   docker run --rm -it -e POSTGRES=1 -e WORKERS=1 -e REDIS=1 \

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -6,6 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # Install base dependencies that Python or Go would require
 RUN apt-get -qq update && apt-get -qq install -y \
+    apt-utils \
     build-essential \
     eatmydata \
     git \
@@ -23,7 +24,7 @@ RUN apt-get -qq update && apt-get -qq install -y \
     rsync \
     sqlite3 \
     wget \
- && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 # Set up the locales, as the default Debian image only has C, and PostgreSQL needs the correct locales to make a UTF-8 database
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
@@ -55,7 +56,7 @@ ENV PGUSER=postgres
 
 RUN for ver in `ls /usr/lib/postgresql | head -n 1`; do \
     su postgres -c '/usr/lib/postgresql/'$ver'/bin/initdb -E "UTF-8" --lc-collate="C" --lc-ctype="C" --username=postgres'; \
-done
+    done
 
 # configure it not to try to listen on IPv6 (it won't work and will cause warnings)
 RUN echo "listen_addresses = '127.0.0.1'" >> "$PGDATA/postgresql.conf"

--- a/docker/dendrite.Dockerfile
+++ b/docker/dendrite.Dockerfile
@@ -1,7 +1,7 @@
 ARG SYTEST_IMAGE_TAG=buster
 FROM matrixdotorg/sytest:${SYTEST_IMAGE_TAG}
 
-ARG GO_VERSION=1.18
+ARG GO_VERSION=1.16.13
 ARG TARGETARCH
 ENV GO_DOWNLOAD https://dl.google.com/go/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz
 

--- a/docker/synapse.Dockerfile
+++ b/docker/synapse.Dockerfile
@@ -3,9 +3,10 @@ ARG SYTEST_IMAGE_TAG=buster
 FROM matrixdotorg/sytest:${SYTEST_IMAGE_TAG}
 
 ARG PYTHON_VERSION=python3
+
 RUN apt-get -qq update && apt-get -qq install -y \
-    ${PYTHON_VERSION} ${PYTHON_VERSION}-dev ${PYTHON_VERSION}-venv \
-    python3-pip eatmydata redis-server
+        apt-utils ${PYTHON_VERSION} ${PYTHON_VERSION}-dev ${PYTHON_VERSION}-venv \
+        python3-pip eatmydata redis-server
 
 RUN ${PYTHON_VERSION} -m pip install -q --no-cache-dir poetry==1.1.12
 
@@ -36,18 +37,18 @@ RUN ${PYTHON_VERSION} -m pip download --dest /pypi-offline-cache \
 # dependencies.
 RUN wget -q https://github.com/matrix-org/synapse/archive/develop.tar.gz \
         -O /synapse.tar.gz && \
-    mkdir /synapse && \
-    tar -C /synapse --strip-components=1 -xf synapse.tar.gz && \
-    ln -s -T /venv /synapse/.venv && \
-    cd /synapse && \
-    poetry install -q --no-root --extras all && \
-    # Finally clean up the poetry cache and the copy of Synapse.
-    # This must be done in the same RUN command, otherwise intermediate layers
-    # of the Docker image will contain all the unwanted files we think we've
-    # deleted.
-    rm -rf `poetry config cache-dir` && \
-    rm -rf /synapse && \
-    rm /synapse.tar.gz
+        mkdir /synapse && \
+        tar -C /synapse --strip-components=1 -xf synapse.tar.gz && \
+        ln -s -T /venv /synapse/.venv && \
+        cd /synapse && \
+        poetry install -q --no-root --extras all && \
+        # Finally clean up the poetry cache and the copy of Synapse.
+        # This must be done in the same RUN command, otherwise intermediate layers
+        # of the Docker image will contain all the unwanted files we think we've
+        # deleted.
+        rm -rf `poetry config cache-dir` && \
+        rm -rf /synapse && \
+        rm /synapse.tar.gz
 
 # Pre-install test dependencies installed by `scripts/synapse_sytest.sh`.
 RUN /venv/bin/pip install -q --no-cache-dir \

--- a/docker/synapse.Dockerfile
+++ b/docker/synapse.Dockerfile
@@ -4,6 +4,8 @@ FROM matrixdotorg/sytest:${SYTEST_IMAGE_TAG}
 
 ARG PYTHON_VERSION=python3
 
+ENV DEBIAN_FRONTEND noninteractive
+
 RUN apt-get -qq update && apt-get -qq install -y \
         apt-utils ${PYTHON_VERSION} ${PYTHON_VERSION}-dev ${PYTHON_VERSION}-venv \
         python3-pip eatmydata redis-server


### PR DESCRIPTION
This appears to be from the migration to Go 1.13, and is no longer needed.

This PR stacks on the ARM64 PR.