### PR TITLE
Check that invalid PDUs are ignored, instead of erroring out

### DIFF
--- a/tests/50federation/51transactions.pl
+++ b/tests/50federation/51transactions.pl
@@ -51,8 +51,8 @@ test "Server correctly handles transactions that break edu limits",
 # on PDUs. Test that a transaction to `send` with a PDU that has bad data will
 # be handled properly.
 #
-# This enforces that the entire transaction is rejected if a single bad PDU is
-# sent. It is unclear if this is the correct behavior or not.
+# This enforces that invalid PDUs are discarded rather than failing the entire
+# transaction.
 #
 # See https://github.com/matrix-org/synapse/issues/7543
 test "Server discards events with invalid JSON in a version 6 room",
@@ -87,7 +87,7 @@ test "Server discards events with invalid JSON in a version 6 room",
 
       my @pdus = ( $good_event, $bad_event );
 
-      # Send the transaction to the client and expect a fail
+      # Send the transaction to the client and expect to succeed
       $outbound_client->send_transaction(
           pdus => \@pdus,
           destination => $creator->server_name,

--- a/tests/50federation/51transactions.pl
+++ b/tests/50federation/51transactions.pl
@@ -160,5 +160,5 @@ test "Server rejects invalid JSON in a version 6 room",
       $outbound_client->send_transaction(
           pdus => \@pdus,
           destination => $creator->server_name,
-      )->main::expect_bad_json
+      )->main::expect_m_bad_json
    };

--- a/tests/50federation/51transactions.pl
+++ b/tests/50federation/51transactions.pl
@@ -54,6 +54,9 @@ test "Server correctly handles transactions that break edu limits",
 # This enforces that invalid PDUs are discarded rather than failing the entire
 # transaction.
 #
+# It is unclear whether the invalid PDU should be included in the /send response
+# with an error, which is why there is no assertion on the response.
+#
 # See https://github.com/matrix-org/synapse/issues/7543
 test "Server discards events with invalid JSON in a version 6 room",
    requires => [ $main::OUTBOUND_CLIENT,


### PR DESCRIPTION
This is similar to #1391, but it doesn't assert on the /send body response, and rather looks at events persisted through /sync and /events