### PR TITLE
Enable room list publication rules explicitly

### DIFF
--- a/lib/SyTest/Homeserver/Synapse.pm
+++ b/lib/SyTest/Homeserver/Synapse.pm
@@ -368,6 +368,11 @@ sub start
            host    => $self->{redis_host},
         },
 
+        # Tests assume that room list publication is enabled.
+        room_list_publication_rules => [{
+           action => "allow",
+        }],
+
         map {
            defined $self->{$_} ? ( $_ => $self->{$_} ) : ()
         } qw(


### PR DESCRIPTION
Synapse disables them by default as of https://github.com/element-hq/synapse/pull/18175