### PR TITLE
Add missing v2 variants from Synapse reverse proxy config.

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -1255,9 +1255,9 @@ sub generate_haproxy_map
 ^/_matrix/federation/v1/query/                        federation_reader
 ^/_matrix/federation/v1/make_join/                    federation_reader
 ^/_matrix/federation/v1/make_leave/                   federation_reader
-^/_matrix/federation/v1/send_join/                    federation_reader
-^/_matrix/federation/v1/send_leave/                   federation_reader
-^/_matrix/federation/v1/invite/                       federation_reader
+^/_matrix/federation/(v1|v2)/send_join/               federation_reader
+^/_matrix/federation/(v1|v2)/send_leave/              federation_reader
+^/_matrix/federation/(v1|v2)/invite/                  federation_reader
 ^/_matrix/federation/v1/query_auth/                   federation_reader
 ^/_matrix/federation/v1/event_auth/                   federation_reader
 ^/_matrix/federation/v1/exchange_third_party_invite/  federation_reader


### PR DESCRIPTION
The v2 variants of these three endpoints were missing. Thus any requests to them were going to the main Synapse process, rather than the `federation_reader` worker.

Noticed by @clokep in https://github.com/matrix-org/sytest/pull/1379/files/a4aad84d4931cb5baeeb93c51e2d6fb55ed8ae55#r1601416890.