### PR TITLE
Try until success for membership event

### DIFF
--- a/tests/30rooms/13guestaccess.pl
+++ b/tests/30rooms/13guestaccess.pl
@@ -141,8 +141,6 @@ test "Guest users are kicked from guest_access rooms on revocation of guest_acce
 
          matrix_set_room_guest_access( $user, $room_id, "forbidden" );
       })->then( sub {
-         matrix_get_room_membership( $user, $room_id, $guest_user );
-      })->then( sub {
          retry_until_success {
             matrix_get_room_membership( $user, $room_id, $guest_user )
                ->then( sub {

--- a/tests/30rooms/13guestaccess.pl
+++ b/tests/30rooms/13guestaccess.pl
@@ -143,11 +143,14 @@ test "Guest users are kicked from guest_access rooms on revocation of guest_acce
       })->then( sub {
          matrix_get_room_membership( $user, $room_id, $guest_user );
       })->then( sub {
-         my ( $membership ) = @_;
-
-         assert_eq( $membership, "leave", "membership" );
-
-         Future->done( 1 );
+         retry_until_success {
+            matrix_get_room_membership( $user, $room_id, $guest_user )
+               ->then( sub {
+                  my ( $membership ) = @_;
+                  $membership eq "leave" or die "Expected membership to be 'leave'";
+                  Future->done(1);
+            })
+         };
       });
    };
 


### PR DESCRIPTION
Due to Dendrites async nature, the membership event might not be persisted yet when hitting `/state`. This now retries until we have the expected result or the test times out.