### PR TITLE
Don't require `end` on `/messages`

### DIFF
--- a/tests/10apidoc/34room-messages.pl
+++ b/tests/10apidoc/34room-messages.pl
@@ -158,7 +158,7 @@ test "GET /rooms/:room_id/messages returns a message",
       })->then( sub {
          my ( $body ) = @_;
 
-         # We should still get events and a "end" key, check it is actually there
+         # We should still get events and a "end" key: check they are actually there
          assert_json_keys( $body, qw( start end chunk ));
          assert_json_list( $body->{chunk} );
          $token = $body->{end};
@@ -166,13 +166,10 @@ test "GET /rooms/:room_id/messages returns a message",
          scalar @{ $body->{chunk} } > 0 or
             die "Expected some messages but got none at all\n";
       })->then( sub {
-
-         # Do another call to /messages, this time we don't expect to receive a "end" key
+         # Do another call to /messages. This time we don't expect to receive a "end" key
          do_request_json_for( $user,
             method => "GET",
             uri    => "/v3/rooms/$room_id/messages",
-
-            # With no params this does "forwards from END"; i.e. nothing useful
             params => {
                 dir => "b",
                 from => $token,
@@ -220,7 +217,7 @@ test "GET /rooms/:room_id/messages lazy loads members correctly",
 
          log_if_fail "Body", $body;
          
-         # We should still get events and a "end" key, check it is actually there
+         # We should still get events and a "end" key: check they are actually there
          assert_json_keys( $body, qw( start end state chunk ));
          assert_json_list( $body->{chunk} );
          assert_json_list( $body->{state} );
@@ -234,12 +231,10 @@ test "GET /rooms/:room_id/messages lazy loads members correctly",
             die "Expected some messages but got none at all\n";
 
       })->then( sub {
-         # Do another call to /messages, this time we don't expect to receive a "end" key
+         # Do another call to /messages. This time we don't expect to receive a "end" key
          do_request_json_for( $user,
             method => "GET",
             uri    => "/v3/rooms/$room_id/messages",
-
-            # With no params this does "forwards from END"; i.e. nothing useful
             params => {
                 dir => "b",
                 from => $token,

--- a/tests/10apidoc/34room-messages.pl
+++ b/tests/10apidoc/34room-messages.pl
@@ -136,6 +136,7 @@ test "GET /rooms/:room_id/messages returns a message",
 
    check => sub {
       my ( $user, $room_id ) = @_;
+      my $token;
 
       matrix_send_room_text_message_synced( $user, $room_id,
          body => "Here is the message content",
@@ -143,8 +144,30 @@ test "GET /rooms/:room_id/messages returns a message",
          matrix_sync( $user )
       })->then( sub {
          my ( $sync_body ) = @_;
-         my $token = $sync_body->{rooms}->{join}->{$room_id}->{timeline}->{prev_batch};
+         $token = $sync_body->{rooms}->{join}->{$room_id}->{timeline}->{prev_batch};
+         do_request_json_for( $user,
+            method => "GET",
+            uri    => "/v3/rooms/$room_id/messages",
 
+            # With no params this does "forwards from END"; i.e. nothing useful
+            params => {
+                dir => "b",
+                from => $token,
+            },
+         )
+      })->then( sub {
+         my ( $body ) = @_;
+
+         # We should still get events and a "end" key, check it is actually there
+         assert_json_keys( $body, qw( start end chunk ));
+         assert_json_list( $body->{chunk} );
+         $token = $body->{end};
+
+         scalar @{ $body->{chunk} } > 0 or
+            die "Expected some messages but got none at all\n";
+      })->then( sub {
+
+         # Do another call to /messages, this time we don't expect to receive a "end" key
          do_request_json_for( $user,
             method => "GET",
             uri    => "/v3/rooms/$room_id/messages",
@@ -159,11 +182,9 @@ test "GET /rooms/:room_id/messages returns a message",
          my ( $body ) = @_;
 
          assert_json_keys( $body, qw( start chunk ));
-         assert_json_list( $body->{chunk} );
-
-         scalar @{ $body->{chunk} } > 0 or
-            die "Expected some messages but got none at all\n";
-
+         if( exists $body->{end} ) {
+            die "Unexpected 'end' key in response"
+         }
          Future->done(1);
       });
    };
@@ -174,6 +195,7 @@ test "GET /rooms/:room_id/messages lazy loads members correctly",
 
    check => sub {
       my ( $user, $room_id ) = @_;
+      my $token;
 
       matrix_send_room_text_message_synced( $user, $room_id,
          body => "Here is the message content",
@@ -181,7 +203,7 @@ test "GET /rooms/:room_id/messages lazy loads members correctly",
          matrix_sync( $user )
       })->then( sub {
          my ( $sync_body ) = @_;
-         my $token = $sync_body->{rooms}->{join}->{$room_id}->{timeline}->{prev_batch};
+         $token = $sync_body->{rooms}->{join}->{$room_id}->{timeline}->{prev_batch};
 
          do_request_json_for( $user,
             method => "GET",
@@ -197,10 +219,12 @@ test "GET /rooms/:room_id/messages lazy loads members correctly",
          my ( $body ) = @_;
 
          log_if_fail "Body", $body;
-
-         assert_json_keys( $body, qw( start state chunk ));
+         
+         # We should still get events and a "end" key, check it is actually there
+         assert_json_keys( $body, qw( start end state chunk ));
          assert_json_list( $body->{chunk} );
          assert_json_list( $body->{state} );
+         $token = $body->{end};
 
          assert_eq( scalar @{$body->{state}}, 1);
          assert_eq( $body->{state}[0]{type}, 'm.room.member');
@@ -209,6 +233,25 @@ test "GET /rooms/:room_id/messages lazy loads members correctly",
          scalar @{ $body->{chunk} } > 0 or
             die "Expected some messages but got none at all\n";
 
+      })->then( sub {
+         # Do another call to /messages, this time we don't expect to receive a "end" key
+         do_request_json_for( $user,
+            method => "GET",
+            uri    => "/v3/rooms/$room_id/messages",
+
+            # With no params this does "forwards from END"; i.e. nothing useful
+            params => {
+                dir => "b",
+                from => $token,
+            },
+         )
+      })->then( sub {
+         my ( $body ) = @_;
+
+         assert_json_keys( $body, qw( start chunk ));
+         if( exists $body->{end} ) {
+            die "Unexpected 'end' key in response"
+         }
          Future->done(1);
       });
    };

--- a/tests/10apidoc/34room-messages.pl
+++ b/tests/10apidoc/34room-messages.pl
@@ -158,7 +158,7 @@ test "GET /rooms/:room_id/messages returns a message",
       })->then( sub {
          my ( $body ) = @_;
 
-         assert_json_keys( $body, qw( start end chunk ));
+         assert_json_keys( $body, qw( start chunk ));
          assert_json_list( $body->{chunk} );
 
          scalar @{ $body->{chunk} } > 0 or
@@ -198,7 +198,7 @@ test "GET /rooms/:room_id/messages lazy loads members correctly",
 
          log_if_fail "Body", $body;
 
-         assert_json_keys( $body, qw( start end state chunk ));
+         assert_json_keys( $body, qw( start state chunk ));
          assert_json_list( $body->{chunk} );
          assert_json_list( $body->{state} );
 


### PR DESCRIPTION
As per the spec, the `end` key is not required if there are no more events for the user.

> If no further events are available (either because we have reached the start of the timeline, or because the user does not have permission to see any more events), this property is omitted from the response.