### PR TITLE
Add the new Matrix v1.11 media worker endpoints

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -1245,6 +1245,8 @@ sub generate_haproxy_map
 ^/_matrix/client/(api/v1|r0|v3)/rooms/[^/]+/initialSync$ synchrotron
 
 ^/_matrix/media/                           media_repository
+^/_matrix/client/v1/media/.*$              media_repository
+^/_matrix/federation/v1/media/.*$          media_repository
 ^/_synapse/admin/v1/purge_media_cache$     media_repository
 ^/_synapse/admin/v1/room/.*/media.*$       media_repository
 ^/_synapse/admin/v1/user/.*/media.*$       media_repository


### PR DESCRIPTION
As per https://spec.matrix.org/v1.11/client-server-api/#get_matrixclientv1mediaconfig and https://spec.matrix.org/v1.11/server-server-api/#get_matrixfederationv1mediadownloadmediaid.

These got missed during review.