### PR TITLE
Bump poetry-version to 1.2.2

### DIFF
--- a/docker/synapse.Dockerfile
+++ b/docker/synapse.Dockerfile
@@ -24,7 +24,7 @@ RUN curl -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-tool
 # pip version provided by Debian Buster. See
 # https://github.com/pypa/setuptools/issues/3457#issuecomment-1190125849
 RUN ${PYTHON_VERSION} -m pip install -q --upgrade pip
-RUN ${PYTHON_VERSION} -m pip install -q --no-cache-dir poetry==1.2.0
+RUN ${PYTHON_VERSION} -m pip install -q --no-cache-dir poetry==1.2.2
 
 # As part of the Docker build, we attempt to pre-install Synapse's dependencies
 # in the hope that it speeds up the real install of Synapse. To make this work,


### PR DESCRIPTION
Should be backwards-compatible, see
https://github.com/matrix-org/setup-python-poetry/pull/14 for rationale