### PR TITLE
Add /register/available endpoint to `client_reader`

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -1297,6 +1297,7 @@ sub generate_haproxy_map
 ^/_matrix/client/versions$                                           client_reader
 ^/_matrix/client/(api/v1|r0|v3|unstable)/voip/turnServer$            client_reader
 ^/_matrix/client/(r0|v3|unstable)/register$                          client_reader
+^/_matrix/client/(r0|v3|unstable)/register/available$                client_reader
 ^/_matrix/client/(r0|v3|unstable)/auth/.*/fallback/web$              client_reader
 ^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/messages$          client_reader
 ^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/event              client_reader


### PR DESCRIPTION
Should match to https://github.com/matrix-org/synapse/pull/15268

Signed-off-by: Jason Little <realtyem@gmail.com>