### PR TITLE
Retry getting unread counts

### DIFF
--- a/tests/61push/03_unread_count.pl
+++ b/tests/61push/03_unread_count.pl
@@ -68,38 +68,46 @@ foreach my $action_and_counter (
 
             matrix_advance_room_receipt_synced( $user1, $room_id, "m.read" => $event_id );
          })->then( sub {
-            matrix_sync( $user1 );
+            retry_until_success {
+               matrix_sync( $user1 )->then( sub {
+                  my ( $body ) = @_;
+
+                  my $room = $body->{rooms}{join}{$room_id};
+
+                  assert_json_keys( $room, "unread_notifications" );
+                  my $unread = $room->{unread_notifications};
+                  assert_json_keys( $unread, $counter );
+                  log_if_fail "room notifications:", $unread;
+                  
+                  $unread->{$counter} == 0
+                     or die "Expected $counter to be 0";
+
+
+                  Future->done(1);
+               });
+            }
          })->then( sub {
-            my ( $body ) = @_;
-
-            my $room = $body->{rooms}{join}{$room_id};
-            log_if_fail "room in sync response", $room;
-
-            assert_json_keys( $room, "unread_notifications" );
-            my $unread = $room->{unread_notifications};
-            assert_json_keys( $unread, $counter );
-
-            $unread->{$counter} == 0
-               or die "Expected $counter to be 0";
-
             matrix_send_room_text_message_synced( $user2, $room_id,
                body => "Test message 2",
             );
          })->then( sub {
-            matrix_sync( $user1 );
-         })->then( sub {
-            my ( $body ) = @_;
+            retry_until_success {
+               matrix_sync( $user1 )->then( sub {
+                  my ( $body ) = @_;
 
-            my $room = $body->{rooms}{join}{$room_id};
+                  my $room = $body->{rooms}{join}{$room_id};
 
-            assert_json_keys( $room, "unread_notifications" );
-            my $unread = $room->{unread_notifications};
-            assert_json_keys( $unread, $counter );
+                  assert_json_keys( $room, "unread_notifications" );
+                  my $unread = $room->{unread_notifications};
+                  assert_json_keys( $unread, $counter );
 
-            $unread->{$counter} == 1
-               or die "Expected $counter to be 1";
+                  log_if_fail "room notifications:", $unread;
+                  $unread->{$counter} == 1
+                     or die "Expected $counter to be 1";
 
-            Future->done(1);
+                  Future->done(1);
+               });
+            }
          });
       };
 }
@@ -149,19 +157,22 @@ test "Messages that highlight from another user increment unread highlight count
             body => "Test message 2",
          );
       })->then( sub {
-         matrix_sync( $user1 );
-      })->then( sub {
-         my ( $body ) = @_;
+         retry_until_success {
+            matrix_sync( $user1 )->then( sub {
+               my ( $body ) = @_;
 
-         my $room = $body->{rooms}{join}{$room_id};
+               my $room = $body->{rooms}{join}{$room_id};
 
-         assert_json_keys( $room, "unread_notifications" );
-         my $unread = $room->{unread_notifications};
-         assert_json_keys( $unread, "highlight_count" );
+               assert_json_keys( $room, "unread_notifications" );
+               my $unread = $room->{unread_notifications};
+               assert_json_keys( $unread, "highlight_count" );
 
-         $unread->{highlight_count} == 1
-            or die "Expected unread highlight count to be 1";
+               log_if_fail "room notifications:", $unread;
+               $unread->{highlight_count} == 1
+                  or die "Expected unread highlight count to be 1";
 
-         Future->done(1);
+               Future->done(1);
+            });
+         }
       })
    };


### PR DESCRIPTION
This should fix flakes like https://github.com/matrix-org/sytest/actions/runs/3949863262/jobs/6761624592#step:6:5