### PR TITLE
Update configurations to recognize `dbname` instead of `database`

### DIFF
--- a/lib/SyTest/Homeserver.pm
+++ b/lib/SyTest/Homeserver.pm
@@ -409,7 +409,7 @@ sub _check_db_config
 
    my $db_type = $db_config{type};
    if( $db_type eq 'pg' ) {
-      foreach (qw( database )) {
+      foreach (qw( dbname )) {
          if( !$db_config{args}->{$_} ) {
             die "Missing required database argument $_";
          }
@@ -445,7 +445,7 @@ sub _clear_db_pg
    my %args = @_;
 
    my $host = $args{host} // '';
-   $self->{output}->diag( "Clearing Pg database $args{database} on '$host'" );
+   $self->{output}->diag( "Clearing Pg database $args{dbname} on '$host'" );
 
    require DBI;
    require DBD::Pg;
@@ -455,13 +455,13 @@ sub _clear_db_pg
    # a fair few seconds)
    my $dbh = DBI->connect( "dbi:Pg:dbname=sytest_template;host=$host", $args{user}, $args{password} );
    if ( $dbh ) {
-      $dbh->do( "DROP DATABASE $args{database}" );  # we don't mind if this dies
+      $dbh->do( "DROP DATABASE $args{dbname}" );  # we don't mind if this dies
 
-      $dbh->do( "CREATE DATABASE $args{database} WITH TEMPLATE sytest_template" ) or
+      $dbh->do( "CREATE DATABASE $args{dbname} WITH TEMPLATE sytest_template" ) or
          die $dbh->errstr;
    }
    else {
-      $dbh = DBI->connect( "dbi:Pg:dbname=$args{database};host=$host", $args{user}, $args{password} )
+      $dbh = DBI->connect( "dbi:Pg:dbname=$args{dbname};host=$host", $args{user}, $args{password} )
          or die DBI->errstr;
 
       foreach my $row ( @{ $dbh->selectall_arrayref( "SELECT tablename FROM pg_tables WHERE schemaname = 'public'" ) } ) {

--- a/lib/SyTest/Homeserver.pm
+++ b/lib/SyTest/Homeserver.pm
@@ -374,8 +374,11 @@ sub _get_dbconfigs
    foreach my $db ( keys %db_configs ) {
       my $db_config = $db_configs{$db};
 
-      # backwards-compatibility hacks
-      my $db_name = delete $db_config->{name};
+      # Extract the name of the module that is used to access the database. This
+      # does add a new item to the database config block, 'type'. It appears to
+      # be harmless and is used later on to determine which method to use to
+      # clear the database
+      my $db_name = $db_config->{name};
       if( defined $db_name ) {
          if( $db_name eq 'psycopg2' ) {
             $db_config->{type} = 'pg';

--- a/lib/SyTest/Homeserver/Dendrite.pm
+++ b/lib/SyTest/Homeserver/Dendrite.pm
@@ -91,7 +91,7 @@ sub _get_config
       $db_config{args}->{user},
       $db_config{args}->{password},
       "", # $db_config{args}->{host},
-      $db_config{args}->{database},
+      $db_config{args}->{dbname},
       $db_config{args}->{sslmode},
    );
 

--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -125,21 +125,6 @@ sub start
       },
    );
 
-   # convert sytest db args onto synapse db args
-   for my $db ( keys %db_configs ) {
-      my %db_config = %{ $db_configs{$db} };
-
-      my $db_type = $db_config{type};
-
-      if( $db_type eq "pg" ) {
-         $db_configs{$db}{name} = 'psycopg2';
-      }
-      else {
-         # must be sqlite
-         $db_configs{$db}{name} = 'sqlite3';
-      }
-   }
-
    # Clean up the media_store directory each time, or else it fills up with
    # thousands of automatically-generated avatar images
    if( -d "$hs_dir/media_store" ) {

--- a/scripts/prep_sytest_for_postgres.sh
+++ b/scripts/prep_sytest_for_postgres.sh
@@ -28,7 +28,7 @@ mkdir -p "server-1"
 cat > "server-0/database.yaml" << EOF
 name: psycopg2
 args:
-    database: $POSTGRES_DB_1
+    dbname: $POSTGRES_DB_1
     user: $PGUSER
     password: $PGPASSWORD
     host: localhost
@@ -38,7 +38,7 @@ EOF
 cat > "server-1/database.yaml" << EOF
 name: psycopg2
 args:
-    database: $POSTGRES_DB_2
+    dbname: $POSTGRES_DB_2
     user: $PGUSER
     password: $PGPASSWORD
     host: localhost

--- a/scripts/synapse_sytest.sh
+++ b/scripts/synapse_sytest.sh
@@ -56,7 +56,7 @@ main:
     data_stores:
         - main
     args:
-        database: pg1_main
+        dbname: pg1_main
         user: postgres
         password: $PGPASSWORD
         host: localhost
@@ -66,7 +66,7 @@ state_db:
     data_stores:
         - state
     args:
-        database: pg1_state
+        dbname: pg1_state
         user: postgres
         password: $PGPASSWORD
         host: localhost
@@ -79,7 +79,7 @@ main:
     data_stores:
         - main
     args:
-        database: pg2_main
+        dbname: pg2_main
         user: postgres
         password: $PGPASSWORD
         host: localhost
@@ -89,7 +89,7 @@ state_db:
     data_stores:
         - state
     args:
-        database: pg2_state
+        dbname: pg2_state
         user: postgres
         password: $PGPASSWORD
         host: localhost


### PR DESCRIPTION
In preparation of a new database driver for Synapse, let's stop mutating the configuration after it's generated. Since `dbname` is what is already used by libpq and is what is expected by Synapse's configuration parsing, just use this. In Dendrite's case, it's not used directly but is parsed and turned into a DSN to feed to it's command line invocation.

This does not modify the pre-existing behavior of adding an additional attribute to that part of the yaml block as it did before: `type: pg` or `type: sqlite`, depending. It appears this is only used to identify which method to invoke to pre-clear the database before testing starts and is otherwise harmless.