### PR TITLE
Check `state`/`ephemeral` only if required

### DIFF
--- a/tests/10apidoc/09synced.pl
+++ b/tests/10apidoc/09synced.pl
@@ -357,11 +357,13 @@ sub assert_room_members {
    my ( $body, $room_id, $memberships ) = @_;
 
    my $room = $body->{rooms}{join}{$room_id};
-   my $timeline = $room->{timeline}{events};
 
    #log_if_fail "Room", $room;
-
-   assert_json_keys( $room, qw( timeline state ephemeral ));
+   
+   if ( scalar @{ $memberships } == 0 && !exists ( $room->{state} ) ) {
+      return 1;
+   }
+   assert_json_keys( $room, qw( state ));
 
    return assert_state_room_members_match( $room->{state}{events}, $memberships );
 }

--- a/tests/30rooms/30history-visibility.pl
+++ b/tests/30rooms/30history-visibility.pl
@@ -417,7 +417,7 @@ foreach my $i (
                my ( $body ) = @_;
 
                my $room = $body->{rooms}{join}{$room_id};
-               assert_json_keys( $room, qw( timeline state ephemeral ));
+               assert_json_keys( $room, qw( timeline ));
                assert_json_keys( $room->{timeline}, qw( events limited prev_batch ));
 
                # look at the last four events
@@ -481,7 +481,7 @@ test "Only see history_visibility changes on boundaries",
          my ( $body ) = @_;
 
          my $room = $body->{rooms}{join}{$room_id};
-         assert_json_keys( $room, qw( timeline state ephemeral ));
+         assert_json_keys( $room, qw( timeline ));
          assert_json_keys( $room->{timeline}, qw( events limited prev_batch ));
 
          # look at the last four events

--- a/tests/31sync/03joined.pl
+++ b/tests/31sync/03joined.pl
@@ -23,10 +23,15 @@ test "Can sync a joined room",
          my ( $body ) = @_;
 
          my $room = $body->{rooms}{join}{$room_id};
-         assert_json_keys( $room, qw( timeline state ephemeral ));
+         assert_json_keys( $room, qw( timeline ));
          assert_json_keys( $room->{timeline}, qw( events limited prev_batch ));
-         assert_json_keys( $room->{state}, qw( events ));
-         assert_json_keys( $room->{ephemeral}, qw( events ));
+         
+         if (exists($room->{state})) {
+            assert_json_empty_list( $room->{state}{events} );
+         }
+         if (exists($room->{ephemeral})) {
+            assert_json_empty_list( $room->{ephemeral}{events} );
+         }
 
          matrix_sync_again( $user, filter => $filter_id );
       })->then( sub {
@@ -67,11 +72,14 @@ test "Full state sync includes joined rooms",
          my ( $body ) = @_;
 
          my $room = $body->{rooms}{join}{$room_id};
-
-         assert_json_keys( $room, qw( timeline state ephemeral ));
-         assert_json_keys( $room->{timeline}, qw( events limited prev_batch ));
-         assert_json_keys( $room->{state}, qw( events ));
-         assert_json_keys( $room->{ephemeral}, qw( events ));
+         
+         assert_json_keys( $room, qw( state ));
+         if (exists($room->{timeline})) {
+            assert_json_keys( $room->{timeline}, qw( events limited prev_batch ));
+         }
+         if (exists($room->{ephemeral})) {
+            assert_json_empty_list( $room->{ephemeral}{events} );
+         }
 
          Future->done(1)
       })
@@ -103,10 +111,14 @@ test "Newly joined room is included in an incremental sync",
          my ( $body ) = @_;
 
          my $room = $body->{rooms}{join}{$room_id};
-         assert_json_keys( $room, qw( timeline state ephemeral ));
+         assert_json_keys( $room, qw( timeline ));
          assert_json_keys( $room->{timeline}, qw( events limited prev_batch ));
