### PR TITLE
Drop old oldstable buster and sub new oldstable bullseye

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,8 +25,8 @@ jobs:
         include:
           - base_image: ubuntu:focal
             tag: focal
-          - base_image: debian:buster
-            tag: buster
+          - base_image: debian:bullseye
+            tag: bullseye
           - base_image: debian:testing
             tag: testing
     steps:
@@ -69,10 +69,10 @@ jobs:
             dockerfile: synapse
             tags: "matrixdotorg/sytest-synapse:focal"
             build_args: "SYTEST_IMAGE_TAG=focal"
-          - sytest_image_tag: buster
+          - sytest_image_tag: bullseye
             dockerfile: synapse
-            tags: "matrixdotorg/sytest-synapse:buster"
-            build_args: "SYTEST_IMAGE_TAG=buster"
+            tags: "matrixdotorg/sytest-synapse:bullseye"
+            build_args: "SYTEST_IMAGE_TAG=bullseye"
           - sytest_image_tag: testing
             dockerfile: synapse
             tags: "matrixdotorg/sytest-synapse:testing"

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,9 +8,9 @@ but its dependencies are.
 Included currently is:
 
 - `matrixdotorg/sytest` Base container with SyTest dependencies installed
-  - Tagged by underlying Debian/Ubuntu image: `focal`, `buster` or `testing`
+  - Tagged by underlying Debian/Ubuntu image: `focal`, `bullseye` or `testing`
 - `matrixdotorg/sytest-synapse`: Runs SyTest against Synapse
-  - Tagged by underlying Debian/Ubunutu image: `focal`, `buster` or `testing`
+  - Tagged by underlying Debian/Ubunutu image: `focal`, `bullseye` or `testing`
 
 ## Target-specific details
 
@@ -23,7 +23,7 @@ it is useful to mount a volume there too.
 For example:
 
 ```
-docker run --rm -it -v /path/to/synapse\:/src:ro -v /path/to/where/you/want/logs\:/logs matrixdotorg/sytest-synapse:buster
+docker run --rm -it -v /path/to/synapse\:/src:ro -v /path/to/where/you/want/logs\:/logs matrixdotorg/sytest-synapse:focal
 ```
 
 The following environment variables can be set with `-e` to control the test run:
@@ -43,7 +43,7 @@ An example of running Synapse in worker mode:
 
 ```
 docker run --rm -it -e POSTGRES=1 -e WORKERS=1 -v /path/to/synapse\:/src:ro \
-    -v /path/to/where/you/want/logs\:/logs matrixdotorg/sytest-synapse:buster
+    -v /path/to/where/you/want/logs\:/logs matrixdotorg/sytest-synapse:focal
 ```
 
 ### Dendrite
@@ -68,7 +68,7 @@ for example:
 docker run --rm -it \
     -e SYTEST_BRANCH="my-sytest-branch"
     -v /path/to/synapse\:/src:ro -v /path/to/where/you/want/logs\:/logs
-    matrixdotorg/sytest-synapse:buster
+    matrixdotorg/sytest-synapse:focal
 ```
 
 If the branch referred to by `SYTEST_BRANCH` does not exist, `develop` is used
@@ -80,7 +80,7 @@ the container:
 
 ```
 docker run --rm -it -v /path/to/synapse\:/src:ro -v /path/to/where/you/want/logs\:/logs \
-    -v /path/to/code/sytest\:/sytest:ro matrixdotorg/sytest-synapse:buster
+    -v /path/to/code/sytest\:/sytest:ro matrixdotorg/sytest-synapse:focal
 ```
 
 ## Running a single test file, and other sytest commandline options
@@ -89,7 +89,7 @@ You can pass arguments to sytest by adding them at the end of the
 docker command. For example:
 
 ```
-docker run --rm -it ... matrixdotorg/sytest-synapse:buster tests/20profile-events.pl
+docker run --rm -it ... matrixdotorg/sytest-synapse:focal tests/20profile-events.pl
 ```
 
 ## Building the containers

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=debian:buster
+ARG BASE_IMAGE=debian:bullseye
 
 FROM ${BASE_IMAGE}
 

--- a/docker/dendrite.Dockerfile
+++ b/docker/dendrite.Dockerfile
@@ -1,4 +1,4 @@
-ARG SYTEST_IMAGE_TAG=buster
+ARG SYTEST_IMAGE_TAG=bullseye
 FROM matrixdotorg/sytest:${SYTEST_IMAGE_TAG}
 
 ARG GO_VERSION=1.19.1

--- a/docker/synapse.Dockerfile
+++ b/docker/synapse.Dockerfile
@@ -1,4 +1,4 @@
-ARG SYTEST_IMAGE_TAG=buster
+ARG SYTEST_IMAGE_TAG=bullseye
 
 FROM matrixdotorg/sytest:${SYTEST_IMAGE_TAG}
 
@@ -21,13 +21,9 @@ RUN mkdir /rust /cargo
 
 RUN curl -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain stable --profile minimal
 
-# Use the latest version of pip. This pulls in fixes not present in the
-# pip version provided by Debian Buster. See
-# https://github.com/pypa/setuptools/issues/3457#issuecomment-1190125849
 # For now, we need to tell Debian we don't care that we're editing the system python
 # installation.
 # Some context in https://github.com/pypa/pip/issues/11381#issuecomment-1399263627
-RUN ${PYTHON_VERSION} -m pip install -q --upgrade pip ${SYSTEM_PIP_INSTALL_SUFFIX}
 RUN ${PYTHON_VERSION} -m pip install -q --no-cache-dir poetry==1.3.2 ${SYSTEM_PIP_INSTALL_SUFFIX}
 
 # As part of the Docker build, we attempt to pre-install Synapse's dependencies


### PR DESCRIPTION
As part of dropping support for python 3.7, drop debian buster (python version 3.7) and sub in debian bullseye (python 3.9). 

Corresponding Synapse PR's: https://github.com/matrix-org/synapse/pull/15892, https://github.com/matrix-org/synapse/pull/15893