### PR TITLE
Update uses of `matrix_put_e2e_keys` to contain valid data

### DIFF
--- a/tests/41end-to-end-keys/01-upload-key.pl
+++ b/tests/41end-to-end-keys/01-upload-key.pl
@@ -188,6 +188,23 @@ test "query for user with no keys returns empty key dict",
 
 push our @EXPORT, qw( matrix_put_e2e_keys matrix_get_e2e_keys );
 
+=head2 matrix_put_e2e_keys
+
+   matrix_put_e2e_keys( $user, device_keys => {
+      algorithms => [ "m.olm.v1.curve25519-aes-sha2", "m.megolm.v1.aes-sha2" ],
+      keys => {
+         "curve25519:".$user->device_id => "base64publicidentitykey",
+         "ed25519:".$user->device_id => "base64publicidentitykey2"
+      },
+      signatures => {}
+   })
+
+Upload device keys and one time keys for a user.
+
+The `user_id` and `device_id` fields in `device_keys` will be set automatically
+by this function.
+=cut
+
 sub matrix_put_e2e_keys
 {
    # TODO(paul): I don't really know what's parametric about this

--- a/tests/41end-to-end-keys/04-query-key-federation.pl
+++ b/tests/41end-to-end-keys/04-query-key-federation.pl
@@ -5,7 +5,16 @@ multi_test "Can query remote device keys using POST",
    check => sub {
       my ( $user, $remote_user ) = @_;
 
-      matrix_put_e2e_keys( $user )
+      my $device_keys = {
+         algorithms => [ "m.olm.v1.curve25519-aes-sha2", "m.megolm.v1.aes-sha2" ],
+         keys => {
+            "curve25519:".$user->device_id => "base64publicidentitykey",
+            "ed25519:".$user->device_id => "base64publicidentitykey2"
+         },
+         signatures => {}
+      };
+
+      matrix_put_e2e_keys( $user, device_keys => $device_keys )
          ->SyTest::pass_on_done( "Uploaded key" )
       ->then( sub {
          matrix_set_device_display_name( $user, $user->device_id, "test display name" ),

--- a/tests/41end-to-end-keys/08-cross-signing.pl
+++ b/tests/41end-to-end-keys/08-cross-signing.pl
@@ -592,7 +592,8 @@ test "uploading signed devices gets propagated over federation",
           "keys" => {
               "curve25519:$user2_device" => "IQ/Hu4GGOaxIpMavovFYGouVJeIP2miSfysv+Db3NXg",
               "ed25519:$user2_device" => "MKkClRdltZlOHyCzxiDrm7MsDAsohXmAyeu2cYO6how",
-          }
+          },
+          "signatures" => {},
       };
       my $cross_signature;
 
@@ -673,7 +674,7 @@ test "uploading signed devices gets propagated over federation",
                exists $sigs->{$user2_id}
                   && exists $sigs->{$user2_id}{$user2_device_key_id}
                   && $sigs->{$user2_id}{$user2_device_key_id} eq $cross_signature
-                  or die "Expected cross-signature ($user2_device_key_id}->$cross_signature not visible";
+                  or die "Expected cross-signature ($user2_device_key_id)->$cross_signature not visible";
 
                Future->done( $content );
             });

--- a/tests/50federation/40devicelists.pl
+++ b/tests/50federation/40devicelists.pl
@@ -33,7 +33,14 @@ test "Local device key changes get to remote servers",
 
                Future->done(1);
             }),
-            matrix_put_e2e_keys( $user )
+            matrix_put_e2e_keys(
+               $user,
+               device_keys => {
+                  algorithms => [ "m.olm.v1.curve25519-aes-sha2", "m.megolm.v1.aes-sha2" ],
+                  keys => { "ed25519:".$user->device_id => "base64publicidentitykey" },
+                  signatures => {},
+               }
+            )
          )
       })->then( sub {
          Future->needs_all(
@@ -49,7 +56,11 @@ test "Local device key changes get to remote servers",
 
                Future->done(1);
             }),
-            matrix_put_e2e_keys( $user, device_keys => { updated => "keys" } )
+            matrix_put_e2e_keys( $user, device_keys => {
+               algorithms => [ "m.olm.v1.curve25519-aes-sha2", "m.megolm.v1.aes-sha2" ],
+               keys => { "ed25519:".$user->device_id => "newkey" },
+               signatures => {},
+            } )
          )
       });
    };
@@ -424,7 +435,14 @@ test "Local device key changes get to remote servers with correct prev_id",
 
                Future->done(1);
             }),
-            matrix_put_e2e_keys( $user1 )
+            matrix_put_e2e_keys(
+               $user1,
+               device_keys => {
+                  algorithms => [ "m.olm.v1.curve25519-aes-sha2", "m.megolm.v1.aes-sha2" ],
+                  keys => { "ed25519:".$user1->device_id => "base64publicidentitykey" },
+                  signatures => {},
+               }
+            )
          )
       })->then( sub {
          Future->needs_all(
@@ -439,7 +457,14 @@ test "Local device key changes get to remote servers with correct prev_id",
 
                Future->done(1);
             }),
-            matrix_put_e2e_keys( $user2 )
+            matrix_put_e2e_keys(
+               $user2,
+               device_keys => {
+                  algorithms => [ "m.olm.v1.curve25519-aes-sha2", "m.megolm.v1.aes-sha2" ],
+                  keys => { "ed25519:".$user2->device_id => "base64publicidentitykey" },
+                  signatures => {},
+               }
+            )
          )
       })->then( sub {
          Future->needs_all(
@@ -455,7 +480,14 @@ test "Local device key changes get to remote servers with correct prev_id",
 
                Future->done(1);
             }),
-            matrix_put_e2e_keys( $user1, device_keys => { updated => "keys" } )
+            matrix_put_e2e_keys(
+               $user1,
+               device_keys => {
+                  algorithms => [ "m.olm.v1.curve25519-aes-sha2", "m.megolm.v1.aes-sha2" ],
+                  keys => { "ed25519:".$user1->device_id => "newkey" },
+                  signatures => {},
+               }
+            )
          )
       });
    };


### PR DESCRIPTION
After adding validation to `/keys/upload` on Synapse, uses of this function with mostly-empty bodies were no longer valid.

This change adds fake test data to them where necessary.

---

This is paired with https://github.com/element-hq/synapse/pull/17097, which was accidentally merged before these tests were.