-         assert_json_keys( $room->{state}, qw( events ));
-         assert_json_keys( $room->{ephemeral}, qw( events ));
+         if (exists($room->{state})) {
+            assert_json_empty_list( $room->{state}{events} );
+         }
+         if (exists($room->{ephemeral})) {
+            assert_json_empty_list( $room->{ephemeral}{events} );
+         }
 
          matrix_sync_again( $user, filter => $filter_id );
       })->then( sub {

--- a/tests/31sync/04timeline.pl
+++ b/tests/31sync/04timeline.pl
@@ -32,7 +32,7 @@ test "Can sync a room with a single message",
          my ( $body ) = @_;
 
          my $room = $body->{rooms}{join}{$room_id};
-         assert_json_keys( $room, qw( timeline state ephemeral ));
+         assert_json_keys( $room, qw( timeline ));
          assert_json_keys( $room->{timeline}, qw( events limited prev_batch ));
          @{ $room->{timeline}{events} } == 2
             or die "Expected two timeline events";
@@ -87,7 +87,7 @@ test "Can sync a room with a message with a transaction id",
          my ( $body ) = @_;
 
          my $room = $body->{rooms}{join}{$room_id};
-         assert_json_keys( $room, qw( timeline state ephemeral ));
+         assert_json_keys( $room, qw( timeline ));
          assert_json_keys( $room->{timeline}, qw( events limited prev_batch ));
          @{ $room->{timeline}{events} } == 1
             or die "Expected only one timeline event";
@@ -148,10 +148,11 @@ test "A message sent after an initial sync appears in the timeline of an increme
          log_if_fail "Sync response", $body;
 
          my $room = $body->{rooms}{join}{$room_id};
-         assert_json_keys( $room, qw( timeline state ephemeral ));
-         assert_json_keys( $room->{state}, qw( events ));
+         assert_json_keys( $room, qw( timeline  ));
          assert_json_keys( $room->{timeline}, qw( events limited prev_batch ));
-         assert_json_empty_list( $room->{state}{events} );
+         if (exists($room->{state})) {
+            assert_json_empty_list( $room->{state}{events} );
+         }
          @{ $room->{timeline}{events} } == 1
             or die "Expected only one timeline event";
          $room->{timeline}{events}[0]{event_id} eq $event_id
@@ -206,10 +207,11 @@ test "A filtered timeline reaches its limit",
          my ( $body ) = @_;
 
          my $room = $body->{rooms}{join}{$room_id};
-         assert_json_keys( $room, qw( timeline state ephemeral ));
-         assert_json_keys( $room->{state}, qw( events ));
+         assert_json_keys( $room, qw( timeline ));
          assert_json_keys( $room->{timeline}, qw( events limited prev_batch ));
-         assert_json_empty_list( $room->{state}{events} );
+         if (exists($room->{state})) {
+            assert_json_empty_list( $room->{state}{events} );
+         }
          @{ $room->{timeline}{events} } == 1
             or die "Expected only one timeline event";
          $room->{timeline}{events}[0]{event_id} eq $event_id
@@ -247,8 +249,10 @@ test "Syncing a new room with a large timeline limit isn't limited",
          my ( $body ) = @_;
 
          my $room = $body->{rooms}{join}{$room_id};
-         assert_json_keys( $room, qw( timeline state ephemeral ));
-         assert_json_keys( $room->{state}, qw( events ));
+         assert_json_keys( $room, qw( timeline ));
+         if (exists($room->{state})) {
+            assert_json_empty_list( $room->{state}{events} );
+         }
          assert_json_keys( $room->{timeline}, qw( events limited prev_batch ));
          (not $room->{timeline}{limited})
             or die "Did not expect timeline to be limited";
@@ -297,7 +301,7 @@ test "A full_state incremental update returns only recent timeline",
          my ( $body ) = @_;
 
          my $room = $body->{rooms}{join}{$room_id};
-         assert_json_keys( $room, qw( timeline state ephemeral ));
+         assert_json_keys( $room, qw( timeline ));
 
          @{ $room->{timeline}{events} } == 1
              or die "Expected only one timeline event";
@@ -343,8 +347,7 @@ test "A prev_batch token can be used in the v1 messages API",
          my ( $body ) = @_;
 
          my $room = $body->{rooms}{join}{$room_id};
-         assert_json_keys( $room, qw( timeline state ephemeral ));
-         assert_json_keys( $room->{state}, qw( events ));
+         assert_json_keys( $room, qw( timeline ));
          assert_json_keys( $room->{timeline}, qw( events limited prev_batch ));
          @{ $room->{timeline}{events} } == 1
             or die "Expected only one timeline event";
@@ -406,8 +409,7 @@ test "A prev_batch token from incremental sync can be used in the v1 messages AP
 
          log_if_fail "Sync for room", $room;
 
-         assert_json_keys( $room, qw( timeline state ephemeral ));
-         assert_json_keys( $room->{state}, qw( events ));
+         assert_json_keys( $room, qw( timeline ));
          assert_json_keys( $room->{timeline}, qw( events limited prev_batch ));
          @{ $room->{timeline}{events} } == 1
             or die "Expected only one timeline event";

--- a/tests/31sync/07invited.pl
+++ b/tests/31sync/07invited.pl
@@ -133,10 +133,14 @@ test "Newly joined room is included in an incremental sync after invite",
          my ( $room ) = @_;
          log_if_fail "post-join sync", $room;
 
-         assert_json_keys( $room, qw( timeline state ephemeral ));
+         assert_json_keys( $room, qw( timeline ));
          assert_json_keys( $room->{timeline}, qw( events limited prev_batch ));
-         assert_json_keys( $room->{state}, qw( events ));
-         assert_json_keys( $room->{ephemeral}, qw( events ));
+         if (exists($room->{state})) {
+            assert_json_empty_list( $room->{state}{events} );
+         }
+         if (exists($room->{ephemeral})) {
+            assert_json_empty_list( $room->{ephemeral}{events} );
+         }
 
          Future->done(1);
       })

