### PR TITLE
Allow race detection in Dendrite

### DIFF
--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -268,6 +268,7 @@ sub _start_monolith
             DENDRITE_TRACE_SQL => $ENV{'DENDRITE_TRACE_SQL'},
             DENDRITE_TRACE_HTTP => $ENV{'DENDRITE_TRACE_HTTP'},
             DENDRITE_TRACE_INTERNAL => $ENV{'DENDRITE_TRACE_INTERNAL'},
+            GORACE => "log_path=" . $self->{hs_dir} . "/racedetection.log"
          },
       ],
       command => [ @command ],

--- a/scripts/dendrite_sytest.sh
+++ b/scripts/dendrite_sytest.sh
@@ -34,9 +34,9 @@ export GOBIN=/tmp/bin
 echo >&2 "--- Building dendrite from source"
 cd /src
 mkdir -p $GOBIN
-go install -buildvcs=false -v ./cmd/dendrite-monolith-server
-go install -buildvcs=false -v ./cmd/generate-keys
-go install -buildvcs=false -v ./cmd/generate-config
+go install -buildvcs=false -race=${RACE_DETECTION:-0} -v ./cmd/dendrite-monolith-server
+go install -buildvcs=false -race=${RACE_DETECTION:-0} -v ./cmd/generate-keys
+go install -buildvcs=false -race=${RACE_DETECTION:-0} -v ./cmd/generate-config
 cd -
 
 # Run the tests


### PR DESCRIPTION
Accepts an optional `RACE_DETECTION` environment variable, which allows Dendrite to be run with race detetion.
`GORACE` sets the output logpath, so the file can be captured by rsync.