### PR TITLE
Improve room send tests

### DIFF
--- a/lib/SyTest/Federation/Room.pm
+++ b/lib/SyTest/Federation/Room.pm
@@ -414,6 +414,7 @@ sub make_join_protoevent
 
       auth_events      => $auth_events,
       content          => { membership => "join" },
+      origin_server_ts => JSON::number( int( time() * 1000 )),
       depth            => JSON::number($self->next_depth),
       prev_events      => $prev_events,
       room_id          => $self->room_id,

--- a/tests/50federation/31room-send.pl
+++ b/tests/50federation/31room-send.pl
@@ -50,7 +50,7 @@ test "Outbound federation can send events",
 test "Inbound federation can receive events",
    requires => [ $main::OUTBOUND_CLIENT,
                  local_user_and_room_fixtures(
-                   user_opts => { with_events => 1 },
+                   user_opts => { with_events => 0 },
                  ),
                  federation_user_id_fixture() ],
 
@@ -98,7 +98,7 @@ test "Inbound federation can receive events",
 test "Inbound federation can receive redacted events",
    requires => [ $main::OUTBOUND_CLIENT,
                  local_user_and_room_fixtures(
-                   user_opts => { with_events => 1 },
+                   user_opts => { with_events => 0 },
                  ),
                  federation_user_id_fixture() ],
 


### PR DESCRIPTION
- Add origin_server_ts in make_join proto events as it's a required in both the [make_join](https://spec.matrix.org/v1.6/server-server-api/#get_matrixfederationv1make_joinroomiduserid) specification and all the PDU definitions in rooms v1-v10.
- Do not require `with_event` in user setup since the tests were migrated to [use sync](https://github.com/matrix-org/sytest/commit/ab34a0ed0d122c7f44fc71fd9a799fdc410a2f38) instead of the deprecated `/event` endpoint