### PR TITLE
No need to configure the `LoggingContextFilter`

### DIFF
--- a/lib/SyTest/Homeserver.pm
+++ b/lib/SyTest/Homeserver.pm
@@ -222,19 +222,11 @@ sub configure_logger
             format => "%(asctime)s - %(name)s - %(lineno)d - %(levelname)s - %(request)s - %(message)s"
          }
       },
-
-      filters => {
-         context => {
-            "()" => "synapse.logging.context.LoggingContextFilter",
-            request => ""
-         }
-      },
       handlers => {
          file => {
             class => "logging.FileHandler",
             formatter => "precise",
             filename => "$hs_dir/$log_type.log",
-            filters => ["context"],
             encoding => "utf8"
          }
       },


### PR DESCRIPTION
No need to configure the `LoggingContextFilter`

This hasn't been necessary for 5 years since https://github.com/matrix-org/synapse/pull/8051 because we automatically configure this for you within Synapse itself.

Spawning from seeing this fail after we tried to change the `LoggingContextFilter` constructor in https://github.com/element-hq/synapse/pull/18868#discussion_r2377192081. Although this served as a decent canary of what people may have historically configured, I've now added the relevant context to that part of the code as part of https://github.com/element-hq/synapse/pull/18868