### PR TITLE
Use generate-config for Dendrite

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -120,9 +120,6 @@ jobs:
             /logs/**/*.log*
 
   dendrite:
-    # dendrite is currently flaky, so disable the tests for now
-    if: false
-  
     runs-on: ubuntu-latest
     name: "Dendrite: ${{ matrix.label }}"
 

--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -118,7 +118,12 @@ sub _get_config
             path => "$self->{hs_dir}/dendrite-logs",
          },
       }];
-
+   if ( $self->{recaptcha_config}) {
+      $config->{client_api}->{enable_registration_captcha} = $JSON::false; # disabled for now
+      $config->{client_api}->{recaptcha_siteverify_api} = $self->{recaptcha_config}->{siteverify_api};
+      $config->{client_api}->{recaptcha_public_key} = $self->{recaptcha_config}->{public_key};
+      $config->{client_api}->{recaptcha_private_key} = $self->{recaptcha_config}->{private_key};
+   }
    # Set database connections for each component depending on which engine to use.
    my @components = ("room_server", "app_service_api", "key_server", "sync_api", "federation_api", "user_api", "media_api", "mscs");
    my $component;

--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -104,6 +104,7 @@ sub _get_config
    # Set SyTest specific values.
    $config->{global}->{server_name} = $self->server_name;
    $config->{global}->{private_key} = $self->{paths}{matrix_key};
+   $config->{global}->{server_notices}->{enabled} = $JSON::false;
    $config->{global}->{jetstream}->{storage_path} = $self->{hs_dir};
    $config->{app_service_api}->{config_files} = $self->{app_service_config_files} ? $self->{app_service_config_files} : [];
    $config->{client_api}->{registration_shared_secret} = "reg_secret";

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -36,6 +36,7 @@ cd /src
 mkdir -p $GOBIN
 go install -v ./cmd/dendrite-monolith-server
 go install -v ./cmd/generate-keys
+go install -v ./cmd/generate-config
 cd -
 
 # Run the tests


### PR DESCRIPTION
This should allow us to introduce new config entries without having to create extra PRs for SyTest.
It also re-enables CI runs for Dendrite, as it shouldn't be as flakey as before.