### PR TITLE
Synapse: increase presence ratelimit for tests

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -229,6 +229,13 @@ sub start
            },
         },
 
+        rc_presence => {
+           per_user => {
+              per_second => 1000,
+              burst_count => 1000,
+           },
+        },
+
         enable_registration => "true",
         enable_registration_without_verification => "true",
         databases => \%db_configs,


### PR DESCRIPTION
This ratelimit is introduced in https://github.com/element-hq/synapse/pull/18000 and causes some existing Sytests to fail for Synapse.

Increase the ratelimit in Sytest's Synapse config so tests pass again.

---

Note: I've re-pushed https://github.com/element-hq/synapse/pull/18000's branch to https://github.com/element-hq/synapse/tree/set-presence-ratelimit so that the Sytest PR's CI will test that branch instead of `develop`.