### PR TITLE
Fix request body structure for "Should reject keys claiming to belong to a different user"

### DIFF
--- a/tests/41end-to-end-keys/01-upload-key.pl
+++ b/tests/41end-to-end-keys/01-upload-key.pl
@@ -91,6 +91,12 @@ test "Should reject keys claiming to belong to a different user",
             device_keys => {
                user_id => "\@50-e2e-alice:localhost:8480",
                device_id => "alices_first_device",
+               algorithms => ["m.olm.curve25519-aes-sha256", "m.megolm.v1.aes-sha"],
+               keys => {
+                 "curve25519:".$user->device_id => "curve25519+key",
+                 "ed25519:".$user->device_id => "ed25519+key",
+               },
+               signatures => {},
             },
          }
       )->main::expect_http_4xx;


### PR DESCRIPTION
This was causing Synapse to respond with validation errors for these tests:

```
2025-10-18 09:24:32,660 - synapse.http.server - 135 - INFO - POST-6877 - <SynapseRequest at 0x7f071c58d9d0 method='POST' uri='/_matrix/client/v3/keys/upload?access_token=<redacted>' clientproto='HTTP/1.1' site='8800'> SynapseError: 400 - 3 validation errors for KeyUploadRequestBody
device_keys.algorithms
  Field required [type=missing, input_value={'user_id': '@anon-202510...evice_id': 'TRIISNQZFQ'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
device_keys.keys
  Field required [type=missing, input_value={'user_id': '@anon-202510...evice_id': 'TRIISNQZFQ'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
device_keys.signatures
  Field required [type=missing, input_value={'user_id': '@anon-202510...evice_id': 'TRIISNQZFQ'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
```

...which caused the test to fail (which we were expecting). Yet, we were looking for failure due to the wrong user ID being passed, not the request body's structure.

This PR fixes up the structure of the request body to avoid the validation error. We now see the correct error in the logs:

```
2025-10-20 17:09:20,357 - synapse.http.server - 135 - INFO - POST-3 - <SynapseRequest at 0x7f091c1570d0 method='POST' uri='/_matrix/client/v3/keys/upload?access_token=<redacted>' clientproto='HTTP/1.1' site='8800'> SynapseError: 400 - Provided `user_id` in `device_keys` does not match that of the authenticated user
```

Ideally we would differentiate the errors based on `errcode`, but [the spec](https://spec.matrix.org/v1.16/client-server-api/#post_matrixclientv3keysupload) doesn't currently define any for this endpoint.