### PR TITLE
Synapse: fix the build and reduce logging noise

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -75,10 +75,8 @@ jobs:
             build_args: "SYTEST_IMAGE_TAG=testing"
           - sytest_image_tag: bookworm
             dockerfile: synapse
-            tags: "matrixdotorg/sytest-synapse:bookworm-python3.10"
-            build_args: |
-              SYTEST_IMAGE_TAG=bookworm
-              PYTHON_VERSION=python3.10
+            tags: "matrixdotorg/sytest-synapse:bookworm"
+            # Note: at the time of writing, bookworm's python3 is python 3.11.
 
     steps:
       - name: Set up QEMU

--- a/docker/synapse.Dockerfile
+++ b/docker/synapse.Dockerfile
@@ -23,8 +23,11 @@ RUN curl -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-tool
 # Use the latest version of pip. This pulls in fixes not present in the
 # pip version provided by Debian Buster. See
 # https://github.com/pypa/setuptools/issues/3457#issuecomment-1190125849
-RUN ${PYTHON_VERSION} -m pip install -q --upgrade pip
-RUN ${PYTHON_VERSION} -m pip install -q --no-cache-dir poetry==1.3.2
+# For now, we need to tell Debian we don't care that we're editing the system python
+# installation.
+# Some context in https://github.com/pypa/pip/issues/11381#issuecomment-1399263627
+RUN ${PYTHON_VERSION} -m pip install -q --upgrade pip --break-system-packages
+RUN ${PYTHON_VERSION} -m pip install -q --no-cache-dir poetry==1.3.2 --break-system-packages
 
 # As part of the Docker build, we attempt to pre-install Synapse's dependencies
 # in the hope that it speeds up the real install of Synapse. To make this work,

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -1201,6 +1201,8 @@ global
     ssl-default-bind-ciphers "EECDH+ECDSA+AESGCM EECDH+aRSA+AESGCM EECDH+ECDSA+SHA384 EECDH+ECDSA+SHA256 EECDH+aRSA+SHA384 EECDH+aRSA+SHA256 EECDH+aRSA+RC4 EECDH EDH+aRSA RC4 !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS !RC4"
     ssl-default-bind-options no-sslv3
 
+    maxconn 2000
+
 defaults
     mode http
     log global

--- a/scripts/synapse_sytest.sh
+++ b/scripts/synapse_sytest.sh
@@ -161,7 +161,7 @@ else
         fi
         ln -s -T /venv /synapse/.venv # reuse the existing virtual env
         pushd /synapse
-        poetry install -vvv --extras all
+        poetry install -vv --extras all
         popd
     else
         # Install Synapse and dependencies using pip. As of pip 20.1, this will


### PR DESCRIPTION
> a42e75a3 origin/dmr/sytest-tweaks Limit number of haproxy connections

Suppresses big scary warnings of the form 

```
WARN: server process exited 1
[server]: [NOTICE]   (2457) : haproxy version is 2.6.7-1
[server]: [NOTICE]   (2457) : path to executable is /usr/sbin/haproxy
[server]: [ALERT]    (2457) : Not enough memory to allocate 1073741815 entries for fdtab!
[server]: [ALERT]    (2457) : No polling mechanism available.
[server]:   It is likely that haproxy was built with TARGET=generic and that FD_SETSIZE
[server]:   is too low on this platform to support maxconn and the number of listeners
[server]:   and servers. You should rebuild haproxy specifying your system using TARGET=
[server]:   in order to support other polling systems (poll, epoll, kqueue) or reduce the
[server]:   global maxconn setting to accommodate the system's limitation. For reference,
[server]:   FD_SETSIZE=1024 on this system, global.maxconn=536870884 resulting in a maximum of
[server]:   1073741815 file descriptors. You should thus reduce global.maxconn by 536870396. Also,
[server]:   check build settings using 'haproxy -vv'.
[server]: 
WARN: Error starting server-0: Process died without becoming connectable at tests/05homeserver.pl line 126.
WARN: Aborting test run due to failure to start test server at tests/05homeserver.pl line 130.
WARN: server process exited 1
[server]: [NOTICE]   (2466) : haproxy version is 2.6.7-1
[server]: [NOTICE]   (2466) : path to executable is /usr/sbin/haproxy
[server]: [ALERT]    (2466) : Not enough memory to allocate 1073741815 entries for fdtab!
[server]: [ALERT]    (2466) : No polling mechanism available.
[server]:   It is likely that haproxy was built with TARGET=generic and that FD_SETSIZE
[server]:   is too low on this platform to support maxconn and the number of listeners
[server]:   and servers. You should rebuild haproxy specifying your system using TARGET=
[server]:   in order to support other polling systems (poll, epoll, kqueue) or reduce the
[server]:   global maxconn setting to accommodate the system's limitation. For reference,
[server]:   FD_SETSIZE=1024 on this system, global.maxconn=536870884 resulting in a maximum of
[server]:   1073741815 file descriptors. You should thus reduce global.maxconn by 536870396. Also,
[server]:   check build settings using 'haproxy -vv'.
[server]: 
```

> 19046cf6 Reduce `poetry install` verbosity

otherwise this means that `poetry install` tells about every single file
it ignores, which includes loads of guff in `.mypy_cache` and
`.ruff_cache` and others

> 352d0a70 Fix synapse-sytest:testing build

This might break the other builds though, I haven't tested. See e.g. https://github.com/matrix-org/sytest/actions/workflows/docker.yml