### PR TITLE
Support rendering some media downloads as inline

### DIFF
--- a/tests/51media/01unicode.pl
+++ b/tests/51media/01unicode.pl
@@ -130,7 +130,7 @@ sub parse_content_disposition_params {
    my $k = shift @parts;
    my $v = shift @parts;
 
-   if ($allow_inline_disposition eq 1) {
+   if ($allow_inline_disposition) {
       assert_ok( $k eq "attachment" or $k eq "inline", "content-disposition");
    }
    else {

--- a/tests/51media/01unicode.pl
+++ b/tests/51media/01unicode.pl
@@ -90,7 +90,7 @@ push our @EXPORT, qw( upload_test_content );
 
 =head2 get_media
 
-   my ( $content_disposition_params, $content ) = get_media( $http, $content_id, $allowed_depositions ) -> get;
+   my ( $content_disposition_params, $content ) = get_media( $http, $content_id, $allow_inline_disposition ) -> get;
 
 Fetches a piece of media from the server.
 

--- a/tests/51media/01unicode.pl
+++ b/tests/51media/01unicode.pl
@@ -57,7 +57,7 @@ sub upload_test_content
 {
    my ( $user, %params, $content_type) = @_;
 
-   $content_type ||= "application/octet-stream"
+   $content_type ||= "application/octet-stream";
 
    $user->http->do_request(
       method       => "POST",

--- a/tests/51media/02nofilename.pl
+++ b/tests/51media/02nofilename.pl
@@ -6,7 +6,7 @@ test "Can upload without a file name",
    do => sub {
       my ( $user ) = @_;
 
-      upload_test_content( $user, )->then( sub {
+      upload_test_content( $user )->then( sub {
          ( $content_id ) = @_;
          Future->done(1)
       });
@@ -19,7 +19,7 @@ sub test_using_client
 {
    my ( $client ) = @_;
 
-   get_media( $client, $content_id )->then( sub {
+   get_media( $client, $content_id, 0 )->then( sub {
       my ( $disposition ) = @_;
 
       # Require `attachment` `Content-Disposition` without a filename portion.

--- a/tests/51media/04inline.pl
+++ b/tests/51media/04inline.pl
@@ -4,10 +4,10 @@ my $content_id;
 # in the browser. This is checked in get_media
 
 test "Can download a file that optionally inlines",
-   requires => [ $main::API_CLIENTS[0] ],
+   requires => [ $main::API_CLIENTS[0], local_user_fixture() ],
 
    check => sub {
-      my ( $http ) = @_;
+      my ( $http, $user ) = @_;
       upload_test_content( $user, {} , "text/plain")->then( sub {
          ( $content_id ) = @_;
          get_media( $http, $content_id, 1 )->then( sub {

--- a/tests/51media/04inline.pl
+++ b/tests/51media/04inline.pl
@@ -1,0 +1,22 @@
+my $content_id;
+
+# This test ensures an uploaded file may optionally be rendered inline
+# in the browser. This is checked in get_media
+
+sub test_using_client
+{
+   my ( $client ) = @_;
+}
+
+test "Can download a file that optionally inlines",
+   requires => [ $main::API_CLIENTS[0] ],
+
+   check => sub {
+      my ( $http ) = @_;
+      upload_test_content( $user, {} , "text/plain")->then( sub {
+         ( $content_id ) = @_;
+         get_media( $http, $content_id, 1 )->then( sub {
+            Future->done(1);
+         })
+      });
+   };

--- a/tests/51media/04inline.pl
+++ b/tests/51media/04inline.pl
@@ -3,11 +3,6 @@ my $content_id;
 # This test ensures an uploaded file may optionally be rendered inline
 # in the browser. This is checked in get_media
 
-sub test_using_client
-{
-   my ( $client ) = @_;
-}
-
 test "Can download a file that optionally inlines",
    requires => [ $main::API_CLIENTS[0] ],
 


### PR DESCRIPTION
For https://github.com/matrix-org/synapse/pull/15988

This is incredibly hamfisted, as my ability to write perl is limited. The idea here is that we allow either inline or attachment depositions for certain content-types.