### PR TITLE
Enable race detection for dendrite server used to run tests

### DIFF
--- a/docker/dendrite.Dockerfile
+++ b/docker/dendrite.Dockerfile
@@ -1,7 +1,7 @@
 ARG SYTEST_IMAGE_TAG=buster
 FROM matrixdotorg/sytest:${SYTEST_IMAGE_TAG}
 
-ARG GO_VERSION=1.18.3
+ARG GO_VERSION=1.19
 ARG TARGETARCH
 ENV GO_DOWNLOAD https://dl.google.com/go/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz
 

--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -276,6 +276,7 @@ sub _start_monolith
       setup => [
          env => {
             LOG_DIR => $self->{hs_dir},
+            GORACE => "log_path=/logs/$idx-race.log", 
             DENDRITE_TRACE_SQL => $ENV{'DENDRITE_TRACE_SQL'},
             DENDRITE_TRACE_HTTP => $ENV{'DENDRITE_TRACE_HTTP'},
             DENDRITE_TRACE_INTERNAL => $ENV{'DENDRITE_TRACE_INTERNAL'},

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -55,7 +55,11 @@ wait $pid || TEST_STATUS=$?
 trap - TERM INT
 
 if [ $TEST_STATUS -ne 0 ]; then
-    echo >&2 -e "run-tests \e[31mFAILED\e[0m: exit code $TEST_STATUS"
+    if [ $TEST_STATUS -ne 66 ]; then
+        echo >&2 -e "run-tests \e[31mFAILED\e[0m: exit code $TEST_STATUS"
+    else
+        echo >&2 -e "run-tests \e[31mFAILED\e[0m: failed with golang race detector warnings, look in the race logs"
+    fi
 else
     echo >&2 -e "run-tests \e[32mPASSED\e[0m"
 fi

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -34,9 +34,9 @@ export GOBIN=/tmp/bin
 echo >&2 "--- Building dendrite from source"
 cd /src
 mkdir -p $GOBIN
-go install -v ./cmd/dendrite-monolith-server
-go install -v ./cmd/generate-keys
-go install -v ./cmd/generate-config
+go install -race -v ./cmd/dendrite-monolith-server
+go install -race -v ./cmd/generate-keys
+go install -race -v ./cmd/generate-config
 cd -
 
 # Run the tests
@@ -67,7 +67,7 @@ fi
 echo >&2 "--- Copying assets"
 
 # Copy out the logs
-rsync -r --ignore-missing-args --min-size=1B -av /work/server-0 /work/server-1 /logs --include "*/" --include="*.log.*" --include="*.log" --exclude="*"
+rsync -r --ignore-missing-args --min-size=1B -av /work/server-0 /work/server-1 /logs --include "*/" --include="*race.log*" --include="*.log.*" --include="*.log" --exclude="*"
 find /logs | xargs -r chmod go+rX
 
 # Generate annotate.md. This is Buildkite-specific.


### PR DESCRIPTION
This change builds and installs the dendrite server and tools enabling the race golang race detector and puts the race logs into the same location as other logs so they can be reviewed if tests introduce races.

This will fail sytest on Dendrite as there are multiple race failures on startup. I have another PR to Dendrite in progress that will allow this to pass, putting this PR up as a placeholder to land after the fixes are in Dendrite.

Signed-off-by: Brian Meek <brian@hntlabs.com>
