### PR TITLE
Update upload-artifact github action

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -112,7 +112,7 @@ jobs:
         run:  /sytest/scripts/tap_to_gha.pl /logs/results.tap
 
       - name: Upload SyTest logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         if: ${{ always() }}
         with:
           name: Sytest Logs - ${{ job.status }} - (Synapse, ${{ matrix.label }})
@@ -187,7 +187,7 @@ jobs:
         run:  /sytest/scripts/tap_to_gha.pl /logs/results.tap
 
       - name: Upload SyTest logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         if: ${{ always() }}
         with:
           name: Sytest Logs - ${{ job.status }} - (Dendrite, ${{ join(matrix.*, ', ') }})


### PR DESCRIPTION
v2 was deprecated mid-2024 and is now breaking workflow runs.