### PR TITLE
Bump poetry version to 1.3.2.

### DIFF
--- a/docker/synapse.Dockerfile
+++ b/docker/synapse.Dockerfile
@@ -24,7 +24,7 @@ RUN curl -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-tool
 # pip version provided by Debian Buster. See
 # https://github.com/pypa/setuptools/issues/3457#issuecomment-1190125849
 RUN ${PYTHON_VERSION} -m pip install -q --upgrade pip
-RUN ${PYTHON_VERSION} -m pip install -q --no-cache-dir poetry==1.2.2
+RUN ${PYTHON_VERSION} -m pip install -q --no-cache-dir poetry==1.3.2
 
 # As part of the Docker build, we attempt to pre-install Synapse's dependencies
 # in the hope that it speeds up the real install of Synapse. To make this work,
@@ -77,7 +77,7 @@ RUN /venv/bin/pip install -q --no-cache-dir \
 # value.
 # See https://github.com/matrix-org/synapse/issues/12419
 # TODO: Once poetry 1.2.0 has been released, use the `installer.max-workers`
-#       config option instead.
+#       or `installer.parallel` config option instead.
 # poetry has a bug where this environment variable is not converted to a
 # boolean, so we choose a falsy string value for it. It's fixed in 1.2.0,
 # where we'll be wanting to use `installer.max-workers` anyway.


### PR DESCRIPTION
Part of https://github.com/matrix-org/synapse/issues/14857.

While poetry 1.2.2 suffices to read the new lockfile format, we're going to need to use 1.3.x in places to write to it. We don't write to the lockfile in sytest, but for the sake of our sanity we'd like to use the same version everywhere.

In other words, this should be a no-op.