### PR TITLE
Install libicu in Docker images

### DIFF
--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -24,6 +24,8 @@ RUN apt-get -qq update && apt-get -qq install -y \
     rsync \
     sqlite3 \
     wget \
+    libicu-dev \
+    pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
 # Set up the locales, as the default Debian image only has C, and PostgreSQL needs the correct locales to make a UTF-8 database


### PR DESCRIPTION
Add a dependency to libicu-dev and pkg-config to the Docker images, to help with Synapse's user search as per https://github.com/matrix-org/synapse/pull/14464.

Required by https://github.com/matrix-org/synapse/pull/14464

CI for Synapse is failing because (obviously) the `matrixdotorg/sytest-synapse` image does not have the `libicu-dev` dependency (and branch matching means it's trying to test against a code base that requires it).