### PR TITLE
[WIP] Also copy out syslog

### DIFF
--- a/scripts/synapse_sytest.sh
+++ b/scripts/synapse_sytest.sh
@@ -231,6 +231,7 @@ echo >&2 "--- Copying assets"
 
 # Copy out the logs
 rsync --ignore-missing-args --min-size=1B -av /work/server-0 /work/server-1 /logs --include "*/" --include="*.log.*" --include="*.log" --exclude="*"
+cp /var/log/syslog /logs/syslog
 #cp /.coverage.* /src || true
 
 #cd /src


### PR DESCRIPTION
Trying to see why worker tests sometimes start failing, one theory is a process gets oom killed so lets copy out syslog