### PR TITLE
Explicitly disable sync caching for Synapse

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -293,6 +293,9 @@ sub start
         # Enable ephemeral message support (MSC2228)
         enable_ephemeral_messages => "true",
 
+	# Disable caching of sync responses to make tests easier.
+	sync_response_cache_duration => 0,
+
         $self->{recaptcha_config} ? (
            recaptcha_siteverify_api => $self->{recaptcha_config}->{siteverify_api},
            recaptcha_public_key     => $self->{recaptcha_config}->{public_key},


### PR DESCRIPTION
All the tests assume that an initial `/sync` will return up-to-date
data.

c.f. https://github.com/matrix-org/synapse/pull/13042