### PR TITLE
Remove deprecated `home_server` from checks

### DIFF
--- a/tests/10apidoc/02login.pl
+++ b/tests/10apidoc/02login.pl
@@ -91,10 +91,7 @@ test "POST /login can log in as a user",
       )->then( sub {
          my ( $body ) = @_;
 
-         assert_json_keys( $body, qw( access_token home_server ));
-
-         assert_eq( $body->{home_server}, $http->server_name,
-            'Response home_server' );
+         assert_json_keys( $body, qw( access_token ));
 
          Future->done(1);
       });
@@ -161,10 +158,7 @@ test "POST /login can log in as a user with just the local part of the id",
       )->then( sub {
          my ( $body ) = @_;
 
-         assert_json_keys( $body, qw( access_token home_server ));
-
-         assert_eq( $body->{home_server}, $http->server_name,
-            'Response home_server' );
+         assert_json_keys( $body, qw( access_token ));
 
          Future->done(1);
       });
@@ -250,7 +244,7 @@ sub matrix_login_again_with_user
    )->then( sub {
       my ( $body ) = @_;
 
-      assert_json_keys( $body, qw( access_token home_server ));
+      assert_json_keys( $body, qw( access_token ));
 
       my $new_user = new_User(
          http          => $user->http,

--- a/tests/10apidoc/02login.pl
+++ b/tests/10apidoc/02login.pl
@@ -93,6 +93,11 @@ test "POST /login can log in as a user",
 
          assert_json_keys( $body, qw( access_token ));
 
+         if (defined $body->{home_server}) {
+            assert_eq( $body->{home_server}, $http->server_name,
+               'Response home_server' );
+         }
+
          Future->done(1);
       });
    };
@@ -159,6 +164,11 @@ test "POST /login can log in as a user with just the local part of the id",
          my ( $body ) = @_;
 
          assert_json_keys( $body, qw( access_token ));
+
+         if (defined $body->{home_server}) {
+            assert_eq( $body->{home_server}, $http->server_name,
+               'Response home_server' );
+         }
 
          Future->done(1);
       });

--- a/tests/10apidoc/13ui-auth.pl
+++ b/tests/10apidoc/13ui-auth.pl
@@ -187,10 +187,14 @@ sub matrix_login_with_cas
 
       assert_json_keys( $body, qw( access_token user_id device_id ));
 
-      assert_eq( $body->{home_server}, $http->server_name,
-                 'home_server in /login response' );
+      if (defined $body->{home_server}) {
+         assert_eq( $body->{home_server}, $http->server_name,
+            'home_server in /login response' );
+      }
+
+      
       assert_eq( $body->{user_id}, $user_id,
-                 'user_id in /login response' );
+         'user_id in /login response' );
 
       Future->done(1);
    });

--- a/tests/10apidoc/13ui-auth.pl
+++ b/tests/10apidoc/13ui-auth.pl
@@ -185,7 +185,7 @@ sub matrix_login_with_cas
 
       log_if_fail "Response from /login", $body;
 
-      assert_json_keys( $body, qw( access_token home_server user_id device_id ));
+      assert_json_keys( $body, qw( access_token user_id device_id ));
 
       assert_eq( $body->{home_server}, $http->server_name,
                  'home_server in /login response' );

--- a/tests/12login/01threepid-and-password.pl
+++ b/tests/12login/01threepid-and-password.pl
@@ -26,7 +26,7 @@ test "Can login with 3pid and password using m.login.password",
       })->then( sub {
          my ( $body ) = @_;
 
-         assert_json_keys( $body, qw( access_token home_server ));
+         assert_json_keys( $body, qw( access_token ));
 
          assert_eq( $body->{home_server}, $http->server_name,
             'Response home_server' );

--- a/tests/12login/01threepid-and-password.pl
+++ b/tests/12login/01threepid-and-password.pl
@@ -28,8 +28,10 @@ test "Can login with 3pid and password using m.login.password",
 
          assert_json_keys( $body, qw( access_token ));
 
-         assert_eq( $body->{home_server}, $http->server_name,
-            'Response home_server' );
+         if (defined $body->{home_server}) {
+            assert_eq( $body->{home_server}, $http->server_name,
+               'Response home_server' );
+         }
 
          Future->done(1);
       });

--- a/tests/60app-services/01as-create.pl
+++ b/tests/60app-services/01as-create.pl
@@ -21,7 +21,7 @@ test "AS can create a user",
 
          log_if_fail "Body", $body;
 
-         assert_json_keys( $body, qw( user_id home_server access_token device_id ));
+         assert_json_keys( $body, qw( user_id access_token device_id ));
 
          Future->done(1);
       });
@@ -46,7 +46,7 @@ test "AS can create a user with an underscore",
 
          log_if_fail "Body", $body;
 
-         assert_json_keys( $body, qw( user_id home_server access_token device_id ));
+         assert_json_keys( $body, qw( user_id access_token device_id ));
 
          Future->done(1);
       });
@@ -73,7 +73,7 @@ test "AS can create a user with inhibit_login",
 
          log_if_fail "Body", $body;
 
-         assert_json_keys( $body, qw( user_id home_server ));
+         assert_json_keys( $body, qw( user_id ));
          foreach ( qw( device_id access_token )) {
             exists $body->{$_} and die "Got an unexpected '$_' key";
          }


### PR DESCRIPTION
The `home_server` field in responses to `/register` and `/login` is deprecated since [r0.4.0](https://matrix.org/docs/spec/client_server/r0.4.0.html)