### PR TITLE
Update Dendrite dockerfile to use Go 1.18.3

### DIFF
--- a/docker/dendrite.Dockerfile
+++ b/docker/dendrite.Dockerfile
@@ -1,7 +1,7 @@
 ARG SYTEST_IMAGE_TAG=buster
 FROM matrixdotorg/sytest:${SYTEST_IMAGE_TAG}
 
-ARG GO_VERSION=1.16.13
+ARG GO_VERSION=1.18.3
 ARG TARGETARCH
 ENV GO_DOWNLOAD https://dl.google.com/go/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz
 


### PR DESCRIPTION
Needed for when we merge matrix-org/dendrite#2563.