### PR TITLE
Fix no servers having historical state after purging events

### DIFF
--- a/tests/48admin.pl
+++ b/tests/48admin.pl
@@ -274,10 +274,10 @@ test "Can backfill purged history",
       ->then( sub {
          matrix_join_room_synced( $remote_user, $room_id )
       })->then( sub {
-         # Force the remote server to backfill all of the events to the beginning of the
-         # room. We want to make sure to de-outlier all of the state (like the invite
-         # event) before the join so it's available later when `server-0` asks about it
-         # again.
+         # Force the remote server (`server-1`) to backfill all of the events to the
+         # beginning of the room. We want to make sure to de-outlier all of the state
+         # (like the invite event) before the join so it's available later when
+         # `server-0` asks about it again.
          matrix_get_room_messages( $remote_user, $room_id, limit => 100 )
       })->then( sub {
          matrix_put_room_state( $user, $room_id,

--- a/tests/48admin.pl
+++ b/tests/48admin.pl
@@ -28,219 +28,219 @@ sub await_purge_complete {
    }, while => sub { $_[0]->get eq 'active' });
 }
 
-test "/whois",
-   requires => [ $main::API_CLIENTS[0] ],
+# test "/whois",
+#    requires => [ $main::API_CLIENTS[0] ],
 
-   do => sub {
-      my ( $http ) = @_;
+#    do => sub {
+#       my ( $http ) = @_;
 
-      my $user;
+#       my $user;
 
-      # Register a user, rather than using a fixture, because we want to very
-      # tightly control the actions taken by that user.
-      # Conceivably this API may change based on the number of API calls the
-      # user made, for instance.
+#       # Register a user, rather than using a fixture, because we want to very
+#       # tightly control the actions taken by that user.
+#       # Conceivably this API may change based on the number of API calls the
+#       # user made, for instance.
 
-      matrix_register_user( $http, "admin" )
-      ->then( sub {
-         ( $user ) = @_;
+#       matrix_register_user( $http, "admin" )
+#       ->then( sub {
+#          ( $user ) = @_;
 
-         # Synapse flushes IP addresses to the database every 5 seconds, so we
-         # need to keep checking because the IP address won't appear for a few
-         # seconds (unless the worker that flushes the IP addresses is the same
-         # as the one that handles /whois).
-         repeat_until_true sub {
-            do_request_json_for( $user,
-               method => "GET",
-               uri    => "/v3/admin/whois/".$user->user_id,
-            )->then( sub {
-               my ( $body ) = @_;
+#          # Synapse flushes IP addresses to the database every 5 seconds, so we
+#          # need to keep checking because the IP address won't appear for a few
+#          # seconds (unless the worker that flushes the IP addresses is the same
+#          # as the one that handles /whois).
+#          repeat_until_true sub {
+#             do_request_json_for( $user,
+#                method => "GET",
+#                uri    => "/v3/admin/whois/".$user->user_id,
+#             )->then( sub {
+#                my ( $body ) = @_;
 
-               assert_json_keys( $body, qw( devices user_id ) );
-               assert_eq( $body->{user_id}, $user->user_id, "user_id" );
-               assert_json_object( $body->{devices} );
+#                assert_json_keys( $body, qw( devices user_id ) );
+#                assert_eq( $body->{user_id}, $user->user_id, "user_id" );
+#                assert_json_object( $body->{devices} );
 
-               # Whether we've found a connection with the right keys
-               # (ip, last_seen, user_agent).
-               my $found_connections = 0;
+#                # Whether we've found a connection with the right keys
+#                # (ip, last_seen, user_agent).
+#                my $found_connections = 0;
 
-               foreach my $value ( values %{ $body->{devices} } ) {
-                  assert_json_keys( $value, "sessions" );
-                  assert_json_list( $value->{sessions} );
-                  assert_json_keys( $value->{sessions}[0], "connections" );
-                  assert_json_list( $value->{sessions}[0]{connections} );
-                  # The `connections` may not yet be populated. If there *is* a connection,
-                  # we check that it has the right shape. If `connections` is still empty, we
-                  # tell `repeat_until_true` to retry by returning a falsey value.
-                  foreach my $connection ( @{ $value->{sessions}[0]{connections} } ) {
-                     assert_json_keys(
-                        $connection,
-                        qw( ip last_seen user_agent )
-                     );
+#                foreach my $value ( values %{ $body->{devices} } ) {
+#                   assert_json_keys( $value, "sessions" );
+#                   assert_json_list( $value->{sessions} );
+#                   assert_json_keys( $value->{sessions}[0], "connections" );
+#                   assert_json_list( $value->{sessions}[0]{connections} );
+#                   # The `connections` may not yet be populated. If there *is* a connection,
+#                   # we check that it has the right shape. If `connections` is still empty, we
+#                   # tell `repeat_until_true` to retry by returning a falsey value.
+#                   foreach my $connection ( @{ $value->{sessions}[0]{connections} } ) {
+#                      assert_json_keys(
+#                         $connection,
+#                         qw( ip last_seen user_agent )
+#                      );
 
-                     $found_connections = 1;
-                  }
-               }
+#                      $found_connections = 1;
+#                   }
+#                }
 
-               Future->done( $found_connections );
-            });
-         }, initial_delay => 0.5;
-      });
-   };
+#                Future->done( $found_connections );
+#             });
+#          }, initial_delay => 0.5;
+#       });
+#    };
 
-test "/purge_history",
-   requires => [ local_admin_fixture(), local_user_and_room_fixtures() ],
-   implementation_specific => ['synapse'],
+# test "/purge_history",
+#    requires => [ local_admin_fixture(), local_user_and_room_fixtures() ],
+#    implementation_specific => ['synapse'],
 
-   do => sub {
-      my ( $admin, $user, $room_id ) = @_;
+#    do => sub {
+#       my ( $admin, $user, $room_id ) = @_;
 
-      my $last_event_id;
+#       my $last_event_id;
 
-      matrix_put_room_state( $user, $room_id,
-         type    => "m.room.name",
-         content => { name => "A room name" },
-      )->then( sub {
-         matrix_sync( $user )
-      })->then( sub {
-         repeat( sub {
-            my $msgnum = $_[0];
+#       matrix_put_room_state( $user, $room_id,
+#          type    => "m.room.name",
+#          content => { name => "A room name" },
+#       )->then( sub {
+#          matrix_sync( $user )
+#       })->then( sub {
+#          repeat( sub {
+#             my $msgnum = $_[0];
 
-            matrix_send_room_text_message_synced( $user, $room_id,
-               body => "Message $msgnum",
-            )
-         }, foreach => [ 1 .. 10 ])
-      })->then( sub {
-         ( $last_event_id ) = @_;
+#             matrix_send_room_text_message_synced( $user, $room_id,
+#                body => "Message $msgnum",
+#             )
+#          }, foreach => [ 1 .. 10 ])
+#       })->then( sub {
+#          ( $last_event_id ) = @_;
 
-         await_message_in_room( $user, $room_id, $last_event_id ),
-      })->then( sub {
-         do_request_json_for( $user,
-            method   => "POST",
-            full_uri => "/_synapse/admin/v1/purge_history/$room_id/${ \uri_escape( $last_event_id ) }",
-            content  => {}
-         )->main::expect_http_403;  # Must be server admin
-      })->then( sub {
-         do_request_json_for( $admin,
-            method   => "POST",
-            full_uri => "/_synapse/admin/v1/purge_history/$room_id/${ \uri_escape( $last_event_id ) }",
-            content  => {}
-         )
-      })->then( sub {
-         my ( $body ) = @_;
+#          await_message_in_room( $user, $room_id, $last_event_id ),
+#       })->then( sub {
+#          do_request_json_for( $user,
+#             method   => "POST",
+#             full_uri => "/_synapse/admin/v1/purge_history/$room_id/${ \uri_escape( $last_event_id ) }",
+#             content  => {}
+#          )->main::expect_http_403;  # Must be server admin
+#       })->then( sub {
+#          do_request_json_for( $admin,
+#             method   => "POST",
+#             full_uri => "/_synapse/admin/v1/purge_history/$room_id/${ \uri_escape( $last_event_id ) }",
+#             content  => {}
+#          )
+#       })->then( sub {
+#          my ( $body ) = @_;
 
-         assert_json_keys( $body, "purge_id" );
-         my $purge_id = $body->{purge_id};
-         await_purge_complete( $admin, $purge_id );
-      })->then( sub {
-         my ( $purge_status ) = @_;
-         assert_eq( $purge_status, 'complete' );
+#          assert_json_keys( $body, "purge_id" );
+#          my $purge_id = $body->{purge_id};
+#          await_purge_complete( $admin, $purge_id );
+#       })->then( sub {
+#          my ( $purge_status ) = @_;
+#          assert_eq( $purge_status, 'complete' );
 
-         # Test that /sync with an existing token still works.
-         matrix_sync_again( $user )
-      })->then( sub {
-         # Test that an initial /sync has the correct data.
-         matrix_sync( $user )
-      })->then( sub {
-         my ( $body ) = @_;
+#          # Test that /sync with an existing token still works.
+#          matrix_sync_again( $user )
+#       })->then( sub {
+#          # Test that an initial /sync has the correct data.
+#          matrix_sync( $user )
+#       })->then( sub {
+#          my ( $body ) = @_;
 
-         assert_json_keys( $body->{rooms}{join}, $room_id );
-         my $room =  $body->{rooms}{join}{$room_id};
+#          assert_json_keys( $body->{rooms}{join}, $room_id );
+#          my $room =  $body->{rooms}{join}{$room_id};
 
-         log_if_fail( "Room", $room->{timeline}{events} );
+#          log_if_fail( "Room", $room->{timeline}{events} );
 
-         # The only message event should be the last one.
-         all {
-            $_->{type} ne "m.room.message" || $_->{event_id} eq $last_event_id
-         } @{ $room->{timeline}{events} } or die "Expected no message events";
+#          # The only message event should be the last one.
+#          all {
+#             $_->{type} ne "m.room.message" || $_->{event_id} eq $last_event_id
+#          } @{ $room->{timeline}{events} } or die "Expected no message events";
 
-         # Ensure we still see the state.
-         foreach my $expected_type( qw(
-            m.room.create
-            m.room.member
-            m.room.power_levels
-            m.room.name
-         ) ) {
-            any { $_->{type} eq $expected_type } @{ $room->{state}{events} }
-               or die "Expected state event of type $expected_type";
-         }
+#          # Ensure we still see the state.
+#          foreach my $expected_type( qw(
+#             m.room.create
+#             m.room.member
+#             m.room.power_levels
+#             m.room.name
+#          ) ) {
+#             any { $_->{type} eq $expected_type } @{ $room->{state}{events} }
+#                or die "Expected state event of type $expected_type";
+#          }
 
-         Future->done( 1 );
-      })
-   };
+#          Future->done( 1 );
+#       })
+#    };
 
-test "/purge_history by ts",
-   requires => [ local_admin_fixture(), local_user_and_room_fixtures() ],
-   implementation_specific => ['synapse'],
+# test "/purge_history by ts",
+#    requires => [ local_admin_fixture(), local_user_and_room_fixtures() ],
+#    implementation_specific => ['synapse'],
 
-   do => sub {
-      my ( $admin, $user, $room_id ) = @_;
+#    do => sub {
+#       my ( $admin, $user, $room_id ) = @_;
 
-      my ($last_event_id, $last_event_ts);
+#       my ($last_event_id, $last_event_ts);
 
-      # we send 9 messages, get the current ts, and
-      # then send one more.
-      matrix_put_room_state( $user, $room_id,
-         type    => "m.room.name",
-         content => { name => "A room name" },
-      )->then( sub {
-         matrix_sync( $user )
-      })->then( sub {
-         repeat( sub {
-            my $msgnum = $_[0];
+#       # we send 9 messages, get the current ts, and
+#       # then send one more.
+#       matrix_put_room_state( $user, $room_id,
+#          type    => "m.room.name",
+#          content => { name => "A room name" },
+#       )->then( sub {
+#          matrix_sync( $user )
+#       })->then( sub {
+#          repeat( sub {
+#             my $msgnum = $_[0];
 
-            matrix_send_room_text_message_synced( $user, $room_id,
-               body => "Message $msgnum",
-            )
-         }, foreach => [ 1 .. 9 ])
-      })->then( sub {
-         $last_event_ts = time();
-         delay(0.01);
-      })->then( sub {
-         matrix_send_room_text_message_synced( $user, $room_id,
-            body => "Message 10",
-         );
-      })->then( sub {
-         ( $last_event_id ) = @_;
-         await_message_in_room( $user, $room_id, $last_event_id ),
-      })->then( sub {
-         do_request_json_for( $admin,
-            method   => "POST",
-            full_uri => "/_synapse/admin/v1/purge_history/$room_id",
-            content  => {
-               purge_up_to_ts => int($last_event_ts * 1000),
-            },
-         )
-      })->then( sub {
-         my ( $body ) = @_;
+#             matrix_send_room_text_message_synced( $user, $room_id,
+#                body => "Message $msgnum",
+#             )
+#          }, foreach => [ 1 .. 9 ])
+#       })->then( sub {
+#          $last_event_ts = time();
+#          delay(0.01);
+#       })->then( sub {
+#          matrix_send_room_text_message_synced( $user, $room_id,
+#             body => "Message 10",
+#          );
+#       })->then( sub {
+#          ( $last_event_id ) = @_;
+#          await_message_in_room( $user, $room_id, $last_event_id ),
+#       })->then( sub {
+#          do_request_json_for( $admin,
+#             method   => "POST",
+#             full_uri => "/_synapse/admin/v1/purge_history/$room_id",
+#             content  => {
+#                purge_up_to_ts => int($last_event_ts * 1000),
+#             },
+#          )
+#       })->then( sub {
+#          my ( $body ) = @_;
 
-         assert_json_keys( $body, "purge_id" );
-         my $purge_id = $body->{purge_id};
-         await_purge_complete( $admin, $purge_id );
-      })->then( sub {
-         my ( $purge_status ) = @_;
-         assert_eq( $purge_status, 'complete' );
+#          assert_json_keys( $body, "purge_id" );
+#          my $purge_id = $body->{purge_id};
+#          await_purge_complete( $admin, $purge_id );
+#       })->then( sub {
+#          my ( $purge_status ) = @_;
+#          assert_eq( $purge_status, 'complete' );
 
-         # Test that /sync with an existing token still works.
-         matrix_sync_again( $user )
-      })->then( sub {
-         # Test that an initial /sync has the correct data.
-         matrix_sync( $user )
-      })->then( sub {
-         my ( $body ) = @_;
+#          # Test that /sync with an existing token still works.
+#          matrix_sync_again( $user )
+#       })->then( sub {
+#          # Test that an initial /sync has the correct data.
+#          matrix_sync( $user )
+#       })->then( sub {
+#          my ( $body ) = @_;
 
-         assert_json_keys( $body->{rooms}{join}, $room_id );
-         my $room =  $body->{rooms}{join}{$room_id};
+#          assert_json_keys( $body->{rooms}{join}, $room_id );
+#          my $room =  $body->{rooms}{join}{$room_id};
 
-         log_if_fail( "Room", $room->{timeline}{events} );
+#          log_if_fail( "Room", $room->{timeline}{events} );
 
-         # The only message event should be the last one.
-         all {
-            $_->{type} ne "m.room.message" || $_->{event_id} eq $last_event_id
-         } @{ $room->{timeline}{events} } or die "Expected no message events";
-         Future->done( 1 );
-      })
-   };
+#          # The only message event should be the last one.
+#          all {
+#             $_->{type} ne "m.room.message" || $_->{event_id} eq $last_event_id
+#          } @{ $room->{timeline}{events} } or die "Expected no message events";
+#          Future->done( 1 );
+#       })
+#    };
 
 test "Can backfill purged history",
    # we create three users:
@@ -273,6 +273,12 @@ test "Can backfill purged history",
       matrix_invite_user_to_room_synced( $user, $remote_user, $room_id )
       ->then( sub {
          matrix_join_room_synced( $remote_user, $room_id )
+      })->then( sub {
+         # Force the remote server to backfill all of the events to the beginning of the
+         # room. We want to make sure to de-outlier all of the state (like the invite
+         # event) before the join so it's available later when `server-0` asks about it
+         # again.
+         matrix_get_room_messages( $remote_user, $room_id, limit => 100 )
       })->then( sub {
          matrix_put_room_state( $user, $room_id,
             type    => "m.room.name",
@@ -398,81 +404,81 @@ test "Can backfill purged history",
    };
 
 
-multi_test "Shutdown room",
-   requires => [ local_admin_fixture(), local_user_fixtures( 2 ), remote_user_fixture(),
-      room_alias_name_fixture() ],
-   implementation_specific => ['synapse'],
+# multi_test "Shutdown room",
+#    requires => [ local_admin_fixture(), local_user_fixtures( 2 ), remote_user_fixture(),
+#       room_alias_name_fixture() ],
+#    implementation_specific => ['synapse'],
 
-   do => sub {
-      my ( $admin, $user, $dummy_user, $remote_user, $room_alias_name ) = @_;
+#    do => sub {
+#       my ( $admin, $user, $dummy_user, $remote_user, $room_alias_name ) = @_;
 
-      my $server_name = $user->http->server_name;
-      my $room_alias = "#$room_alias_name:$server_name";
+#       my $server_name = $user->http->server_name;
+#       my $room_alias = "#$room_alias_name:$server_name";
 
-      my ( $room_id, $new_room_id );
+#       my ( $room_id, $new_room_id );
 
-      matrix_create_room_synced( $user,
-         room_alias_name => $room_alias_name,
-      )->then( sub {
-         ( $room_id ) = @_;
+#       matrix_create_room_synced( $user,
+#          room_alias_name => $room_alias_name,
+#       )->then( sub {
+#          ( $room_id ) = @_;
 
-         matrix_invite_user_to_room_synced( $user, $remote_user, $room_id );
-      })->then( sub {
-         matrix_join_room_synced( $remote_user, $room_id );
-      })->then( sub {
-         do_request_json_for( $admin,
-            method   => "DELETE",
-            full_uri => "/_synapse/admin/v1/rooms/$room_id",
-            content  => {
-               new_room_user_id => $dummy_user->user_id,
-               block => JSON::true,
-               purge => JSON::false,
-            },
-         );
-      })->SyTest::pass_on_done( "Shutdown room returned success" )
-      ->then( sub {
-         my ( $body ) = @_;
+#          matrix_invite_user_to_room_synced( $user, $remote_user, $room_id );
+#       })->then( sub {
+#          matrix_join_room_synced( $remote_user, $room_id );
+#       })->then( sub {
+#          do_request_json_for( $admin,
+#             method   => "DELETE",
+#             full_uri => "/_synapse/admin/v1/rooms/$room_id",
+#             content  => {
+#                new_room_user_id => $dummy_user->user_id,
+#                block => JSON::true,
+#                purge => JSON::false,
+#             },
+#          );
+#       })->SyTest::pass_on_done( "Shutdown room returned success" )
+#       ->then( sub {
+#          my ( $body ) = @_;
 
-         $new_room_id = $body->{new_room_id};
+#          $new_room_id = $body->{new_room_id};
 
-         log_if_fail "Shutdown room, new room ID", $new_room_id;
+#          log_if_fail "Shutdown room, new room ID", $new_room_id;
 
-         matrix_send_room_text_message( $user, $room_id, body => "Hello" )
-         ->main::expect_http_403;
-      })->SyTest::pass_on_done( "User cannot post in room" )
-      ->then( sub {
-         matrix_join_room( $user, $room_id )
-         ->main::expect_http_403;
-      })->SyTest::pass_on_done( "User cannot rejoin room" )
-      ->then( sub {
-         matrix_invite_user_to_room( $remote_user, $user, $room_id )
-         ->main::expect_http_403;
-      })->SyTest::pass_on_done( "Remote users can't invite local users into room" )
-      ->then( sub {
-         do_request_json_for( $user,
-            method => "GET",
-            uri    => "/v3/directory/room/$room_alias",
-         );
-      })->then( sub {
-         my ( $body ) = @_;
+#          matrix_send_room_text_message( $user, $room_id, body => "Hello" )
+#          ->main::expect_http_403;
+#       })->SyTest::pass_on_done( "User cannot post in room" )
+#       ->then( sub {
+#          matrix_join_room( $user, $room_id )
+#          ->main::expect_http_403;
+#       })->SyTest::pass_on_done( "User cannot rejoin room" )
+#       ->then( sub {
+#          matrix_invite_user_to_room( $remote_user, $user, $room_id )
+#          ->main::expect_http_403;
+#       })->SyTest::pass_on_done( "Remote users can't invite local users into room" )
+#       ->then( sub {
+#          do_request_json_for( $user,
+#             method => "GET",
+#             uri    => "/v3/directory/room/$room_alias",
+#          );
+#       })->then( sub {
+#          my ( $body ) = @_;
 
-         assert_json_keys( $body, qw( room_id ));
+#          assert_json_keys( $body, qw( room_id ));
 
-         $body->{room_id} eq $new_room_id or die "Expected room_id to be new";
+#          $body->{room_id} eq $new_room_id or die "Expected room_id to be new";
 
-         pass( "Aliases were repointed" );
+#          pass( "Aliases were repointed" );
 
-         retry_until_success {
-            matrix_get_room_state( $user, $new_room_id,
-               type      => "m.room.name",
-               state_key => "",
-            )->SyTest::pass_on_done( "User was added to new room" )
-         }
-      })->then( sub {
-         matrix_send_room_text_message( $user, $new_room_id, body => "Hello" )
-         ->main::expect_http_403;
-      })->SyTest::pass_on_done( "User cannot send into new room" );
-   };
+#          retry_until_success {
+#             matrix_get_room_state( $user, $new_room_id,
+#                type      => "m.room.name",
+#                state_key => "",
+#             )->SyTest::pass_on_done( "User was added to new room" )
+#          }
+#       })->then( sub {
+#          matrix_send_room_text_message( $user, $new_room_id, body => "Hello" )
+#          ->main::expect_http_403;
+#       })->SyTest::pass_on_done( "User cannot send into new room" );
+#    };
 
 
 sub await_message_in_room

--- a/tests/48admin.pl
+++ b/tests/48admin.pl
@@ -28,219 +28,219 @@ sub await_purge_complete {
    }, while => sub { $_[0]->get eq 'active' });
 }
 
-# test "/whois",
-#    requires => [ $main::API_CLIENTS[0] ],
+test "/whois",
+   requires => [ $main::API_CLIENTS[0] ],
 
-#    do => sub {
-#       my ( $http ) = @_;
+   do => sub {
+      my ( $http ) = @_;
 
-#       my $user;
+      my $user;
 
-#       # Register a user, rather than using a fixture, because we want to very
-#       # tightly control the actions taken by that user.
-#       # Conceivably this API may change based on the number of API calls the
-#       # user made, for instance.
+      # Register a user, rather than using a fixture, because we want to very
+      # tightly control the actions taken by that user.
+      # Conceivably this API may change based on the number of API calls the
+      # user made, for instance.
 
-#       matrix_register_user( $http, "admin" )
-#       ->then( sub {
-#          ( $user ) = @_;
+      matrix_register_user( $http, "admin" )
+      ->then( sub {
+         ( $user ) = @_;
 
-#          # Synapse flushes IP addresses to the database every 5 seconds, so we
-#          # need to keep checking because the IP address won't appear for a few
-#          # seconds (unless the worker that flushes the IP addresses is the same
-#          # as the one that handles /whois).
-#          repeat_until_true sub {
-#             do_request_json_for( $user,
-#                method => "GET",
-#                uri    => "/v3/admin/whois/".$user->user_id,
-#             )->then( sub {
-#                my ( $body ) = @_;
+         # Synapse flushes IP addresses to the database every 5 seconds, so we
+         # need to keep checking because the IP address won't appear for a few
+         # seconds (unless the worker that flushes the IP addresses is the same
+         # as the one that handles /whois).
+         repeat_until_true sub {
+            do_request_json_for( $user,
+               method => "GET",
+               uri    => "/v3/admin/whois/".$user->user_id,
+            )->then( sub {
+               my ( $body ) = @_;
 
-#                assert_json_keys( $body, qw( devices user_id ) );
-#                assert_eq( $body->{user_id}, $user->user_id, "user_id" );
-#                assert_json_object( $body->{devices} );
+               assert_json_keys( $body, qw( devices user_id ) );
+               assert_eq( $body->{user_id}, $user->user_id, "user_id" );
+               assert_json_object( $body->{devices} );
 
-#                # Whether we've found a connection with the right keys
-#                # (ip, last_seen, user_agent).
-#                my $found_connections = 0;
+               # Whether we've found a connection with the right keys
+               # (ip, last_seen, user_agent).
+               my $found_connections = 0;
 
-#                foreach my $value ( values %{ $body->{devices} } ) {
-#                   assert_json_keys( $value, "sessions" );
-#                   assert_json_list( $value->{sessions} );
-#                   assert_json_keys( $value->{sessions}[0], "connections" );
-#                   assert_json_list( $value->{sessions}[0]{connections} );
-#                   # The `connections` may not yet be populated. If there *is* a connection,
-#                   # we check that it has the right shape. If `connections` is still empty, we
-#                   # tell `repeat_until_true` to retry by returning a falsey value.
-#                   foreach my $connection ( @{ $value->{sessions}[0]{connections} } ) {
-#                      assert_json_keys(
-#                         $connection,
-#                         qw( ip last_seen user_agent )
-#                      );
+               foreach my $value ( values %{ $body->{devices} } ) {
+                  assert_json_keys( $value, "sessions" );
+                  assert_json_list( $value->{sessions} );
+                  assert_json_keys( $value->{sessions}[0], "connections" );
+                  assert_json_list( $value->{sessions}[0]{connections} );
+                  # The `connections` may not yet be populated. If there *is* a connection,
+                  # we check that it has the right shape. If `connections` is still empty, we
+                  # tell `repeat_until_true` to retry by returning a falsey value.
+                  foreach my $connection ( @{ $value->{sessions}[0]{connections} } ) {
+                     assert_json_keys(
+                        $connection,
+                        qw( ip last_seen user_agent )
+                     );
 
-#                      $found_connections = 1;
-#                   }
-#                }
+                     $found_connections = 1;
+                  }
+               }
 
-#                Future->done( $found_connections );
-#             });
-#          }, initial_delay => 0.5;
-#       });
-#    };
+               Future->done( $found_connections );
+            });
+         }, initial_delay => 0.5;
+      });
+   };
 
-# test "/purge_history",
-#    requires => [ local_admin_fixture(), local_user_and_room_fixtures() ],
-#    implementation_specific => ['synapse'],
+test "/purge_history",
+   requires => [ local_admin_fixture(), local_user_and_room_fixtures() ],
+   implementation_specific => ['synapse'],
 
-#    do => sub {
-#       my ( $admin, $user, $room_id ) = @_;
+   do => sub {
+      my ( $admin, $user, $room_id ) = @_;
 
-#       my $last_event_id;
+      my $last_event_id;
 
-#       matrix_put_room_state( $user, $room_id,
-#          type    => "m.room.name",
-#          content => { name => "A room name" },
-#       )->then( sub {
-#          matrix_sync( $user )
-#       })->then( sub {
-#          repeat( sub {
-#             my $msgnum = $_[0];
+      matrix_put_room_state( $user, $room_id,
+         type    => "m.room.name",
+         content => { name => "A room name" },
+      )->then( sub {
+         matrix_sync( $user )
+      })->then( sub {
+         repeat( sub {
+            my $msgnum = $_[0];
 
-#             matrix_send_room_text_message_synced( $user, $room_id,
-#                body => "Message $msgnum",
-#             )
-#          }, foreach => [ 1 .. 10 ])
-#       })->then( sub {
-#          ( $last_event_id ) = @_;
+            matrix_send_room_text_message_synced( $user, $room_id,
+               body => "Message $msgnum",
+            )
+         }, foreach => [ 1 .. 10 ])
+      })->then( sub {
+         ( $last_event_id ) = @_;
 
-#          await_message_in_room( $user, $room_id, $last_event_id ),
-#       })->then( sub {
-#          do_request_json_for( $user,
-#             method   => "POST",
-#             full_uri => "/_synapse/admin/v1/purge_history/$room_id/${ \uri_escape( $last_event_id ) }",
-#             content  => {}
-#          )->main::expect_http_403;  # Must be server admin
-#       })->then( sub {
-#          do_request_json_for( $admin,
-#             method   => "POST",
-#             full_uri => "/_synapse/admin/v1/purge_history/$room_id/${ \uri_escape( $last_event_id ) }",
-#             content  => {}
-#          )
-#       })->then( sub {
-#          my ( $body ) = @_;
+         await_message_in_room( $user, $room_id, $last_event_id ),
+      })->then( sub {
+         do_request_json_for( $user,
+            method   => "POST",
+            full_uri => "/_synapse/admin/v1/purge_history/$room_id/${ \uri_escape( $last_event_id ) }",
+            content  => {}
+         )->main::expect_http_403;  # Must be server admin
+      })->then( sub {
+         do_request_json_for( $admin,
+            method   => "POST",
+            full_uri => "/_synapse/admin/v1/purge_history/$room_id/${ \uri_escape( $last_event_id ) }",
+            content  => {}
+         )
+      })->then( sub {
+         my ( $body ) = @_;
 
-#          assert_json_keys( $body, "purge_id" );
-#          my $purge_id = $body->{purge_id};
-#          await_purge_complete( $admin, $purge_id );
-#       })->then( sub {
-#          my ( $purge_status ) = @_;
-#          assert_eq( $purge_status, 'complete' );
+         assert_json_keys( $body, "purge_id" );
+         my $purge_id = $body->{purge_id};
+         await_purge_complete( $admin, $purge_id );
+      })->then( sub {
+         my ( $purge_status ) = @_;
+         assert_eq( $purge_status, 'complete' );
 
-#          # Test that /sync with an existing token still works.
-#          matrix_sync_again( $user )
-#       })->then( sub {
-#          # Test that an initial /sync has the correct data.
-#          matrix_sync( $user )
-#       })->then( sub {
-#          my ( $body ) = @_;
+         # Test that /sync with an existing token still works.
+         matrix_sync_again( $user )
+      })->then( sub {
+         # Test that an initial /sync has the correct data.
+         matrix_sync( $user )
+      })->then( sub {
+         my ( $body ) = @_;
 
-#          assert_json_keys( $body->{rooms}{join}, $room_id );
-#          my $room =  $body->{rooms}{join}{$room_id};
+         assert_json_keys( $body->{rooms}{join}, $room_id );
+         my $room =  $body->{rooms}{join}{$room_id};
 
-#          log_if_fail( "Room", $room->{timeline}{events} );
+         log_if_fail( "Room", $room->{timeline}{events} );
 
-#          # The only message event should be the last one.
-#          all {
-#             $_->{type} ne "m.room.message" || $_->{event_id} eq $last_event_id
-#          } @{ $room->{timeline}{events} } or die "Expected no message events";
+         # The only message event should be the last one.
+         all {
+            $_->{type} ne "m.room.message" || $_->{event_id} eq $last_event_id
+         } @{ $room->{timeline}{events} } or die "Expected no message events";
 
-#          # Ensure we still see the state.
-#          foreach my $expected_type( qw(
-#             m.room.create
-#             m.room.member
-#             m.room.power_levels
-#             m.room.name
-#          ) ) {
-#             any { $_->{type} eq $expected_type } @{ $room->{state}{events} }
-#                or die "Expected state event of type $expected_type";
-#          }
+         # Ensure we still see the state.
+         foreach my $expected_type( qw(
+            m.room.create
+            m.room.member
+            m.room.power_levels
+            m.room.name
+         ) ) {
+            any { $_->{type} eq $expected_type } @{ $room->{state}{events} }
+               or die "Expected state event of type $expected_type";
+         }
 
-#          Future->done( 1 );
-#       })
-#    };
+         Future->done( 1 );
+      })
+   };
 
-# test "/purge_history by ts",
-#    requires => [ local_admin_fixture(), local_user_and_room_fixtures() ],
-#    implementation_specific => ['synapse'],
+test "/purge_history by ts",
+   requires => [ local_admin_fixture(), local_user_and_room_fixtures() ],
+   implementation_specific => ['synapse'],
 
-#    do => sub {
-#       my ( $admin, $user, $room_id ) = @_;
+   do => sub {
+      my ( $admin, $user, $room_id ) = @_;
 
-#       my ($last_event_id, $last_event_ts);
+      my ($last_event_id, $last_event_ts);
 
-#       # we send 9 messages, get the current ts, and
-#       # then send one more.
-#       matrix_put_room_state( $user, $room_id,
-#          type    => "m.room.name",
-#          content => { name => "A room name" },
-#       )->then( sub {
-#          matrix_sync( $user )
-#       })->then( sub {
-#          repeat( sub {
-#             my $msgnum = $_[0];
+      # we send 9 messages, get the current ts, and
+      # then send one more.
+      matrix_put_room_state( $user, $room_id,
+         type    => "m.room.name",
+         content => { name => "A room name" },
+      )->then( sub {
+         matrix_sync( $user )
+      })->then( sub {
+         repeat( sub {
+            my $msgnum = $_[0];
 
-#             matrix_send_room_text_message_synced( $user, $room_id,
-#                body => "Message $msgnum",
-#             )
-#          }, foreach => [ 1 .. 9 ])
-#       })->then( sub {
-#          $last_event_ts = time();
-#          delay(0.01);
-#       })->then( sub {
-#          matrix_send_room_text_message_synced( $user, $room_id,
-#             body => "Message 10",
-#          );
-#       })->then( sub {
-#          ( $last_event_id ) = @_;
-#          await_message_in_room( $user, $room_id, $last_event_id ),
-#       })->then( sub {
-#          do_request_json_for( $admin,
-#             method   => "POST",
-#             full_uri => "/_synapse/admin/v1/purge_history/$room_id",
-#             content  => {
-#                purge_up_to_ts => int($last_event_ts * 1000),
-#             },
-#          )
-#       })->then( sub {
-#          my ( $body ) = @_;
+            matrix_send_room_text_message_synced( $user, $room_id,
+               body => "Message $msgnum",
+            )
+         }, foreach => [ 1 .. 9 ])
+      })->then( sub {
+         $last_event_ts = time();
+         delay(0.01);
+      })->then( sub {
+         matrix_send_room_text_message_synced( $user, $room_id,
+            body => "Message 10",
+         );
+      })->then( sub {
+         ( $last_event_id ) = @_;
+         await_message_in_room( $user, $room_id, $last_event_id ),
+      })->then( sub {
+         do_request_json_for( $admin,
+            method   => "POST",
+            full_uri => "/_synapse/admin/v1/purge_history/$room_id",
+            content  => {
+               purge_up_to_ts => int($last_event_ts * 1000),
+            },
+         )
+      })->then( sub {
+         my ( $body ) = @_;
 
-#          assert_json_keys( $body, "purge_id" );
-#          my $purge_id = $body->{purge_id};
-#          await_purge_complete( $admin, $purge_id );
-#       })->then( sub {
-#          my ( $purge_status ) = @_;
-#          assert_eq( $purge_status, 'complete' );
+         assert_json_keys( $body, "purge_id" );
+         my $purge_id = $body->{purge_id};
+         await_purge_complete( $admin, $purge_id );
+      })->then( sub {
+         my ( $purge_status ) = @_;
+         assert_eq( $purge_status, 'complete' );
 
-#          # Test that /sync with an existing token still works.
-#          matrix_sync_again( $user )
-#       })->then( sub {
-#          # Test that an initial /sync has the correct data.
-#          matrix_sync( $user )
-#       })->then( sub {
-#          my ( $body ) = @_;
+         # Test that /sync with an existing token still works.
+         matrix_sync_again( $user )
+      })->then( sub {
+         # Test that an initial /sync has the correct data.
+         matrix_sync( $user )
+      })->then( sub {
+         my ( $body ) = @_;
 
-#          assert_json_keys( $body->{rooms}{join}, $room_id );
-#          my $room =  $body->{rooms}{join}{$room_id};
+         assert_json_keys( $body->{rooms}{join}, $room_id );
+         my $room =  $body->{rooms}{join}{$room_id};
 
-#          log_if_fail( "Room", $room->{timeline}{events} );
+         log_if_fail( "Room", $room->{timeline}{events} );
 
-#          # The only message event should be the last one.
-#          all {
-#             $_->{type} ne "m.room.message" || $_->{event_id} eq $last_event_id
-#          } @{ $room->{timeline}{events} } or die "Expected no message events";
-#          Future->done( 1 );
-#       })
-#    };
+         # The only message event should be the last one.
+         all {
+            $_->{type} ne "m.room.message" || $_->{event_id} eq $last_event_id
+         } @{ $room->{timeline}{events} } or die "Expected no message events";
+         Future->done( 1 );
+      })
+   };
 
 test "Can backfill purged history",
    # we create three users:
@@ -404,81 +404,81 @@ test "Can backfill purged history",
    };
 
 
