### PR TITLE
Synapse: handle the /account/whoami endpoint on client_reader

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -1320,7 +1320,8 @@ sub generate_haproxy_map
 ^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/state$             client_reader
 ^/_matrix/client/(api/v1|r0|v3|unstable)/login$                      client_reader
 ^/_matrix/client/(api/v1|r0|v3|unstable)/account/3pid$               client_reader
-^/_matrix/client/versions$                                        client_reader
+^/_matrix/client/(api/v1|r0|v3|unstable)/account/whoami$             client_reader
+^/_matrix/client/versions$                                           client_reader
 ^/_matrix/client/(api/v1|r0|v3|unstable)/voip/turnServer$            client_reader
 ^/_matrix/client/(r0|v3|unstable)/register$                          client_reader
 ^/_matrix/client/(r0|v3|unstable)/auth/.*/fallback/web$              client_reader


### PR DESCRIPTION
Test the [`/account/whoami`](https://spec.matrix.org/v1.2/client-server-api/#get_matrixclientv3accountwhoami) endpoint on workers, off the back of https://github.com/matrix-org/synapse/pull/12866.