### PR TITLE
Remove unused Synapse config: `worker_main_http_uri`

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -942,7 +942,6 @@ sub _start_synapse
          "worker_log_config"            => $self->configure_logger("frontend_proxy"),
          "worker_replication_host"      => "$bind_host",
          "worker_replication_http_port" => $self->{ports}{synapse_unsecure},
-         "worker_main_http_uri"         => "http://$bind_host:$self->{ports}{synapse_unsecure}",
          "worker_listeners"             => [
             {
                type      => "http",
@@ -975,7 +974,6 @@ sub _start_synapse
          "worker_log_config"            => $self->configure_logger("background_worker"),
          "worker_replication_host"      => "$bind_host",
          "worker_replication_http_port" => $self->{ports}{synapse_unsecure},
-         "worker_main_http_uri"         => "http://$bind_host:$self->{ports}{synapse_unsecure}",
       };
 
       push @worker_configs, $background_worker_config;
@@ -989,7 +987,6 @@ sub _start_synapse
          "worker_log_config"            => $self->configure_logger("event_persister1"),
          "worker_replication_host"      => "$bind_host",
          "worker_replication_http_port" => $self->{ports}{synapse_unsecure},
-         "worker_main_http_uri"         => "http://$bind_host:$self->{ports}{synapse_unsecure}",
          "worker_listeners"             => [
             {
                type      => "http",
@@ -1022,7 +1019,6 @@ sub _start_synapse
          "worker_log_config"            => $self->configure_logger("event_persister2"),
          "worker_replication_host"      => "$bind_host",
          "worker_replication_http_port" => $self->{ports}{synapse_unsecure},
-         "worker_main_http_uri"         => "http://$bind_host:$self->{ports}{synapse_unsecure}",
          "worker_listeners"             => [
             {
                type      => "http",
@@ -1055,7 +1051,6 @@ sub _start_synapse
          "worker_log_config"            => $self->configure_logger("stream_writer"),
          "worker_replication_host"      => "$bind_host",
          "worker_replication_http_port" => $self->{ports}{synapse_unsecure},
-         "worker_main_http_uri"         => "http://$bind_host:$self->{ports}{synapse_unsecure}",
          "worker_listeners"             => [
             {
                type      => "http",


### PR DESCRIPTION
See matrix-org/synapse#14400. This removes some warnings in the logs.