### PR TITLE
Attempt to fix synapse-sytest docker images

### DIFF
--- a/lib/SyTest/SSL.pm
+++ b/lib/SyTest/SSL.pm
@@ -62,7 +62,13 @@ sub create_ssl_cert
    # Create extension file
    my $ext_file = "$cert_file.ext";
    open(my $fh, '>', $ext_file) or die "Could not open file '$ext_file': $!";
-   print $fh "subjectAltName=DNS:$server_name\n";
+   if ( $server_name =~ m/^[\d\.:]+$/ ) {
+      # We assume that a server name that is purely numeric (plus ':' and '.')
+      # is an IP.
+      print $fh "subjectAltName=IP:$server_name\n";
+   } else {
+      print $fh "subjectAltName=DNS:$server_name\n";
+   }
    close $fh;
 
    # sign it with the CA

--- a/scripts/synapse_sytest.sh
+++ b/scripts/synapse_sytest.sh
@@ -192,9 +192,11 @@ echo >&2 "+++ Running tests"
 
 export COVERAGE_PROCESS_START="/src/.coveragerc"
 
+# We set the `--bind-host` as 127.0.0.1 as docker sometimes can't find
+# localhost.
 RUN_TESTS=(
     perl -I "$SYTEST_LIB" /sytest/run-tests.pl --python=/venv/bin/python --synapse-directory=/src -B "/src/$BLACKLIST" --coverage -O tap --all
-    --work-directory="/work"
+    --work-directory="/work" --bind-host 127.0.0.1
 )
 
 if [ -n "$ASYNCIO_REACTOR" ]; then


### PR DESCRIPTION
Bind to 127.0.0.1 when using docker.

I'm not sure why this is a problem, but emprically it is now required
for me to run it locally.

The exact thing that needs to change is that HaProxy server addresses
need to be changed. I assume its something like when HaProxy starts
`localhost` can't be resolved.