### PR TITLE
Prevent using deprected endpoints for non-deprecated endpoint tests

### DIFF
--- a/tests/30rooms/02members-local.pl
+++ b/tests/30rooms/02members-local.pl
@@ -122,11 +122,10 @@ test "All room members see all room members' presence in global initialSync",
       my ( $first_user, $local_user, $room_id ) = @_;
       my @all_users = ( $first_user, $local_user );
 
-      Future->needs_all( map {
-         my $user = $_;
-
-         flush_events_for( $user )
-         ->then(sub {
+      Future->needs_all( map { matrix_set_presence_status($_, "online") } @all_users)
+      ->then(sub {
+         Future->needs_all( map {
+            my $user = $_;
             matrix_initialsync( $user )->then( sub {
                my ( $body ) = @_;
 
@@ -152,6 +151,6 @@ test "All room members see all room members' presence in global initialSync",
 
                Future->done(1);
             });
-         })
-      } @all_users );
+         } @all_users );
+      });
    };

--- a/tests/30rooms/02members-local.pl
+++ b/tests/30rooms/02members-local.pl
@@ -125,7 +125,7 @@ test "All room members see all room members' presence in global initialSync",
       Future->needs_all( map {
          my $user = $_;
 
-         matrix_set_presence_status( $user, "online")
+         flush_events_for( $user )
          ->then(sub {
             matrix_initialsync( $user )->then( sub {
                my ( $body ) = @_;

--- a/tests/30rooms/03members-remote.pl
+++ b/tests/30rooms/03members-remote.pl
@@ -5,13 +5,11 @@ my $creator_fixture = local_user_fixture(
    # Some of these tests depend on the user having a displayname
    displayname => "My name here",
    avatar_url  => "mxc://foo/bar",
-   with_events => 1,
 );
 
 my $remote_user_fixture = remote_user_fixture(
    displayname => "My remote name here",
    avatar_url  => "mxc://foo/remote",
-   with_events => 1,
 );
 
 my $room_fixture = fixture(
@@ -35,14 +33,12 @@ test "Remote users can join room by alias",
    do => sub {
       my ( $user, $room_id, $room_alias ) = @_;
 
-      flush_events_for( $user )->then( sub {
-         do_request_json_for( $user,
-            method => "POST",
-            uri    => "/v3/join/$room_alias",
+      do_request_json_for( $user,
+         method => "POST",
+         uri    => "/v3/join/$room_alias",
 
-            content => {},
-         );
-      });
+         content => {},
+      )
    },
 
    check => sub {
@@ -94,45 +90,49 @@ test "New room members see existing members' presence in room initialSync",
    do => sub {
       my ( $first_user, $user, $room_id, $room_alias ) = @_;
 
-      ( repeat_until_true {
-         matrix_initialsync_room( $user, $room_id )->then( sub {
-            my ( $body ) = @_;
+      matrix_set_presence_status( $first_user, "online")
+      ->then(sub {
+         ( repeat_until_true {
 
-            log_if_fail "initialSync result", $body;
+            matrix_initialsync_room( $user, $room_id )->then( sub {
+               my ( $body ) = @_;
 
-            my %presence = map { $_->{content}{user_id} => $_ } @{ $body->{presence} };
+               log_if_fail "initialSync result", $body;
 
-            # it's possible that the user's presence hasn't yet arrived at our
-            # server (or hasn't propagated between the workers). In this case,
-            # we expect the presence value to be either missing, or present
-            # (hah!) with a default value.
+               my %presence = map { $_->{content}{user_id} => $_ } @{ $body->{presence} };
 
-            my $first_user_id = $first_user->user_id;
-            my $first_presence = $presence{$first_user_id};
+               # it's possible that the user's presence hasn't yet arrived at our
+               # server (or hasn't propagated between the workers). In this case,
+               # we expect the presence value to be either missing, or present
+               # (hah!) with a default value.
 
-            if( not $first_presence ) {
-               log_if_fail "No presence for user $first_user_id: retrying";
-               return Future->done( undef );  # try again
-            }
+               my $first_user_id = $first_user->user_id;
+               my $first_presence = $presence{$first_user_id};
 
-            assert_json_keys( $first_presence, qw( type content ));
-            assert_json_keys( $first_presence->{content}, qw( presence ));
+               if( not $first_presence ) {
+                  log_if_fail "No presence for user $first_user_id: retrying";
+                  return Future->done( undef );  # try again
+               }
 
-            if( $first_presence->{content}{presence} eq 'offline' &&
-                   not exists $first_presence->{content}{last_active_ago} ) {
-               log_if_fail "Default presence block for user $first_user_id: retrying";
-               return Future->done( undef );  # try again
-            }
+               assert_json_keys( $first_presence, qw( type content ));
+               assert_json_keys( $first_presence->{content}, qw( presence ));
 
-            # otherwise, there should be a last_active_ago field.
-            # (the user may or may not actually be online, because it might
-            # have taken quite a while for us to spin up the prerequisites for
-            # this test).
-            assert_json_keys( $first_presence->{content}, qw( last_active_ago ));
+               if( $first_presence->{content}{presence} eq 'offline' &&
+                     not exists $first_presence->{content}{last_active_ago} ) {
+                  log_if_fail "Default presence block for user $first_user_id: retrying";
+                  return Future->done( undef );  # try again
+               }
 
-            return Future->done( 1 );
-         })
-      });
+               # otherwise, there should be a last_active_ago field.
+               # (the user may or may not actually be online, because it might
+               # have taken quite a while for us to spin up the prerequisites for
+               # this test).
+               assert_json_keys( $first_presence->{content}, qw( last_active_ago ));
+
+               return Future->done( 1 );
+            })
+         });
+      })
    };
 
 test "Existing members see new members' join events",
@@ -164,15 +164,18 @@ test "Existing members see new member's presence",
    do => sub {
       my ( $first_user, $user, $room_id, $room_alias ) = @_;
 
-      await_sync_presence_contains( $first_user, check => sub {
-         my ( $event ) = @_;
+      matrix_set_presence_status($user, "online")
+      ->then(sub {
+         await_sync_presence_contains( $first_user, check => sub {
+            my ( $event ) = @_;
 
-         return unless $event->{type} eq "m.presence";
-         assert_json_keys( $event, qw( type content sender ));
-         assert_json_keys( $event->{content}, qw( presence last_active_ago ));
-         return unless $event->{sender} eq $user->user_id;
+            return unless $event->{type} eq "m.presence";
+            assert_json_keys( $event, qw( type content sender ));
+            assert_json_keys( $event->{content}, qw( presence last_active_ago ));
+            return unless $event->{sender} eq $user->user_id;
 
-         return 1;
+            return 1;
+         });
       });
    };
 


### PR DESCRIPTION
Until now, members tests were indirectly using deprecated endpoints even in those tests which are not marked with `deprecated_endpoints`. These tests initialization were using `flush_events_for`, which is calling `/r0/events`, but this initialization is not strictly needed because there's no further call to `/r0/events` (so it does not need to track an `eventstream_token`).

One side effect of calling the `/r0/events` endpoint was that presence for the users [was updated ](https://github.com/matrix-org/synapse/blob/4c4889cac0e6f7df4689287b9fddea1bf8b15b7f/synapse/handlers/events.py#L70-L74), which enabled some of the test to do some assertions regarding presence events. Because of the removal of `flush_events_for` during the test set up, the tests related to presence have been changed to explicitly set the presence of the corresponding users.