### PR TITLE
Update python poetry from 1.3.2 to 2.2.1 in Synapse dockerfile

### DIFF
--- a/docker/synapse.Dockerfile
+++ b/docker/synapse.Dockerfile
@@ -24,7 +24,7 @@ ARG PYTHON_VERSION=3.10
 
 RUN --mount=type=bind,from=ghcr.io/astral-sh/uv:0.9.4,source=/uv,target=/bin/uv \
         uv python install "$PYTHON_VERSION" && \
-        uv tool install poetry@1.3.2
+        uv tool install poetry@2.2.1
 
 ENV PATH=/root/.local/bin:$PATH
 
@@ -48,7 +48,7 @@ RUN mkdir /src
 # Download a cache of build dependencies to support offline mode.
 # These version numbers are arbitrary and were the latest at the time.
 RUN "python${PYTHON_VERSION}" -m pip download --dest /pypi-offline-cache \
-        poetry-core==1.1.0 setuptools==65.3.0 wheel==0.37.1 \
+        poetry-core==2.2.1 setuptools==65.3.0 wheel==0.37.1 \
         setuptools-rust==1.5.1
 
 # Create the virtual env upfront so we don't need to keep reinstalling
@@ -75,14 +75,8 @@ RUN /venv/bin/pip install -q --no-cache-dir \
 # Poetry runs multiple pip operations in parallel. Unfortunately this results
 # in race conditions when a dependency is installed while another dependency
 # is being up/downgraded in `scripts/synapse_sytest.sh`. Configure poetry to
-# serialize `pip` operations by setting `experimental.new-installer` to a falsy
-# value.
+# serialize `pip` operations by setting `installer.parallel` to false.
 # See https://github.com/matrix-org/synapse/issues/12419
-# TODO: Once poetry 1.2.0 has been released, use the `installer.max-workers`
-#       or `installer.parallel` config option instead.
-# poetry has a bug where this environment variable is not converted to a
-# boolean, so we choose a falsy string value for it. It's fixed in 1.2.0,
-# where we'll be wanting to use `installer.max-workers` anyway.
-ENV POETRY_EXPERIMENTAL_NEW_INSTALLER ""
+ENV POETRY_INSTALLER_PARALLEL false
 
 ENTRYPOINT [ "/bin/bash", "/bootstrap.sh", "synapse" ]


### PR DESCRIPTION
To coincide with https://github.com/element-hq/synapse/pull/19137, which makes Poetry 2.x the minimum version. This PR can be merged at any time, as Poetry 2.x is backwards-compatible with the old format which the linked Synapse PR replaces.

