### PR TITLE
Allow HSes to omit device display names

### DIFF
--- a/tests/41end-to-end-keys/06-device-lists.pl
+++ b/tests/41end-to-end-keys/06-device-lists.pl
@@ -212,7 +212,7 @@ test "Can query remote device keys using POST after notification",
          # and they're considered optional in the GET /user/devices/{userId} response.
          # So accept either a match or a lack of key.
          my $device_display_name = $alice_device_keys->{"unsigned"}->{"device_display_name"};
-         $device_display_name = undef or $device_display_name = "test display name" or
+         (!defined $device_display_name) or ($device_display_name == "test display name") or
             croak "Unexpected device_display_name: $device_display_name";
 
          Future->done(1)

--- a/tests/41end-to-end-keys/06-device-lists.pl
+++ b/tests/41end-to-end-keys/06-device-lists.pl
@@ -208,9 +208,12 @@ test "Can query remote device keys using POST after notification",
          my $alice_device_keys = $alice_keys->{ $user2->device_id };
 
          # TODO: Check that the content matches what we uploaded.
-
-         assert_eq( $alice_device_keys->{"unsigned"}->{"device_display_name"},
-                    "test display name" );
+         # Device display names aren't mandated in the POST /user/keys/query response,
+         # and they're considered optional in the GET /user/devices/{userId} response.
+         # So accept either a match or a lack of key.
+         my $device_display_name = $alice_device_keys->{"unsigned"}->{"device_display_name"};
+         $device_display_name = undef or $device_display_name = "test display name" or
+            croak "Unexpected device_display_name: $device_display_name";
 
          Future->done(1)
       });


### PR DESCRIPTION
Hopefully gets https://github.com/matrix-org/synapse/pull/10015 over the line.

I don't speak perl and it's not easy to test this change against that PR because it comes from a fork.

I suggest we merge this if CI is green and move on with our lives.