### PR TITLE
Build a `sytest-synapse` docker image with 3.12

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,6 +25,8 @@ jobs:
         include:
           - base_image: ubuntu:focal
             tag: focal
+          - base_image: ubuntu:mantic
+            tag: mantic
           - base_image: debian:bullseye
             tag: bullseye
           - base_image: debian:testing
@@ -69,6 +71,12 @@ jobs:
             dockerfile: synapse
             tags: "matrixdotorg/sytest-synapse:focal"
             build_args: "SYTEST_IMAGE_TAG=focal"
+          - sytest_image_tag: mantic
+            dockerfile: synapse
+            tags: "matrixdotorg/sytest-synapse:mantic-3.12"
+            build_args: |
+              SYTEST_IMAGE_TAG=mantic
+              PYTHON_VERSION=python3.12
           - sytest_image_tag: bullseye
             dockerfile: synapse
             tags: "matrixdotorg/sytest-synapse:bullseye"


### PR DESCRIPTION
Mainly to see if it speeds up synapse CI when using asyncio