### PR TITLE
Allow /notifications API to return read push actions

### DIFF
--- a/lib/SyTest/Homeserver.pm
+++ b/lib/SyTest/Homeserver.pm
@@ -241,7 +241,7 @@ sub configure_logger
 
       loggers => {
          synapse => {
-            level => "INFO"
+            level => "DEBUG"
          }
       },
 

--- a/tests/61push/09_notifications_api.pl
+++ b/tests/61push/09_notifications_api.pl
@@ -97,7 +97,12 @@ test "Notifications can be viewed with GET /notifications",
 
                assert_json_keys( $body, "notifications" );
 
-               assert_eq( scalar @{ $body->{notifications} }, 0 );
+               # Either we return no notifications, or we make sure its marked
+               # as read.
+               if ( scalar @{ $body->{notifications} } > 0 ) {
+                  my $notif = $body->{notifications}[0];
+                  assert_eq( $notif->{read}, JSON::true );
+               }
 
                Future->done(1);
             });


### PR DESCRIPTION
This is in line with the spec.

Fixes the tests in #13118