### PR TITLE
Add proper server names to join in unban tests

### DIFF
--- a/tests/30rooms/07ban.pl
+++ b/tests/30rooms/07ban.pl
@@ -29,7 +29,7 @@ test "Banned user is kicked and may not rejoin until unbanned",
             })
          }
       })->then( sub {
-         matrix_join_room( $banned_user, $room_id )
+         matrix_join_room( $banned_user, $room_id, ( server_name => $creator->server_name, ) )
             ->main::expect_http_403;  # Must be unbanned first
       })->then( sub {
          do_request_json_for( $creator,
@@ -103,7 +103,7 @@ test "Remote banned user is kicked and may not rejoin until unbanned",
          };
       })->then( sub {
          # Must be unbanned first
-         matrix_join_room( $banned_user, $room_id )->main::check_http_code(
+         matrix_join_room( $banned_user, $room_id, ( server_name => $creator->server_name, ) )->main::check_http_code(
             403 => "ok",
             200 => "redo",
          );


### PR DESCRIPTION
Otherwise the join will fail for reasons other than the one we test for on Synapse.

Required for https://github.com/matrix-org/synapse/pull/15323