### PR TITLE
Fix DBD::Pg install for debian:testing image build

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -6,13 +6,6 @@ requires 'Crypt::Ed25519';
 
 requires 'Data::Dump';
 
-# DBD::Pg fails to install if DBI is not already installed before we start.
-# (DBI goes into an architecture-dependent directory, which may not exist when
-# the installation process starts; by doing the install in two steps, we force
-# perl to rescan the library directories and add any new ones which it finds.)
-requires 'DBI';
-
-requires 'DBD::Pg';
 requires 'Digest::HMAC_SHA1';
 requires 'Digest::SHA';
 requires 'Email::Address::XS';

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -25,7 +25,8 @@ RUN apt-get -qq update && apt-get -qq install -y \
     sqlite3 \
     wget \
     libicu-dev \
-    pkg-config
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
 
 # Set up the locales, as the default Debian image only has C, and PostgreSQL needs the correct locales to make a UTF-8 database
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
@@ -38,7 +39,9 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 # Install some Perl module(s) from Debian repos that have trouble being installed by the below script
-RUN apt-get -qq install -y libdbd-pg-perl
+RUN apt-get -qq update && apt-get -qq install -y \
+    libdbd-pg-perl \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy in the sytest dependencies and install them
 # (we expect the docker build context be the sytest repo root, rather than the `docker` folder)
@@ -64,5 +67,3 @@ RUN for ver in `ls /usr/lib/postgresql | head -n 1`; do \
 
 # configure it not to try to listen on IPv6 (it won't work and will cause warnings)
 RUN echo "listen_addresses = '127.0.0.1'" >> "$PGDATA/postgresql.conf"
-
-RUN rm -rf /var/lib/apt/lists/*

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -25,8 +25,7 @@ RUN apt-get -qq update && apt-get -qq install -y \
     sqlite3 \
     wget \
     libicu-dev \
-    pkg-config \
-    && rm -rf /var/lib/apt/lists/*
+    pkg-config
 
 # Set up the locales, as the default Debian image only has C, and PostgreSQL needs the correct locales to make a UTF-8 database
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
@@ -65,3 +64,5 @@ RUN for ver in `ls /usr/lib/postgresql | head -n 1`; do \
 
 # configure it not to try to listen on IPv6 (it won't work and will cause warnings)
 RUN echo "listen_addresses = '127.0.0.1'" >> "$PGDATA/postgresql.conf"
+
+RUN rm -rf /var/lib/apt/lists/*

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -38,6 +38,9 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
+# Install some Perl module(s) from Debian repos that have trouble being installed by the below script
+RUN apt-get -qq install -y libdbd-pg-perl
+
 # Copy in the sytest dependencies and install them
 # (we expect the docker build context be the sytest repo root, rather than the `docker` folder)
 ADD install-deps.pl ./install-deps.pl


### PR DESCRIPTION
Installing DBD::Pg via [install-deps.pl](https://github.com/matrix-org/sytest/blob/develop/install-deps.pl) currently fails under Debian Testing, apparently [due to a change in GCC 15](https://github.com/bucardo/dbdpg/issues/135).

An alternative is installing it via Debian repositories, which works even for non-Testing Debian.