### PR TITLE
Fix unsafe assertions for media api tests

### DIFF
--- a/tests/51media/01unicode.pl
+++ b/tests/51media/01unicode.pl
@@ -122,10 +122,10 @@ sub parse_content_disposition_params {
    assert_eq( scalar @parts, 1, "number of content-dispostion header lists" );
    @parts = @{$parts[0]};
 
-   # the first part must be 'inline'
+   # the first part must be 'attachment'
    my $k = shift @parts;
    my $v = shift @parts;
-   assert_eq( $k, "inline", "content-disposition" );
+   assert_eq( $k, "attachment", "content-disposition" );
    die "invalid CD" if defined $v;
 
    my %params;
@@ -233,8 +233,8 @@ test "Can download specifying a different Unicode file name",
          my ( $body, $response ) = @_;
 
          my $disposition = $response->header( "Content-Disposition" );
-         uc $disposition eq uc "inline; filename*=utf-8''$alt_filename_encoded" or
-            uc $disposition eq uc "inline; filename=utf-8\"$alt_filename\"" or
+         uc $disposition eq uc "attachment; filename*=utf-8''$alt_filename_encoded" or
+            uc $disposition eq uc "attachment; filename=utf-8\"$alt_filename\"" or
             die "Expected a UTF-8 filename parameter";
 
          Future->done(1);

--- a/tests/51media/03ascii.pl
+++ b/tests/51media/03ascii.pl
@@ -77,7 +77,7 @@ test "Can download specifying a different ASCII file name",
          my ( $body, $response ) = @_;
 
          my $disposition = $response->header( "Content-Disposition" );
-         $disposition eq "inline; filename=also_ascii" or
+         $disposition eq "attachment; filename=also_ascii" or
             die "Expected an ASCII filename parameter";
 
          Future->done(1);


### PR DESCRIPTION
Fix assertions for unsafe behaviour blocking [matrix-org/synapse/#15680](https://github.com/matrix-org/synapse/pull/15680).