### PR TITLE
Remove `origin` from events and assertions

### DIFF
--- a/lib/SyTest/Federation/Client.pm
+++ b/lib/SyTest/Federation/Client.pm
@@ -240,7 +240,6 @@ sub join_room
             auth_events content depth prev_events room_id sender
             state_key type ) ),
 
-         origin           => $store->server_name,
          origin_server_ts => $self->time_ms,
       );
 

--- a/lib/SyTest/Federation/Client.pm
+++ b/lib/SyTest/Federation/Client.pm
@@ -240,6 +240,9 @@ sub join_room
             auth_events content depth prev_events room_id sender
             state_key type ) ),
 
+         # The spec does not require the origin field, but Dendrite does. This can be removed
+         # once this issue gets solved: https://github.com/matrix-org/dendrite/issues/2736
+         origin           => $store->server_name,
          origin_server_ts => $self->time_ms,
       );
 

--- a/lib/SyTest/Federation/Client.pm
+++ b/lib/SyTest/Federation/Client.pm
@@ -240,9 +240,6 @@ sub join_room
             auth_events content depth prev_events room_id sender
             state_key type ) ),
 
-         # The spec does not require the origin field, but Dendrite does. This can be removed
-         # once this issue gets solved: https://github.com/matrix-org/dendrite/issues/2736
-         origin           => $store->server_name,
          origin_server_ts => $self->time_ms,
       );
 

--- a/lib/SyTest/Federation/Datastore.pm
+++ b/lib/SyTest/Federation/Datastore.pm
@@ -194,6 +194,9 @@ sub create_event
 
    my $event = {
       %fields,
+      # The spec does not require the origin field, but Dendrite does. This can be removed
+      # once this issue gets solved: https://github.com/matrix-org/dendrite/issues/2736
+      origin           => $self->server_name,
       origin_server_ts => JSON::number( int( time() * 1000 )),
    };
 

--- a/lib/SyTest/Federation/Datastore.pm
+++ b/lib/SyTest/Federation/Datastore.pm
@@ -194,7 +194,6 @@ sub create_event
 
    my $event = {
       %fields,
-      origin           => $self->server_name,
       origin_server_ts => JSON::number( int( time() * 1000 )),
    };
 

--- a/lib/SyTest/Federation/Datastore.pm
+++ b/lib/SyTest/Federation/Datastore.pm
@@ -194,9 +194,6 @@ sub create_event
 
    my $event = {
       %fields,
-      # The spec does not require the origin field, but Dendrite does. This can be removed
-      # once this issue gets solved: https://github.com/matrix-org/dendrite/issues/2736
-      origin           => $self->server_name,
       origin_server_ts => JSON::number( int( time() * 1000 )),
    };
 

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -92,6 +92,9 @@ foreach my $versionprefix ( qw( v1 v2 ) ) {
                   user_id => $user_id,
                );
 
+               # The spec does not require the origin field, but Dendrite does. This can be removed
+               # once this issue gets solved: https://github.com/matrix-org/dendrite/issues/2736
+               $proto->{origin}           = $inbound_server->server_name;
                $proto->{origin_server_ts} = $inbound_server->time_ms;
 
                $req->respond_json( {
@@ -273,6 +276,9 @@ foreach my $versionprefix ( qw ( v1 v2 ) ) {
                   state_key type ) ),
 
                event_id         => $datastore->next_event_id,
+               # The spec does not require the origin field, but Dendrite does. This can be removed
+               # once this issue gets solved: https://github.com/matrix-org/dendrite/issues/2736
+               origin           => $local_server_name,
                origin_server_ts => $inbound_server->time_ms,
             );
 
@@ -441,6 +447,9 @@ test "Inbound /v1/send_join rejects incorrectly-signed joins",
 
          $join_event = $body->{event};
 
+         # The spec does not require the origin field, but Dendrite does. This can be removed
+         # once this issue gets solved: https://github.com/matrix-org/dendrite/issues/2736
+         $join_event->{origin} = $sytest_server_name;
          $join_event->{origin_server_ts} = $outbound_client->time_ms;
 
          if( $room_version eq '1' || $room_version eq '2' ) {
@@ -853,6 +862,9 @@ test "Outbound federation rejects send_join responses with no m.room.create even
                user_id => $user_id,
             );
 