--- a/tests/31sync/09archived.pl
+++ b/tests/31sync/09archived.pl
@@ -57,10 +57,11 @@ test "Newly left rooms appear in the leave section of incremental sync",
          my ( $body ) = @_;
 
          my $room = $body->{rooms}{leave}{$room_id};
-         assert_json_keys( $room, qw( timeline state ));
-
-         @{ $room->{state}{events} } == 0
-            or die "Expected no state events";
+         assert_json_keys( $room, qw( timeline ));
+         if ( exists ( $room->{state} ) ) {
+            @{ $room->{state}{events} } == 0
+               or die "Expected no state events";
+         }
 
          Future->done(1);
       });
@@ -101,10 +102,12 @@ test "We should see our own leave event, even if history_visibility is " .
          log_if_fail "sync result", $body;
 
          my $room = $body->{rooms}{leave}{$room_id};
-         assert_json_keys( $room, qw( timeline state ));
+         assert_json_keys( $room, qw( timeline ));
 
-         assert_eq( scalar @{ $room->{state}{events} }, 0,
-                    "state events" );
+         if ( exists ( $room->{state} ) ) {
+            @{ $room->{state}{events} } == 0
+               or die "Expected no state events";
+         }
 
          # we should see our own leave event
          assert_eq( scalar @{ $room->{timeline}{events} }, 1,
@@ -206,7 +209,7 @@ test "Newly left rooms appear in the leave section of gapped sync",
          my ( $body ) = @_;
 
          my $room = $body->{rooms}{leave}{$room_id_1};
-         assert_json_keys( $room, qw( timeline state ));
+         assert_json_keys( $room, qw( timeline ));
 
          Future->done(1);
       });
@@ -298,7 +301,7 @@ test "Left rooms appear in the leave section of full state sync",
          my ( $body ) = @_;
 
          my $room = $body->{rooms}{leave}{$room_id};
-         assert_json_keys( $room, qw( timeline state ));
+         assert_json_keys( $room, qw( timeline ));
 
          Future->done(1);
       });

--- a/tests/31sync/10archived-ban.pl
+++ b/tests/31sync/10archived-ban.pl
@@ -89,7 +89,7 @@ test "Newly banned rooms appear in the leave section of incremental sync",
          my ( $body ) = @_;
 
          my $room = $body->{rooms}{leave}{$room_id};
-         assert_json_keys( $room, qw( timeline state ));
+         assert_json_keys( $room, qw( timeline ));
 
          Future->done(1);
       });
@@ -134,7 +134,7 @@ test "Newly banned rooms appear in the leave section of incremental sync",
          my ( $body ) = @_;
 
          my $room = $body->{rooms}{leave}{$room_id};
-         assert_json_keys( $room, qw( timeline state ));
+         assert_json_keys( $room, qw( state ));
 
          Future->done(1);
       });

--- a/tests/31sync/13filtered_sync.pl
+++ b/tests/31sync/13filtered_sync.pl
@@ -22,7 +22,9 @@ test "Can pass a JSON filter as a query parameter",
 
          my $room = $body->{rooms}{join}{$room_id};
 
-         assert_json_empty_list( $room->{timeline}{events} );
+         if (exists($room->{timeline})) {
+             assert_json_empty_list( $room->{timeline}{events} );
+         }       
 
          @{ $room->{state}{events} } == 1
             or die "Expected a single state event because of the filter";

--- a/tests/31sync/17peeking.pl
+++ b/tests/31sync/17peeking.pl
@@ -33,15 +33,18 @@ test "Local users can peek into world_readable rooms by room ID",
          log_if_fail "first sync response", $body;
 
          my $room = $body->{rooms}{peek}{$room_id};
-         assert_json_keys( $room, qw( timeline state ephemeral ));
+         assert_json_keys( $room, qw( timeline ));
          assert_json_keys( $room->{timeline}, qw( events limited prev_batch ));
-         assert_json_keys( $room->{state}, qw( events ));
-         assert_json_keys( $room->{ephemeral}, qw( events ));
+         if (exists($room->{state})) {
+            assert_json_empty_list( $room->{state}{events} );
+         }
+         if (exists($room->{ephemeral})) {
+            assert_json_empty_list( $room->{ephemeral}{events} );
+         }
 
          assert_ok( $room->{timeline}->{events}->[0]->{type} eq 'm.room.create', "peek has m.room.create" );
          assert_ok( $room->{timeline}->{events}->[-1]->{type} eq 'm.room.message', "peek has message type" );
          assert_ok( $room->{timeline}->{events}->[-1]->{content}->{body} eq 'something to peek', "peek has message body" );
-         assert_ok( @{$room->{state}->{events}} == 0 );
 
          assert_ok( scalar keys(%{$body->{rooms}{join}}) == 0, "no joined rooms present");
 


### PR DESCRIPTION
Removes some `rooms.join.$roomID.state/ephemeral` checks, since they are not required as per the spec (if I read the spec right)