### PR TITLE
Allow running Synapse with the asyncioreactor enabled

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -33,6 +33,7 @@ The following environment variables can be set with `-e` to control the test run
   PostgreSQL databases where the main store and state store are split.
 - `WORKERS`: set non-empty to test a worker-mode deployment rather than a
   monolith. Requires `POSTGRES`.
+- `ASYNCIO_REACTOR`: set non-empty to test with the Twisted asyncio reactor enabled
 - `OFFLINE`: set non-empty to avoid updating the python or perl dependencies.
 - `BLACKLIST`: set non-empty to change the default blacklist file to the
   specified path relative to the Synapse directory

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -29,7 +29,7 @@ sub _init
    my ( $args ) = @_;
 
    $self->{$_} = delete $args->{$_} for qw(
-      synapse_dir extra_args python coverage
+      synapse_dir extra_args python coverage asyncio_reactor
    );
 
    $self->{paths} = {};
@@ -380,6 +380,7 @@ sub start
       "PATH" => $ENV{PATH},
       "PYTHONDONTWRITEBYTECODE" => "Don't write .pyc files",
       "SYNAPSE_TEST_PATCH_LOG_CONTEXTS" => 1,
+      "SYNAPSE_ASYNC_IO_REACTOR" => $self->{asyncio_reactor},
    };
 
    my $loop = $self->loop;

--- a/lib/SyTest/HomeserverFactory/Synapse.pm
+++ b/lib/SyTest/HomeserverFactory/Synapse.pm
@@ -26,11 +26,12 @@ sub _init
    $self->{impl} = "SyTest::Homeserver::Synapse::Direct";
 
    $self->{args} = {
-      synapse_dir   => "../synapse",
-      python        => "python",
-      coverage      => 0,
-      print_output  => 0,
-      filter_output => undef,
+      synapse_dir     => "../synapse",
+      python          => "python",
+      asyncio_reactor => 0,
+      coverage        => 0,
+      print_output    => 0,
+      filter_output   => undef,
    };
 
    $self->{extra_args} = [];
@@ -51,6 +52,7 @@ sub get_options
       'd|synapse-directory=s' => \$self->{args}{synapse_dir},
       'python=s' => \$self->{args}{python},
       'coverage+' => \$self->{args}{coverage},
+      'asyncio-reactor+' => \$self->{args}{asyncio_reactor},
 
       'S|server-log+' => \$self->{args}{print_output},
       'server-grep=s' => \$self->{args}{filter_output},
@@ -76,6 +78,8 @@ sub print_usage
        --python PATH            - path to the 'python' binary
 
        --coverage               - generate code coverage stats for synapse
+
+       --asyncio-reactor        - run Synapse with the asyncio reactor enabled
 
    -ENAME, -ENAME=VALUE         - pass extra argument NAME or NAME=VALUE to the
                                   homeserver.

--- a/scripts/synapse_sytest.sh
+++ b/scripts/synapse_sytest.sh
@@ -197,6 +197,10 @@ RUN_TESTS=(
     --work-directory="/work"
 )
 
+if [ -n "$ASYNCIO_REACTOR" ]; then
+    RUN_TESTS+=(--asyncio-reactor)
+fi
+
 if [ -n "$WORKERS" ]; then
     RUN_TESTS+=(-I Synapse::ViaHaproxy --workers)
     RUN_TESTS+=(--redis-host=localhost)


### PR DESCRIPTION
This adds a flag `--asyncio-reactor`, which sets the `SYNAPSE_ASYNCIO_REACTOR` environment variable to `1`.
It also adds a `ASYNCIO_REACTOR` environment variable to the Docker image to set this flag.

Note that it currently also sets `SYNAPSE_ASYNCIO_REACTOR` to `0` when the flag is not set, which currently enables the asyncioreactor anyway, so this will require some changes in Synapse first: https://github.com/matrix-org/synapse/pull/14092

Related: https://github.com/matrix-org/synapse/issues/14091