### PR TITLE
Fix flakey pusher test - ensure we wait for the receipt to be processed

### DIFF
--- a/tests/61push/08_rejected_pushers.pl
+++ b/tests/61push/08_rejected_pushers.pl
@@ -70,7 +70,7 @@ multi_test "Test that rejected pushers are removed.",
          my ( $event_id ) = @_;
 
          # Set a read receipt so that we pushed for the subsequent messages.
-         matrix_advance_room_receipt( $alice, $room_id,
+         matrix_advance_room_receipt_synced( $alice, $room_id,
             "m.read" => $event_id
          );
       })->then( sub {


### PR DESCRIPTION
Dendrite (SQLite) can very rarely fail this test because the receipt isn't
processed before next message is sent, which results in the push being
sent early for an already read event so you get:
```
#** Received spurious HTTP request to /_matrix/push/v1/notify
#** Destroying unresponded HTTP request to /_matrix/push/v1/notify at /usr/local/share/perl/5.28.1/Net/Async/HTTP/Server/Protocol.pm line 53.~
```