### PR TITLE
Update appservice tests to check for access token in header vs query params

### DIFF
--- a/tests/60app-services/05lookup3pe.pl
+++ b/tests/60app-services/05lookup3pe.pl
@@ -147,13 +147,15 @@ test "HS will proxy request for 3PU mapping",
             my ( $request ) = @_;
             
             my $access_token = $appserv1->info->hs2as_token;
+            my $auth_header = $request->header("Authorization");
+
+            assert_eq($auth_header, "Bearer " . $access_token, 'Access token');
 
             assert_deeply_eq(
                { $request->query_form },
                {
                   field1 => "ONE",
                   field2 => "TWO",
-                  access_token => $access_token,
                },
                'fields in received AS request'
             );
@@ -213,12 +215,14 @@ test "HS will proxy request for 3PL mapping",
          )->then( sub {
             my ( $request ) = @_;
             my $access_token = $appserv1->info->hs2as_token;
+            my $auth_header = $request->header("Authorization");
+
+            assert_eq($auth_header, "Bearer " . $access_token, 'Access token');
 
             assert_deeply_eq(
                { $request->query_form },
                {
                   field3 => "THREE",
-                  access_token => $access_token,
                },
                'fields in received AS request'
             );


### PR DESCRIPTION
Synapse v1.81.0 deprecated application service authorization via query parameters - authorization should now be sent via Authorization header. This PR (I hope, Perl is not my native language) changes two appservice tests to stop checking the query params for the access token and to check for them instead in the Authorization header. 