+            # The spec does not require the origin field, but Dendrite does. This can be removed
+            # once this issue gets solved: https://github.com/matrix-org/dendrite/issues/2736
+            $proto->{origin}           = $inbound_server->server_name;
             $proto->{origin_server_ts} = $inbound_server->time_ms;
 
             $req->respond_json( {
@@ -941,6 +953,9 @@ test "Outbound federation rejects m.room.create events with an unknown room vers
                user_id => $user_id,
             );
 
+            # The spec does not require the origin field, but Dendrite does. This can be removed
+            # once this issue gets solved: https://github.com/matrix-org/dendrite/issues/2736
+            $proto->{origin}           = $inbound_server->server_name;
             $proto->{origin_server_ts} = $inbound_server->time_ms;
 
             $req->respond_json( {
@@ -1034,6 +1049,9 @@ test "Event with an invalid signature in the send_join response should not cause
                user_id => $user_id,
             );
 
+            # The spec does not require the origin field, but Dendrite does. This can be removed
+            # once this issue gets solved: https://github.com/matrix-org/dendrite/issues/2736
+            $proto->{origin}           = $inbound_server->server_name;
             $proto->{origin_server_ts} = $inbound_server->time_ms;
 
             $req->respond_json( {
@@ -1173,7 +1191,9 @@ test "Inbound: send_join rejects invalid JSON for room version 6",
             ( map { $_ => $protoevent->{$_} } qw(
                auth_events content depth prev_events room_id sender
                state_key type ) ),
-
+            # The spec does not require the origin field, but Dendrite does. This can be removed
+            # once this issue gets solved: https://github.com/matrix-org/dendrite/issues/2736
+            origin           => $local_server_name,
             origin_server_ts => $inbound_server->time_ms,
          );
          # Insert a "bad" value into the send join, in this case a float.

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -17,15 +17,13 @@ sub assert_is_valid_pdu {
    my ( $event ) = @_;
 
    assert_json_keys( $event, qw(
-      auth_events content depth hashes origin origin_server_ts
+      auth_events content depth hashes origin_server_ts
       prev_events room_id sender signatures type
    ));
 
    assert_json_list( $event->{auth_events} );
    assert_json_number( $event->{depth} );
    assert_json_object( $event->{hashes} );
-
-   assert_json_string( $event->{origin} );
 
    assert_json_number( $event->{origin_server_ts} );
    assert_json_list( $event->{prev_events} );
@@ -94,7 +92,6 @@ foreach my $versionprefix ( qw( v1 v2 ) ) {
                   user_id => $user_id,
                );
 
-               $proto->{origin}           = $inbound_server->server_name;
                $proto->{origin_server_ts} = $inbound_server->time_ms;
 
                $req->respond_json( {
@@ -276,7 +273,6 @@ foreach my $versionprefix ( qw ( v1 v2 ) ) {
                   state_key type ) ),
 
                event_id         => $datastore->next_event_id,
-               origin           => $local_server_name,
                origin_server_ts => $inbound_server->time_ms,
             );
 
@@ -445,7 +441,6 @@ test "Inbound /v1/send_join rejects incorrectly-signed joins",
 
          $join_event = $body->{event};
 
-         $join_event->{origin} = $sytest_server_name;
          $join_event->{origin_server_ts} = $outbound_client->time_ms;
 
          if( $room_version eq '1' || $room_version eq '2' ) {
@@ -858,7 +853,6 @@ test "Outbound federation rejects send_join responses with no m.room.create even
                user_id => $user_id,
             );
 
-            $proto->{origin}           = $inbound_server->server_name;
             $proto->{origin_server_ts} = $inbound_server->time_ms;
 
             $req->respond_json( {
@@ -947,7 +941,6 @@ test "Outbound federation rejects m.room.create events with an unknown room vers
                user_id => $user_id,
             );
 
-            $proto->{origin}           = $inbound_server->server_name;
             $proto->{origin_server_ts} = $inbound_server->time_ms;
 
             $req->respond_json( {
@@ -1041,7 +1034,6 @@ test "Event with an invalid signature in the send_join response should not cause
                user_id => $user_id,
             );
 
-            $proto->{origin}           = $inbound_server->server_name;
             $proto->{origin_server_ts} = $inbound_server->time_ms;
 
             $req->respond_json( {
@@ -1182,7 +1174,6 @@ test "Inbound: send_join rejects invalid JSON for room version 6",
                auth_events content depth prev_events room_id sender
                state_key type ) ),
 
-            origin           => $local_server_name,
             origin_server_ts => $inbound_server->time_ms,
          );
          # Insert a "bad" value into the send join, in this case a float.

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -92,9 +92,6 @@ foreach my $versionprefix ( qw( v1 v2 ) ) {
                   user_id => $user_id,
                );
 
-               # The spec does not require the origin field, but Dendrite does. This can be removed
-               # once this issue gets solved: https://github.com/matrix-org/dendrite/issues/2736
-               $proto->{origin}           = $inbound_server->server_name;
                $proto->{origin_server_ts} = $inbound_server->time_ms;
 
                $req->respond_json( {
@@ -276,9 +273,6 @@ foreach my $versionprefix ( qw ( v1 v2 ) ) {
                   state_key type ) ),
 
                event_id         => $datastore->next_event_id,
-               # The spec does not require the origin field, but Dendrite does. This can be removed
-               # once this issue gets solved: https://github.com/matrix-org/dendrite/issues/2736
-               origin           => $local_server_name,
                origin_server_ts => $inbound_server->time_ms,
             );
 
@@ -447,9 +441,6 @@ test "Inbound /v1/send_join rejects incorrectly-signed joins",
 
          $join_event = $body->{event};
 
-         # The spec does not require the origin field, but Dendrite does. This can be removed
-         # once this issue gets solved: https://github.com/matrix-org/dendrite/issues/2736
-         $join_event->{origin} = $sytest_server_name;
          $join_event->{origin_server_ts} = $outbound_client->time_ms;
 
          if( $room_version eq '1' || $room_version eq '2' ) {
@@ -862,9 +853,6 @@ test "Outbound federation rejects send_join responses with no m.room.create even
                user_id => $user_id,
             );
 
-            # The spec does not require the origin field, but Dendrite does. This can be removed
-            # once this issue gets solved: https://github.com/matrix-org/dendrite/issues/2736
-            $proto->{origin}           = $inbound_server->server_name;
             $proto->{origin_server_ts} = $inbound_server->time_ms;
 
             $req->respond_json( {
@@ -953,9 +941,6 @@ test "Outbound federation rejects m.room.create events with an unknown room vers
                user_id => $user_id,
             );
 
-            # The spec does not require the origin field, but Dendrite does. This can be removed
-            # once this issue gets solved: https://github.com/matrix-org/dendrite/issues/2736
-            $proto->{origin}           = $inbound_server->server_name;
             $proto->{origin_server_ts} = $inbound_server->time_ms;
 
             $req->respond_json( {
@@ -1049,9 +1034,6 @@ test "Event with an invalid signature in the send_join response should not cause
                user_id => $user_id,
             );
 
-            # The spec does not require the origin field, but Dendrite does. This can be removed
-            # once this issue gets solved: https://github.com/matrix-org/dendrite/issues/2736
-            $proto->{origin}           = $inbound_server->server_name;
             $proto->{origin_server_ts} = $inbound_server->time_ms;
 
             $req->respond_json( {
@@ -1191,9 +1173,7 @@ test "Inbound: send_join rejects invalid JSON for room version 6",
             ( map { $_ => $protoevent->{$_} } qw(
                auth_events content depth prev_events room_id sender
                state_key type ) ),
-            # The spec does not require the origin field, but Dendrite does. This can be removed
-            # once this issue gets solved: https://github.com/matrix-org/dendrite/issues/2736
-            origin           => $local_server_name,
+
             origin_server_ts => $inbound_server->time_ms,
          );
          # Insert a "bad" value into the send join, in this case a float.

--- a/tests/50federation/32room-getevent.pl
+++ b/tests/50federation/32room-getevent.pl
@@ -21,7 +21,7 @@ test "Inbound federation can return events",
          my ( $body ) = @_;
          log_if_fail "Body", $body;
 
-         assert_json_keys( $body, qw( origin origin_server_ts pdus ));
+         assert_json_keys( $body, qw( origin_server_ts pdus ));
          assert_json_list( my $events = $body->{pdus} );
 
          @$events == 1 or
@@ -30,7 +30,7 @@ test "Inbound federation can return events",
 
          # Check that the string fields seem right
          assert_eq( $event->{$_}, $member_event->{$_},
-            "event $_" ) for qw( depth origin room_id sender state_key type );
+            "event $_" ) for qw( depth room_id sender state_key type );
 
          if ( $room->room_version eq "1" || $room->room_version eq "2" ) {
             assert_eq( $event->{event_id}, $member_event->{event_id}, "event_id" );

--- a/tests/50federation/35room-invite.pl
+++ b/tests/50federation/35room-invite.pl
@@ -600,9 +600,6 @@ test "Inbound federation rejects incorrectly-signed invite rejections",
 
          $leave_event = $resp->{event};
 
-         # The spec does not require the origin field, but Dendrite does. This can be removed
-         # once this issue gets solved: https://github.com/matrix-org/dendrite/issues/2736
-         $leave_event->{origin} = $outbound_client->server_name;
          $leave_event->{origin_server_ts} = JSON::number($outbound_client->time_ms);
          $leave_event->{event_id} = $leave_event_id = $outbound_client->datastore->next_event_id();
 
@@ -911,9 +908,6 @@ test "Inbound federation rejects invite rejections which include invalid JSON fo
                auth_events content depth prev_events room_id sender
                state_key type)),
 
-            # The spec does not require the origin field, but Dendrite does. This can be removed
-            # once this issue gets solved: https://github.com/matrix-org/dendrite/issues/2736
-            origin           => $outbound_client->server_name,
             origin_server_ts => $inbound_server->time_ms,
          );
          # Insert a "bad" value into the send leave, in this case a float.

--- a/tests/50federation/35room-invite.pl
+++ b/tests/50federation/35room-invite.pl
@@ -600,6 +600,9 @@ test "Inbound federation rejects incorrectly-signed invite rejections",
 
          $leave_event = $resp->{event};
 
+         # The spec does not require the origin field, but Dendrite does. This can be removed
+         # once this issue gets solved: https://github.com/matrix-org/dendrite/issues/2736
+         $leave_event->{origin} = $outbound_client->server_name;
          $leave_event->{origin_server_ts} = JSON::number($outbound_client->time_ms);
          $leave_event->{event_id} = $leave_event_id = $outbound_client->datastore->next_event_id();
 
@@ -908,6 +911,9 @@ test "Inbound federation rejects invite rejections which include invalid JSON fo
                auth_events content depth prev_events room_id sender
                state_key type)),
 
+            # The spec does not require the origin field, but Dendrite does. This can be removed
+            # once this issue gets solved: https://github.com/matrix-org/dendrite/issues/2736
+            origin           => $outbound_client->server_name,
             origin_server_ts => $inbound_server->time_ms,
          );
          # Insert a "bad" value into the send leave, in this case a float.

--- a/tests/50federation/35room-invite.pl
+++ b/tests/50federation/35room-invite.pl
@@ -68,12 +68,10 @@ foreach my $prefix ( qw( v1 v2 )) {
                }
 
                # this should be a member event
-               assert_json_keys( $body, qw( origin room_id sender type ));
+               assert_json_keys( $body, qw( room_id sender type ));
 
                assert_eq( $body->{type}, "m.room.member",
                   'event type' );
-               assert_eq( $body->{origin}, $user->http->server_name,
-                  'event origin' );
                assert_eq( $body->{room_id}, $room_id,
                   'event room_id' );
                assert_eq( $body->{sender}, $user->user_id,
@@ -226,7 +224,7 @@ sub invite_server
 
          # Response should be the same event reflected back
          assert_eq( $event->{$_}, $invitation->{$_},
-            "response $_" ) for qw( event_id origin room_id sender state_key type );
+            "response $_" ) for qw( event_id room_id sender state_key type );
 
          # server should have signed it
          exists $event->{signatures}{$first_home_server} or
@@ -602,7 +600,6 @@ test "Inbound federation rejects incorrectly-signed invite rejections",
 
          $leave_event = $resp->{event};
 
-         $leave_event->{origin} = $outbound_client->server_name;
          $leave_event->{origin_server_ts} = JSON::number($outbound_client->time_ms);
          $leave_event->{event_id} = $leave_event_id = $outbound_client->datastore->next_event_id();
 
@@ -911,7 +908,6 @@ test "Inbound federation rejects invite rejections which include invalid JSON fo
                auth_events content depth prev_events room_id sender
                state_key type)),
 
-            origin           => $outbound_client->server_name,
             origin_server_ts => $inbound_server->time_ms,
          );
          # Insert a "bad" value into the send leave, in this case a float.


### PR DESCRIPTION
Related to: https://github.com/matrix-org/matrix-spec/pull/998

Setting `origin` field in events/PDUs is not required any more, so I've removed assertions and assignments to this field.