### PR TITLE
Retrieve Redis logs for Synapse runs

### DIFF
--- a/scripts/synapse_sytest.sh
+++ b/scripts/synapse_sytest.sh
@@ -17,7 +17,7 @@ mkdir -p /work
 
 # start the redis server, if desired
 if [ -n "$WORKERS" ]; then
-    /usr/bin/redis-server /etc/redis/redis.conf --loglevel verbose
+    /usr/bin/redis-server /etc/redis/redis.conf --loglevel debug
 fi
 
 # PostgreSQL setup


### PR DESCRIPTION
Retrieve the redis log as well from where it lives: `/var/log/redis` <- `redis-server.log`

It's not especially large, and seems for a normal run to be extremely uninteresting. Next big fail if it shows nothing, let's bump the verbosity up a level

Simple enough
![image](https://github.com/user-attachments/assets/9eb883e2-8640-4417-a337-8fcc7f32eac6)
