### PR TITLE
Work around Synapse Docker build failures by using a `--cache-dir`

### DIFF
--- a/docker/synapse.Dockerfile
+++ b/docker/synapse.Dockerfile
@@ -10,7 +10,13 @@ RUN apt-get -qq update && apt-get -qq install -y \
         apt-utils ${PYTHON_VERSION} ${PYTHON_VERSION}-dev ${PYTHON_VERSION}-venv \
         python3-pip eatmydata redis-server
 
-RUN ${PYTHON_VERSION} -m pip install -q --no-cache-dir poetry==1.1.12
+RUN ${PYTHON_VERSION} -m pip install --cache-dir /pip-cache poetry==1.1.12 && \
+    rm -rf /pip-cache
+# Instead of using `--no-cache-dir`, we specify a `--cache-dir` and delete it
+# afterwards. This works around a bug where `msgpack` gets installed to
+# `site-packages`, where Python can't find it, instead of `dist-packages`, when
+# using `setuptools>=48.0.0` and the `--no-cache-dir` option.
+# https://github.com/matrix-org/sytest/issues/1269
 
 # As part of the Docker build, we attempt to pre-install Synapse's dependencies
 # in the hope that it speeds up the real install of Synapse. To make this work,


### PR DESCRIPTION
When the `--no-cache-dir` option is given to pip, setuptools>=48.0.0
installs msgpack to `/usr/lib/python3.7/site-packages/` instead of
`/usr/local/lib/python3.7/dist-packages/`, where Python can't find it.

---

Fixes #1269.
