### PR TITLE
Make device display name check optional for `federation/v1/user/keys/query`

### DIFF
--- a/tests/41end-to-end-keys/04-query-key-federation.pl
+++ b/tests/41end-to-end-keys/04-query-key-federation.pl
@@ -30,9 +30,8 @@ multi_test "Can query remote device keys using POST",
 
          # Device display names are optional for POST /user/keys/query responses.
          # If one exists, ensure it's the one we expected.
-         my $device_display_name = $alice_device_keys->{"unsigned"}->{"device_display_name"};
-         (!defined $device_display_name) or ($device_display_name == "test display name") or
-            croak "Unexpected device_display_name: $device_display_name";
+         my $device_display_name = $alice_device_keys->{"unsigned"}->{"device_display_name"} // "";
+         assert_eq "test display name", $device_display_name, "device display name";
 
          Future->done(1)
       });

--- a/tests/41end-to-end-keys/04-query-key-federation.pl
+++ b/tests/41end-to-end-keys/04-query-key-federation.pl
@@ -28,8 +28,11 @@ multi_test "Can query remote device keys using POST",
 
          # TODO: Check that the content matches what we uploaded.
 
-         assert_eq( $alice_device_keys->{"unsigned"}->{"device_display_name"},
-                    "test display name" );
+         # Device display names are optional for POST /user/keys/query responses.
+         # If one exists, ensure it's the one we expected.
+         my $device_display_name = $alice_device_keys->{"unsigned"}->{"device_display_name"};
+         (!defined $device_display_name) or ($device_display_name == "test display name") or
+            croak "Unexpected device_display_name: $device_display_name";
 
          Future->done(1)
       });

--- a/tests/41end-to-end-keys/04-query-key-federation.pl
+++ b/tests/41end-to-end-keys/04-query-key-federation.pl
@@ -30,8 +30,12 @@ multi_test "Can query remote device keys using POST",
 
          # Device display names are optional for POST /user/keys/query responses.
          # If one exists, ensure it's the one we expected.
-         my $device_display_name = $alice_device_keys->{"unsigned"}->{"device_display_name"} // "";
-         assert_eq "test display name", $device_display_name, "device display name";
+         if (exists( $alice_device_keys->{"unsigned"}->{"device_display_name"} )) {
+            assert_eq(
+               $alice_device_keys->{"unsigned"}->{"device_display_name"},
+               "test display name",
+            );
+         }
 
          Future->done(1)
       });

--- a/tests/41end-to-end-keys/06-device-lists.pl
+++ b/tests/41end-to-end-keys/06-device-lists.pl
@@ -212,8 +212,12 @@ test "Can query remote device keys using POST after notification",
          # Device display names aren't mandated in the POST /user/keys/query response,
          # and they're considered optional in the GET /user/devices/{userId} response.
          # So accept either a match or a lack of key.
-         my $device_display_name = $alice_device_keys->{"unsigned"}->{"device_display_name"} // "";
-         assert_eq "test display name", $device_display_name, "device display name";
+         if (exists( $alice_device_keys->{"unsigned"}->{"device_display_name"} )) {
+            assert_eq(
+               $alice_device_keys->{"unsigned"}->{"device_display_name"},
+               "test display name",
+            );
+         }
 
          Future->done(1)
       });

--- a/tests/41end-to-end-keys/06-device-lists.pl
+++ b/tests/41end-to-end-keys/06-device-lists.pl
@@ -208,12 +208,12 @@ test "Can query remote device keys using POST after notification",
          my $alice_device_keys = $alice_keys->{ $user2->device_id };
 
          # TODO: Check that the content matches what we uploaded.
+
          # Device display names aren't mandated in the POST /user/keys/query response,
          # and they're considered optional in the GET /user/devices/{userId} response.
          # So accept either a match or a lack of key.
-         my $device_display_name = $alice_device_keys->{"unsigned"}->{"device_display_name"};
-         (!defined $device_display_name) or ($device_display_name == "test display name") or
-            croak "Unexpected device_display_name: $device_display_name";
+         my $device_display_name = $alice_device_keys->{"unsigned"}->{"device_display_name"} // "";
+         assert_eq "test display name", $device_display_name, "device display name";
 
          Future->done(1)
       });


### PR DESCRIPTION
Some homeservers (Synapse) have started [omitting device's display name over federation](https://matrix-org.github.io/synapse/latest/usage/configuration/config_documentation.html#allow_device_name_lookup_over_federation) by default. The spec [doesn't mandate that this field be available](https://spec.matrix.org/v1.4/server-server-api/#post_matrixfederationv1userkeysquery), so Sytest shouldn't either.

This PR modifies the check so that it is optional - only if the field is present do we check the value.