### PR TITLE
Remove origin as expected field in federation formatted sync event

### DIFF
--- a/tests/31sync/13filtered_sync.pl
+++ b/tests/31sync/13filtered_sync.pl
@@ -79,7 +79,7 @@ test "Can request federation format via the filter",
 
          assert_json_keys(
             $room->{timeline}{events}[0], qw(
-               event_id content room_id sender origin origin_server_ts type
+               event_id content room_id sender origin_server_ts type
                prev_events auth_events depth hashes signatures
             )
          );


### PR DESCRIPTION
The origin field was remove from all PDUs in https://github.com/matrix-org/matrix-spec/pull/998
This was mostly cleaned up back with this PR https://github.com/matrix-org/sytest/pull/1293, but it seems like one location was missed.

When [removing the origin field from Synapse](https://github.com/element-hq/synapse/pull/18418), the `13filtered_sync.pl/Can request federation format via the filter` test fails because it asserts that the origin field is present.

As per the [spec section on event formats for the client-server API](https://spec.matrix.org/v1.14/client-server-api/#room-event-format), the returned events should follow the PDU definition for the relevant room version. The `origin` field has been removed in all room version PDU definitions, so it should no longer be asserted in this test.