### PR TITLE
Build docker images overnight

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,8 @@ name: Build and deploy docker images
 on:
   push:
     branches: [develop]
+  schedule:
+    - cron: 0 1 * * *  # 1am, daily.
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Even if there are no sytest changes, there are often Synapse dependency changes which we spend time `poetry install`ing. By rebuilding the docker image we are more likely to have Synapse's latest set of dependencies installed when we come to use the sytest docker image.