### PR TITLE
Remove unsupported distros

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,10 +23,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - base_image: ubuntu:focal
-            tag: focal
-          - base_image: ubuntu:mantic
-            tag: mantic
           - base_image: debian:bullseye
             tag: bullseye
           - base_image: debian:testing
@@ -67,17 +63,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - sytest_image_tag: focal
-            dockerfile: synapse
-            tags: "matrixdotorg/sytest-synapse:focal"
-            build_args: "SYTEST_IMAGE_TAG=focal"
-          - sytest_image_tag: mantic
-            dockerfile: synapse
-            tags: "matrixdotorg/sytest-synapse:mantic-3.12"
-            build_args: |
-              SYTEST_IMAGE_TAG=mantic
-              PYTHON_VERSION=python3.12
-              SYSTEM_PIP_INSTALL_SUFFIX=--break-system-packages
           - sytest_image_tag: bullseye
             dockerfile: synapse
             tags: "matrixdotorg/sytest-synapse:bullseye"

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,18 +21,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - label: Py 3.8, SQLite 3.31.1, Monolith
-            sytest-tag: focal
-
-          - label: Py 3.8, PG 12, Monolith
-            sytest-tag: focal
-            postgres: postgres
-
-          - label: Py 3.8, PG 12, Workers
-            sytest-tag: focal
-            postgres: postgres
-            workers: workers
-
           - label: Py 3.10, PG 14, Monolith
             sytest-tag: bookworm-python3.10
             postgres: postgres

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,9 +8,9 @@ but its dependencies are.
 Included currently is:
 
 - `matrixdotorg/sytest` Base container with SyTest dependencies installed
-  - Tagged by underlying Debian/Ubuntu image: `focal`, `bullseye` or `testing`
+  - Tagged by underlying Debian/Ubuntu image: `bullseye` or `testing`
 - `matrixdotorg/sytest-synapse`: Runs SyTest against Synapse
-  - Tagged by underlying Debian/Ubunutu image: `focal`, `bullseye` or `testing`
+  - Tagged by underlying Debian/Ubunutu image: `bullseye` or `testing`
 
 ## Target-specific details
 
@@ -23,7 +23,7 @@ it is useful to mount a volume there too.
 For example:
 
 ```
-docker run --rm -it -v /path/to/synapse\:/src:ro -v /path/to/where/you/want/logs\:/logs matrixdotorg/sytest-synapse:focal
+docker run --rm -it -v /path/to/synapse\:/src:ro -v /path/to/where/you/want/logs\:/logs matrixdotorg/sytest-synapse:bullseye
 ```
 
 The following environment variables can be set with `-e` to control the test run:
@@ -43,7 +43,7 @@ An example of running Synapse in worker mode:
 
 ```
 docker run --rm -it -e POSTGRES=1 -e WORKERS=1 -v /path/to/synapse\:/src:ro \
-    -v /path/to/where/you/want/logs\:/logs matrixdotorg/sytest-synapse:focal
+    -v /path/to/where/you/want/logs\:/logs matrixdotorg/sytest-synapse:bullseye
 ```
 
 ### Dendrite
@@ -68,7 +68,7 @@ for example:
 docker run --rm -it \
     -e SYTEST_BRANCH="my-sytest-branch"
     -v /path/to/synapse\:/src:ro -v /path/to/where/you/want/logs\:/logs
-    matrixdotorg/sytest-synapse:focal
+    matrixdotorg/sytest-synapse:bullseye
 ```
 
 If the branch referred to by `SYTEST_BRANCH` does not exist, `develop` is used
@@ -80,7 +80,7 @@ the container:
 
 ```
 docker run --rm -it -v /path/to/synapse\:/src:ro -v /path/to/where/you/want/logs\:/logs \
-    -v /path/to/code/sytest\:/sytest:ro matrixdotorg/sytest-synapse:focal
+    -v /path/to/code/sytest\:/sytest:ro matrixdotorg/sytest-synapse:bullseye
 ```
 
 ## Running a single test file, and other sytest commandline options
@@ -89,7 +89,7 @@ You can pass arguments to sytest by adding them at the end of the
 docker command. For example:
 
 ```
-docker run --rm -it ... matrixdotorg/sytest-synapse:focal tests/20profile-events.pl
+docker run --rm -it ... matrixdotorg/sytest-synapse:bullseye tests/20profile-events.pl
 ```
 
 ## Building the containers

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,7 +10,7 @@ Included currently is:
 - `matrixdotorg/sytest` Base container with SyTest dependencies installed
   - Tagged by underlying Debian/Ubuntu image: `bullseye` or `testing`
 - `matrixdotorg/sytest-synapse`: Runs SyTest against Synapse
-  - Tagged by underlying Debian/Ubunutu image: `bullseye` or `testing`
+  - Tagged by underlying Debian/Ubuntu image: `bullseye` or `testing`
 
 ## Target-specific details
 


### PR DESCRIPTION
Synapse v1.119 will remove support for python 3.8. This means Ubuntu `focal` is no longer supported either.
This PR also removes the `mantic` distro since it is unsupported as well.