CI on this PR (and the associated Synapse PR) will fail until `matrixdotorg/sytest-synapse:<debian_version>` is updated with the `poetry` change. Merging this PR and then manually running the daily [Build and deploy docker images](https://github.com/matrix-org/sytest/actions/workflows/docker.yml) workflow will updated said image on DockerHub.

I've tested locally that these changes build:

```
➜ docker build -t matrixdotorg/sytest-synapse:bookworm --build-arg BASE_IMAGE=debian:bookworm --build-arg POSTGRESQL_VERSION=13 -f docker/synapse.Dockerfile .
[+] Building 49.4s (16/16) FINISHED                                                                                                                                                                                                                                                                                              docker:default
 => [internal] load build definition from synapse.Dockerfile                                                                                                                                                                                                                                                                               0.0s
 => => transferring dockerfile: 3.58kB                                                                                                                                                                                                                                                                                                     0.0s
 => [internal] load metadata for ghcr.io/astral-sh/uv:0.9.4                                                                                                                                                                                                                                                                                0.6s
 => [internal] load metadata for docker.io/matrixdotorg/sytest:bookworm                                                                                                                                                                                                                                                                    0.4s
 => [auth] astral-sh/uv:pull token for ghcr.io                                                                                                                                                                                                                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                          0.0s
 => => transferring context: 66B                                                                                                                                                                                                                                                                                                           0.0s
 => [stage-0 1/9] FROM docker.io/matrixdotorg/sytest:bookworm@sha256:a48a0a42bf40db54b300e88fe019cd712f88742aab4aa1a8a68897990bebdcfe                                                                                                                                                                                                      0.1s
 => => resolve docker.io/matrixdotorg/sytest:bookworm@sha256:a48a0a42bf40db54b300e88fe019cd712f88742aab4aa1a8a68897990bebdcfe                                                                                                                                                                                                              0.0s
 => => sha256:a48a0a42bf40db54b300e88fe019cd712f88742aab4aa1a8a68897990bebdcfe 1.61kB / 1.61kB                                                                                                                                                                                                                                             0.0s
 => => sha256:7e20dffbebbc34fe5a47817f98db6df4cdfcb11fb4a82cbe349fee6d7428bddd 2.77kB / 2.77kB                                                                                                                                                                                                                                             0.0s
 => => sha256:fe8843a46531cfcb7c7a82047455bb34bc32c713d8da8d564bede310d9bb7bd6 5.59kB / 5.59kB                                                                                                                                                                                                                                             0.0s
 => CACHED FROM ghcr.io/astral-sh/uv:0.9.4@sha256:c4089b0085cf4d38e38d5cdaa5e57752c1878a6f41f2e3a3a234dc5f23942cb4                                                                                                                                                                                                                         0.0s
 => [stage-0 2/9] RUN apt-get -qq update && apt-get -qq install -y         apt-utils eatmydata redis-server curl         && rm -rf /var/lib/apt/lists/*                                                                                                                                                                                    5.6s
 => [stage-0 3/9] RUN mkdir /rust /cargo                                                                                                                                                                                                                                                                                                   0.2s
 => [stage-0 4/9] RUN curl -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain stable --profile minimal                                                                                                                                                                                                          12.4s 
 => [stage-0 5/9] RUN --mount=type=bind,from=ghcr.io/astral-sh/uv:0.9.4,source=/uv,target=/bin/uv         uv python install "3.10" &&         uv tool install poetry@2.2.1                                                                                                                                                                 3.3s 
 => [stage-0 6/9] RUN mkdir /src                                                                                                                                                                                                                                                                                                           0.1s 
 => [stage-0 7/9] RUN "python3.10" -m pip download --dest /pypi-offline-cache         poetry-core==2.2.1 setuptools==65.3.0 wheel==0.37.1         setuptools-rust==1.5.1                                                                                                                                                                   2.7s 
 => [stage-0 8/9] RUN wget -q https://github.com/element-hq/synapse/archive/develop.tar.gz         -O /synapse.tar.gz &&         mkdir /synapse &&         tar -C /synapse --strip-components=1 -xf synapse.tar.gz &&         ln -s -T /venv /synapse/.venv &&         cd /synapse &&         poetry install --no-root --extras all &&    20.0s 
 => [stage-0 9/9] RUN /venv/bin/pip install -q --no-cache-dir         coverage codecov tap.py coverage_enable_subprocess                                                                                                                                                                                                                   2.9s 
 => exporting to image                                                                                                                                                                                                                                                                                                                     1.2s 
 => => exporting layers                                                                                                                                                                                                                                                                                                                    1.2s 
 => => writing image sha256:c2ddd67a1a43a094b33593d3b274005fa892520de715bf40b20d9677a0559de0                                                                                                                                                                                                                                               0.0s 
 => => naming to docker.io/matrixdotorg/sytest-synapse:bookworm
```

Running some tests with the new image succeeds:

```
docker run --rm -it -v $PWD:/src:ro -v $PWD/sytest_logs:/logs -v /home/work/code/sytest:/sytest:ro matrixdotorg/sytest-synapse:bookworm tests/30rooms/70publicroomslist.pl
...
+ perl -I /sytest/lib /sytest/run-tests.pl --python=/venv/bin/python --synapse-directory=/src -B /src/sytest-blacklist --coverage -O tap --all --work-directory=/work --bind-host 127.0.0.1 -I Synapse tests/30rooms/70publicroomslist.pl
tests/30rooms/70publicroomslist.pl:
    Test 1 Name/topic keys are correct... Certificate request self-signature ok
subject=CN = 127.0.0.1
Certificate request self-signature ok
subject=CN = 127.0.0.1
OK
    Test 2 Can get remote public room list... Certificate request self-signature ok
subject=CN = 127.0.0.1
OK
    Test 3 Can paginate public room list... OK
    Test 4 Asking for a remote rooms list, but supplying the local server's name, returns the local rooms list... OK
[synapse-0-master]: /venv/lib/python3.10/site-packages/coverage/inorout.py:473: CoverageWarning: --include is ignored because --source is set (include-ignored); see https://coverage.readthedocs.io/en/7.11.0/messages.html#warning-include-ignored
[synapse-0-master]:   self.warn("--include is ignored because --source is set", slug="include-ignored")
[synapse-1-master]: /venv/lib/python3.10/site-packages/coverage/inorout.py:473: CoverageWarning: --include is ignored because --source is set (include-ignored); see https://coverage.readthedocs.io/en/7.11.0/messages.html#warning-include-ignored
[synapse-1-master]:   self.warn("--include is ignored because --source is set", slug="include-ignored")
+ trap - TERM INT
+ '[' 0 -ne 0 ']'
+ echo -e 'run-tests \e[32mPASSED\e[0m'
run-tests PASSED
+ echo '--- Copying assets'
--- Copying assets
+ rsync --ignore-missing-args --min-size=1B -av /work/server-0 /work/server-1 /logs --include '*/' '--include=*.log.*' '--include=*.log' '--exclude=*'
sending incremental file list
server-0/
server-0/homeserver.log
server-0/media_store/
server-1/
server-1/homeserver.log
server-1/media_store/

sent 162,582 bytes  received 74 bytes  325,312.00 bytes/sec
total size is 161,647  speedup is 0.99
+ '[' -n '' ']'
+ exit 0
```

whereas with the currently-published `matrixdotorg/sytest-synapse:bookworm` we get the issue caused by a `1.x` poetry version:

```
  RuntimeError

  The Poetry configuration is invalid:
    - 'name' is a required property
    - 'version' is a required property
    - 'description' is a required property
    - 'authors' is a required property
  

  at ~/.local/share/uv/tools/poetry/lib/python3.10/site-packages/poetry/core/factory.py:57 in create_poetry
       53│             message = ""
       54│             for error in check_result["errors"]:
       55│                 message += f"  - {error}\n"
       56│ 
    →  57│             raise RuntimeError("The Poetry configuration is invalid:\n" + message)
       58│ 
       59│         # Load package
       60│         name = local_config["name"]
       61│         assert isinstance(name, str)
```