-# multi_test "Shutdown room",
-#    requires => [ local_admin_fixture(), local_user_fixtures( 2 ), remote_user_fixture(),
-#       room_alias_name_fixture() ],
-#    implementation_specific => ['synapse'],
+multi_test "Shutdown room",
+   requires => [ local_admin_fixture(), local_user_fixtures( 2 ), remote_user_fixture(),
+      room_alias_name_fixture() ],
+   implementation_specific => ['synapse'],
 
-#    do => sub {
-#       my ( $admin, $user, $dummy_user, $remote_user, $room_alias_name ) = @_;
+   do => sub {
+      my ( $admin, $user, $dummy_user, $remote_user, $room_alias_name ) = @_;
 
-#       my $server_name = $user->http->server_name;
-#       my $room_alias = "#$room_alias_name:$server_name";
+      my $server_name = $user->http->server_name;
+      my $room_alias = "#$room_alias_name:$server_name";
 
-#       my ( $room_id, $new_room_id );
+      my ( $room_id, $new_room_id );
 
-#       matrix_create_room_synced( $user,
-#          room_alias_name => $room_alias_name,
-#       )->then( sub {
-#          ( $room_id ) = @_;
+      matrix_create_room_synced( $user,
+         room_alias_name => $room_alias_name,
+      )->then( sub {
+         ( $room_id ) = @_;
 
-#          matrix_invite_user_to_room_synced( $user, $remote_user, $room_id );
-#       })->then( sub {
-#          matrix_join_room_synced( $remote_user, $room_id );
-#       })->then( sub {
-#          do_request_json_for( $admin,
-#             method   => "DELETE",
-#             full_uri => "/_synapse/admin/v1/rooms/$room_id",
-#             content  => {
-#                new_room_user_id => $dummy_user->user_id,
-#                block => JSON::true,
-#                purge => JSON::false,
-#             },
-#          );
-#       })->SyTest::pass_on_done( "Shutdown room returned success" )
-#       ->then( sub {
-#          my ( $body ) = @_;
+         matrix_invite_user_to_room_synced( $user, $remote_user, $room_id );
+      })->then( sub {
+         matrix_join_room_synced( $remote_user, $room_id );
+      })->then( sub {
+         do_request_json_for( $admin,
+            method   => "DELETE",
+            full_uri => "/_synapse/admin/v1/rooms/$room_id",
+            content  => {
+               new_room_user_id => $dummy_user->user_id,
+               block => JSON::true,
+               purge => JSON::false,
+            },
+         );
+      })->SyTest::pass_on_done( "Shutdown room returned success" )
+      ->then( sub {
+         my ( $body ) = @_;
 
-#          $new_room_id = $body->{new_room_id};
+         $new_room_id = $body->{new_room_id};
 
-#          log_if_fail "Shutdown room, new room ID", $new_room_id;
+         log_if_fail "Shutdown room, new room ID", $new_room_id;
 
-#          matrix_send_room_text_message( $user, $room_id, body => "Hello" )
-#          ->main::expect_http_403;
-#       })->SyTest::pass_on_done( "User cannot post in room" )
-#       ->then( sub {
-#          matrix_join_room( $user, $room_id )
-#          ->main::expect_http_403;
-#       })->SyTest::pass_on_done( "User cannot rejoin room" )
-#       ->then( sub {
-#          matrix_invite_user_to_room( $remote_user, $user, $room_id )
-#          ->main::expect_http_403;
-#       })->SyTest::pass_on_done( "Remote users can't invite local users into room" )
-#       ->then( sub {
-#          do_request_json_for( $user,
-#             method => "GET",
-#             uri    => "/v3/directory/room/$room_alias",
-#          );
-#       })->then( sub {
-#          my ( $body ) = @_;
+         matrix_send_room_text_message( $user, $room_id, body => "Hello" )
+         ->main::expect_http_403;
+      })->SyTest::pass_on_done( "User cannot post in room" )
+      ->then( sub {
+         matrix_join_room( $user, $room_id )
+         ->main::expect_http_403;
+      })->SyTest::pass_on_done( "User cannot rejoin room" )
+      ->then( sub {
+         matrix_invite_user_to_room( $remote_user, $user, $room_id )
+         ->main::expect_http_403;
+      })->SyTest::pass_on_done( "Remote users can't invite local users into room" )
+      ->then( sub {
+         do_request_json_for( $user,
+            method => "GET",
+            uri    => "/v3/directory/room/$room_alias",
+         );
+      })->then( sub {
+         my ( $body ) = @_;
 
-#          assert_json_keys( $body, qw( room_id ));
+         assert_json_keys( $body, qw( room_id ));
 
-#          $body->{room_id} eq $new_room_id or die "Expected room_id to be new";
+         $body->{room_id} eq $new_room_id or die "Expected room_id to be new";
 
-#          pass( "Aliases were repointed" );
+         pass( "Aliases were repointed" );
 
-#          retry_until_success {
-#             matrix_get_room_state( $user, $new_room_id,
-#                type      => "m.room.name",
-#                state_key => "",
-#             )->SyTest::pass_on_done( "User was added to new room" )
-#          }
-#       })->then( sub {
-#          matrix_send_room_text_message( $user, $new_room_id, body => "Hello" )
-#          ->main::expect_http_403;
-#       })->SyTest::pass_on_done( "User cannot send into new room" );
-#    };
+         retry_until_success {
+            matrix_get_room_state( $user, $new_room_id,
+               type      => "m.room.name",
+               state_key => "",
+            )->SyTest::pass_on_done( "User was added to new room" )
+         }
+      })->then( sub {
+         matrix_send_room_text_message( $user, $new_room_id, body => "Hello" )
+         ->main::expect_http_403;
+      })->SyTest::pass_on_done( "User cannot send into new room" );
+   };
 
 
 sub await_message_in_room


### PR DESCRIPTION
Fix no servers having historical state after purging events when running with `POSTGRES=1 -e MULTI_POSTGRES=1 -e WORKERS=1`

As seen in https://github.com/matrix-org/synapse/pull/13816#discussion_r987522070 (details and more context). The reason we're now only noticing this problem is because with the introduction of https://github.com/matrix-org/synapse/pull/13816, we stop trying to fetch missing `prev_events` if we already tried recently (backoff). The `/state_ids` for the invite event 404's which means we can't verify the rest of the DAG all the way down.

Sytest failure in CI:

https://github.com/matrix-org/synapse/actions/runs/3185784983/jobs/5198427610
```
FAILURE: #588: Can backfill purged history
```

---

The reason this isn't seen in monolith is because TODO


### Dev notes


```
docker run --rm -it -e POSTGRES=1 -e MULTI_POSTGRES=1 -e WORKERS=1 \
    -v ~/Documents/github/element/synapse:/src:ro \
    -v ~/Documents/github/element/synapse/logs:/logs \
    -v ~/Documents/github/element/sytest:/sytest:ro matrixdotorg/sytest-synapse:buster tests/48admin.pl
```