### PR TITLE
Bump docker actions to latest stable release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,23 +30,23 @@ jobs:
     steps:
       - name: Set up QEMU
         id: QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Inspect builder
         run: docker buildx inspect
 
       - name: Log in to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           pull: true
           push: true
@@ -83,23 +83,23 @@ jobs:
     steps:
       - name: Set up QEMU
         id: QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Inspect builder
         run: docker buildx inspect
 
       - name: Log in to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           pull: true
           push: true


### PR DESCRIPTION
Part of https://github.com/matrix-org/synapse/issues/14203. Should get rid of the warnings at e.g. https://github.com/matrix-org/sytest/actions/runs/4604942169. Probably easiest to test by letting this hit develop and see if it works.

I've checked changelogs and AFAICS these are backwards compatible for our purposes. (There's a semver bump because a newer version of GHA runners and/or node.js is required. But we don't care about those.)