### PR TITLE
Fix tests to work with Rust event

### DIFF
--- a/lib/SyTest/Federation/Datastore.pm
+++ b/lib/SyTest/Federation/Datastore.pm
@@ -379,6 +379,11 @@ sub create_room
    my $creator = $args{creator};
    my $room_version = $args{room_version} // 1;
 
+   # Allow override the room version we add to the create event, to test the
+   # case where the create event's room version is different from the room's
+   # actual version.
+   my $room_version_create_event = $args{room_version_create_event} // $room_version;
+
    my $room = SyTest::Federation::Room->new(
       datastore => $self,
       room_version => $room_version,
@@ -386,6 +391,7 @@ sub create_room
 
    $room->create_initial_events(
       creator => $creator,
+      room_version => $room_version_create_event,
    );
 
    $self->{rooms_by_id}{ $room->room_id } = $room;

--- a/lib/SyTest/Federation/Datastore.pm
+++ b/lib/SyTest/Federation/Datastore.pm
@@ -379,9 +379,10 @@ sub create_room
    my $creator = $args{creator};
    my $room_version = $args{room_version} // 1;
 
-   # Allow override the room version we add to the create event, to test the
-   # case where the create event's room version is different from the room's
-   # actual version.
+   # Allow override of the room version declared in the create event.
+   #
+   # Events will be formatted according to the `$room_version` but the
+   # room will be declared as this room version instead.
    my $room_version_used_for_create_event = $args{room_version_used_for_create_event} // $room_version;
 
    my $room = SyTest::Federation::Room->new(

--- a/lib/SyTest/Federation/Datastore.pm
+++ b/lib/SyTest/Federation/Datastore.pm
@@ -382,7 +382,7 @@ sub create_room
    # Allow override the room version we add to the create event, to test the
    # case where the create event's room version is different from the room's
    # actual version.
-   my $room_version_create_event = $args{room_version_create_event} // $room_version;
+   my $room_version_used_for_create_event = $args{room_version_used_for_create_event} // $room_version;
 
    my $room = SyTest::Federation::Room->new(
       datastore => $self,
@@ -391,7 +391,7 @@ sub create_room
 
    $room->create_initial_events(
       creator => $creator,
-      room_version => $room_version_create_event,
+      room_version => $room_version_used_for_create_event,
    );
 
    $self->{rooms_by_id}{ $room->room_id } = $room;

--- a/lib/SyTest/Federation/Room.pm
+++ b/lib/SyTest/Federation/Room.pm
@@ -176,9 +176,9 @@ sub create_initial_events
    my $creator = $args{creator} or
       croak "Require a 'creator'";
 
-   my $room_version = $args{room_version} // (
-      $self->room_version eq "1" ? undef : $self->room_version
-   );
+   # Only declare a room version if its not 1.
+   my $room_version = $args{room_version} // $self->room_version;
+   $room_version = $room_version eq "1" ? undef : $room_version;
 
    $self->create_and_insert_event(
       type => "m.room.create",

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -932,8 +932,8 @@ test "Outbound federation rejects m.room.create events with an unknown room vers
          # We create a room with an unknown room version. However, we still need
          # to base it off a known version (to actually be able to create the
          # events), and so we choose v1.
-         room_version              => '1',
-         room_version_create_event => 'sytest-room-ver',
+         room_version                       => '1',
+         room_version_used_for_create_event => 'sytest-room-ver',
       );
 
       my $room_id = $room->room_id;

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -929,8 +929,9 @@ test "Outbound federation rejects m.room.create events with an unknown room vers
          creator => $creator_id,
          alias   => $room_alias,
 
-         # We want this room to act like a v1 room, but declare itself an
-         # unknown version.
+         # We create a room with an unknown room version. However, we still need
+         # to base it off a known version (to actually be able to create the
+         # events), and so we choose v1.
          room_version              => '1',
          room_version_create_event => 'sytest-room-ver',
       );
@@ -947,6 +948,11 @@ test "Outbound federation rejects m.room.create events with an unknown room vers
 
             $proto->{origin_server_ts} = JSON::number($inbound_server->time_ms);
 
+            # Note: if we were being compliant we would return the unknown room
+            # version here. Instead, we skip it and so the calling server will
+            # assume its a v1 room. Since the room events are formatted like v1,
+            # this won't cause any problems here and the server will continue to
+            # the send_join stage.
             $req->respond_json( {
                event => $proto,
             } );
@@ -967,6 +973,9 @@ test "Outbound federation rejects m.room.create events with an unknown room vers
                @{ $room->event_ids_from_refs( $event->{auth_events} ) }
             );
 
+            # This is where we respond with the create event, which has the
+            # unknown room version. At this point the calling server should
+            # realise that the room version is unknown and reject the join.
             $req->respond_json(
                my $response = {
                   auth_chain => \@auth_chain,

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -946,6 +946,8 @@ test "Outbound federation rejects m.room.create events with an unknown room vers
                user_id => $user_id,
             );
 
+            # Need to make sure `origin_server_ts` is formatted as a JSON number
+            # (by default perl will serialize as a string)
             $proto->{origin_server_ts} = JSON::number($inbound_server->time_ms);
 
             # Note: if we were being compliant we would return the unknown room

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -929,7 +929,10 @@ test "Outbound federation rejects m.room.create events with an unknown room vers
          creator => $creator_id,
          alias   => $room_alias,
 
-         room_version => 'sytest-room-ver',
+         # We want this room to act like a v1 room, but declare itself an
+         # unknown version.
+         room_version              => '1',
+         room_version_create_event => 'sytest-room-ver',
       );
 
       my $room_id = $room->room_id;
@@ -942,7 +945,7 @@ test "Outbound federation rejects m.room.create events with an unknown room vers
                user_id => $user_id,
             );
 
-            $proto->{origin_server_ts} = $inbound_server->time_ms;
+            $proto->{origin_server_ts} = JSON::number($inbound_server->time_ms);
 
             $req->respond_json( {
                event => $proto,
@@ -1085,7 +1088,7 @@ test "Event with an invalid signature in the send_join response should not cause
          })->then(sub {
             await_sync_timeline_contains( $user, $room_id, check => sub {
                my ( $event ) = @_;
-                
+
                assert_json_keys( $event, qw( type sender ));
                return unless $event->{type} eq "m.room.member";
                assert_json_keys( $event->{content}, qw( membership ) );

--- a/tests/50federation/30room-join.pl
+++ b/tests/50federation/30room-join.pl
@@ -442,6 +442,7 @@ test "Inbound /v1/send_join rejects incorrectly-signed joins",
          $join_event = $body->{event};
 
          $join_event->{origin_server_ts} = $outbound_client->time_ms;
+         $join_event->{hashes} = {};
 
          if( $room_version eq '1' || $room_version eq '2' ) {
             # room v1/v2: assign an event id

--- a/tests/50federation/35room-invite.pl
+++ b/tests/50federation/35room-invite.pl
@@ -601,6 +601,7 @@ test "Inbound federation rejects incorrectly-signed invite rejections",
          $leave_event = $resp->{event};
 
          $leave_event->{origin_server_ts} = JSON::number($outbound_client->time_ms);
+         $leave_event->{hashes} = {};
          $leave_event->{event_id} = $leave_event_id = $outbound_client->datastore->next_event_id();
 
          # let's start by sending it back without any signatures


### PR DESCRIPTION
The PR https://github.com/element-hq/synapse/pull/19701 ports the event class to Rust, which as a side-effect adds some extra validation when we parse the event. As such, when we create "fake" events in tests we need to make sure they are sufficiently valid to parse, otherwise we don't test what we wanted to test.