### PR TITLE
Assert default field is present in pushrules

### DIFF
--- a/tests/61push/02add_rules.pl
+++ b/tests/61push/02add_rules.pl
@@ -11,9 +11,11 @@ sub check_add_push_rule
 
       log_if_fail "Rule", $rule;
 
-      assert_json_keys( $rule, qw( rule_id actions enabled ) );
+      assert_json_keys( $rule, qw( rule_id actions enabled default ) );
 
       assert_json_boolean( $rule->{enabled} );
+
+      assert_json_boolean( $rule->{default} );
 
       assert_eq( $rule->{rule_id}, $rule_id );
    };


### PR DESCRIPTION
Relates to https://github.com/matrix-org/synapse/pull/13904#issuecomment-1261387124

Signed-off-by: Nicolas Werner <nicolas.werner@hotmail.de>