### PR TITLE
Disable version control tagging for dendrite build

### DIFF
--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -34,9 +34,9 @@ export GOBIN=/tmp/bin
 echo >&2 "--- Building dendrite from source"
 cd /src
 mkdir -p $GOBIN
-go install -v ./cmd/dendrite-monolith-server
-go install -v ./cmd/generate-keys
-go install -v ./cmd/generate-config
+go install -buildvcs=false -v ./cmd/dendrite-monolith-server
+go install -buildvcs=false -v ./cmd/generate-keys
+go install -buildvcs=false -v ./cmd/generate-config
 cd -
 
 # Run the tests


### PR DESCRIPTION
This change disables tagging the dendrite binary with version control information. This allows running sytest with docker on dendrite source code that was mounted from a git worktree directory.

Motivation:
If running go install/build inside of a git repository, go relies on it being a fully functioning repository in order to tag the binary with relevant build information. If that git repository is not fully functioning then go install/build will fail.
When mounting a git worktree into a docker container the git repository is broken unless you have also mounted the entire filesystem path up to that point. This is due to git worktrees not supporting relative paths.
To prevent from having to either manipulate default git worktree setups or adding further complexity to the dendrite mounting procedure, it is simplest to disable the version control tagging in the go install command. 