### PR TITLE
Change expectations of filenameless `Content-Disposition`

### DIFF
--- a/tests/51media/02nofilename.pl
+++ b/tests/51media/02nofilename.pl
@@ -24,7 +24,7 @@ sub test_using_client
 
       # Require `attachment` `Content-Disposition` without a filename portion.
       # See `get_media`: {} means attachment with no key-value components in the header value.
-      assert_eq( $disposition, {}, "content-disposition" );
+      assert_eq( scalar %$disposition, 0, "content-disposition" );
 
       Future->done(1);
    });

--- a/tests/51media/02nofilename.pl
+++ b/tests/51media/02nofilename.pl
@@ -23,7 +23,7 @@ sub test_using_client
       my ( $disposition ) = @_;
 
       # Require `attachment` `Content-Disposition` without a filename portion.
-      assert_eq( $disposition, "attachment", "content-disposition" );
+      $disposition eq "attachment" or die "Expected content-disposition of `attachment`";
 
       Future->done(1);
    });

--- a/tests/51media/02nofilename.pl
+++ b/tests/51media/02nofilename.pl
@@ -23,7 +23,8 @@ sub test_using_client
       my ( $disposition ) = @_;
 
       # Require `attachment` `Content-Disposition` without a filename portion.
-      $disposition eq "attachment" or die "Expected content-disposition of `attachment`";
+      # See `get_media`: {} means attachment with no key-value components in the header value.
+      assert_eq( $disposition, {}, "content-disposition" );
 
       Future->done(1);
    });

--- a/tests/51media/02nofilename.pl
+++ b/tests/51media/02nofilename.pl
@@ -22,8 +22,8 @@ sub test_using_client
    get_media( $client, $content_id )->then( sub {
       my ( $disposition ) = @_;
 
-      defined $disposition and
-         die "Unexpected Content-Disposition header";
+      # Require `attachment` `Content-Disposition` without a filename portion.
+      assert_eq( $disposition, "attachment", "content-disposition" );
 
       Future->done(1);
    });


### PR DESCRIPTION
Follows #1353 

For the 'no filename' test, SyTest was expecting no `Content-Disposition` header. Given what we want to achieve, I propose we instead expect a value of `attachment` (without a filename part).