### PR TITLE
More fixes to auth events

### DIFF
--- a/tests/50federation/52soft-fail.pl
+++ b/tests/50federation/52soft-fail.pl
@@ -239,7 +239,6 @@ test "Inbound federation accepts a second soft-failed event",
          # the DAG.
          @remote_auth_events = (
             $room->get_current_state_event( "m.room.create" ),
-            $room->get_current_state_event( "m.room.join_rules" ),
             $room->get_current_state_event( "m.room.power_levels" ),
             $join_event,
          );


### PR DESCRIPTION
A followup to #1261: we should not be including `m.room.join_rules` in the auth
events for most events.