### PR TITLE
Use non-deprecated config options for Synapse.

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -696,7 +696,7 @@ sub _start_synapse
 
    {
       my $appservice_config = {
-         "worker_app"              => "synapse.app.appservice",
+         "worker_app"              => "synapse.app.generic_worker",
          "worker_name"             => "appservice",
          "worker_pid_file"         => "$hsdir/appservice.pid",
          "worker_log_config"       => $self->configure_logger("appservice"),
@@ -882,7 +882,7 @@ sub _start_synapse
 
    {
       my $user_dir_config = {
-         "worker_app"              => "synapse.app.user_dir",
+         "worker_app"              => "synapse.app.generic_worker",
          "worker_name"             => "user_dir",
          "worker_pid_file"         => "$hsdir/user_dir.pid",
          "worker_log_config"       => $self->configure_logger("user_dir"),

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -262,16 +262,13 @@ sub start
         # If we're using workers we need to disable these things in the main
         # process
         start_pushers         => ( not $self->{workers} ),
-        notify_appservices    => ( not $self->{workers} ),
         send_federation       => ( not $self->{workers} ),
         enable_media_repo     => ( not $self->{workers} ),
         run_background_tasks_on  => ( $self->{workers} ? "background_worker1" : "master" ),
         $self->{workers} ? (
-            update_user_directory_on  => "user_dir",
+            notify_appservices_from_worker     => "appservice",
+            update_user_directory_from_worker  => "user_dir",
         ) : (),
-        # update_user_directory is kept for backwards compatibility,
-        # worker_to_update_user_directory is prioritized before this option.
-        update_user_directory => ( not $self->{workers} ),
 
         url_preview_enabled => "true",
         url_preview_ip_range_blacklist => [],


### PR DESCRIPTION
Fixes some warning when running sytest:

```
[synapse-0-master]: The 'notify_appservices' configuration option is deprecated and will be removed in a future
[synapse-0-master]: Synapse version. Please use ``notify_appservices_from_worker: name_of_worker`` instead.
[synapse-0-master]: 
[synapse-0-master]: 
[synapse-0-master]: The 'update_user_directory' configuration option is deprecated and will be removed in a future
[synapse-0-master]: Synapse version. Please use ``update_user_directory_from_worker: name_of_worker`` instead.
[synapse-0-master]: 
```