### PR TITLE
Use `sender` instead of `user_id` for any stripped state event usages

### DIFF
--- a/tests/30rooms/12thirdpartyinvite.pl
+++ b/tests/30rooms/12thirdpartyinvite.pl
@@ -8,7 +8,7 @@ test "Can invite existing 3pid",
    do => sub {
       my ( $inviter, $invitee, $id_server ) = @_;
 
-      my $invitee_mxid = $invitee->user_id;
+      my $invitee_mxid = $invitee->sender;
 
       my $room_id;
       my $id_access_token = $id_server->get_access_token;
@@ -50,7 +50,7 @@ test "Can invite existing 3pid with no ops into a private room",
    do => sub {
       my ( $creator, $inviter, $invitee, $id_server ) = @_;
 
-      my $invitee_mxid = $invitee->user_id;
+      my $invitee_mxid = $invitee->sender;
 
       my $room_id;
       my $id_access_token = $id_server->get_access_token;
@@ -99,7 +99,7 @@ test "Can invite existing 3pid in createRoom",
    do => sub {
       my ( $inviter, $invitee, $id_server ) = @_;
 
-      my $invitee_mxid = $invitee->user_id;
+      my $invitee_mxid = $invitee->sender;
 
       my $room_id;
       my $id_access_token = $id_server->get_access_token;
@@ -226,11 +226,11 @@ sub can_invite_unbound_3pid
          $_->{state_key} => $_
       } grep { $_->{type} eq "m.room.member" } @{ $body->{invite_state}{events} };
 
-      exists $members{ $inviter->user_id } or die "No inviter member invite state";
+      exists $members{ $inviter->sender } or die "No inviter member invite state";
 
       matrix_get_room_state( $inviter, $room_id,
          type      => "m.room.member",
-         state_key => $invitee->user_id,
+         state_key => $invitee->sender,
       )
    })->then( sub {
       my ( $body ) = @_;
@@ -245,7 +245,7 @@ sub can_invite_unbound_3pid
       retry_until_success {
          matrix_get_room_state( $inviter, $room_id,
             type      => "m.room.member",
-            state_key => $invitee->user_id,
+            state_key => $invitee->sender,
          )->followed_by( assert_membership( "join" ) )
       }
    })
@@ -278,7 +278,7 @@ test "Can invite unbound 3pid over federation with users from both servers",
          await_event_for( $inviter, filter => sub {
             my ( $event ) = @_;
             return unless $event->{type} eq "m.room.member";
-            return unless $event->{state_key} eq $invitee->user_id;
+            return unless $event->{state_key} eq $invitee->sender;
 
             assert_eq( $event->{content}{membership}, "invite" );
 
@@ -287,7 +287,7 @@ test "Can invite unbound 3pid over federation with users from both servers",
       })->then( sub {
          matrix_get_room_state( $inviter, $room_id,
             type      => "m.room.member",
-            state_key => $invitee->user_id,
+            state_key => $invitee->sender,
          )
       })->then( sub {
          my ( $body ) = @_;
@@ -302,7 +302,7 @@ test "Can invite unbound 3pid over federation with users from both servers",
          await_event_for( $inviter, filter => sub {
             my ( $event ) = @_;
             return unless $event->{type} eq "m.room.member";
-            return unless $event->{state_key} eq $invitee->user_id;
+            return unless $event->{state_key} eq $invitee->sender;
 
             assert_eq( $event->{content}{membership},  "join" );
 
@@ -312,7 +312,7 @@ test "Can invite unbound 3pid over federation with users from both servers",
          retry_until_success {
             matrix_get_room_state( $inviter, $room_id,
                type      => "m.room.member",
-               state_key => $invitee->user_id,
+               state_key => $invitee->sender,
             )->followed_by( assert_membership( "join" ) )
          }
       });
@@ -346,7 +346,7 @@ test "Can accept unbound 3pid invite after inviter leaves",
       })->then( sub {
          matrix_get_room_state( $other_member, $room_id,
             type      => "m.room.member",
-            state_key => $invitee->user_id,
+            state_key => $invitee->sender,
          )
       })->followed_by( assert_membership( "join" ) );
    };
@@ -377,8 +377,8 @@ test "Can accept third party invite with /join",
          my $token = $invite_event->{state_key};
 
          my %req = (
-            mxid   => $invitee->user_id,
-            sender => $inviter->user_id,
+            mxid   => $invitee->sender,
+            sender => $inviter->sender,
             token  => $token,
          );
 
@@ -390,7 +390,7 @@ test "Can accept third party invite with /join",
       })->then( sub {
          matrix_get_room_state( $inviter, $room_id,
             type      => "m.room.member",
-            state_key => $invitee->user_id,
+            state_key => $invitee->sender,
          )
       })->followed_by( assert_membership( "join" ) );
    };
@@ -465,7 +465,7 @@ sub invite_should_fail {
    })->then( sub {
       matrix_get_room_state( $inviter, $room_id,
          type      => "m.room.member",
-         state_key => $invitee->user_id,
+         state_key => $invitee->sender,
       )
    })->followed_by(assert_membership( undef ) );
 }


### PR DESCRIPTION
Use `sender` instead of `user_id` for any stripped state event usages

Spawning from https://github.com/element-hq/synapse/pull/19723 (where these tests started to fail) which ensures we actually use [stripped state](https://spec.matrix.org/v1.18/client-server-api/#stripped-state) everywhere. Stripped state only has `content`, `sender`, `state_key`, `type` available. Previously, this relied on the full PDU being available which meant access to`user_id` as well.

`user_id` is a [deprecated field](https://github.com/element-hq/synapse/blob/0e39c0c8f684d471d53b2a8e459e997f51d114a9/synapse/events/__init__.py#L249-L250) from Synapse that isn't in the spec.


### Dev notes

<details>
<summary>Example failure:</summary>

```
Error: FAILURE: #219: Can invite unbound 3pid over federation with no ops into a private room
Logs
  # Started: 2026-05-26 20:15:54.169
  # Ended: 2026-05-26 20:15:55.904
  # No inviter member invite state at tests/30rooms/12thirdpartyinvite.pl line 229.
  # 0.029646: Registered new user @anon-20260526_201439-154:127.0.0.1:8838
  # 0.052488: Registered new user @anon-20260526_201439-152:127.0.0.1:8800
  # 0.053313: Registered new user @anon-20260526_201439-153:127.0.0.1:8800
  # 0.439184: room_id=!KRaggKHbkwunOCEjIy:127.0.0.1:8800
  # 0.545050: Invited user @anon-20260526_201439-153:127.0.0.1:8800 to !KRaggKHbkwunOCEjIy:127.0.0.1:8800
  # {}
  # 0.664036: User @anon-20260526_201439-153:127.0.0.1:8800 joined room
  # { room_id => "!KRaggKHbkwunOCEjIy:127.0.0.1:8800" }
  # 0.714240: Created room_id=!KRaggKHbkwunOCEjIy:127.0.0.1:8800
  # 1.159396: sent 3pid invite for lemurs@monkeyworld.org to SyTest::Identity::Server=HASH(0x55b492174fc8)
  # 1.730745: Invite
  # {
  #   invite_state => {
  #     events => [
  #       {
  #         content   => {
  #                        creator => "\@anon-20260526_201439-152:127.0.0.1:8800",
  #                        room_version => 10,
  #                      },
  #         sender    => "\@anon-20260526_201439-152:127.0.0.1:8800",
  #         state_key => "",
  #         type      => "m.room.create",
  #       },
  #       {
  #         content   => { join_rule => "invite" },
  #         sender    => "\@anon-20260526_201439-152:127.0.0.1:8800",
  #         state_key => "",
  #         type      => "m.room.join_rules",
  #       },
  #       {
  #         content   => { alias => "#test-20260526_201439-23:127.0.0.1:8800" },
  #         sender    => "\@anon-20260526_201439-152:127.0.0.1:8800",
  #         state_key => "",
  #         type      => "m.room.canonical_alias",
  #       },
  #       {
  #         content   => {
  #                        membership => "invite",
  #                        third_party_invite => {
  #                          display_name => "Bob",
  #                          signed => {
  #                            mxid => "\@anon-20260526_201439-154:127.0.0.1:8838",
  #                            signatures => {
  #                              "localhost:45425" => {
  #                                "ed25519:0" => "nYMBeK9UPutCo2CxT7JQat8pwbmmixGJT/xVTqsRZVArP7YVwWv0XRogUYA82pSqoZyw9eLtQ6dvmT4ORuAqAg",
  #                              },
  #                            },
  #                            token => 3,
  #                          },
  #                        },
  #                      },
  #         sender    => "\@anon-20260526_201439-153:127.0.0.1:8800",
  #         state_key => "\@anon-20260526_201439-154:127.0.0.1:8838",
  #         type      => "m.room.member",
  #       },
  #     ],
  #   },
  # }
  ```
  
</details>

Testing:

```
docker run --rm -it \
    -v ~/Documents/github/element/synapse:/src:ro \
    -v ~/Documents/github/element/sytest/logs\:/logs \
    -v ~/Documents/github/element/sytest:/sytest:ro \
    matrixdotorg/sytest-synapse:bookworm \
    tests/30rooms/12thirdpartyinvite.pl
```

Generic ([from docs](https://github.com/matrix-org/sytest/blob/develop/docker/README.md#selecting-a-checkout-of-sytest)):

```
docker run --rm -it -v /path/to/synapse\:/src:ro -v /path/to/where/you/want/logs\:/logs \
    -v /path/to/code/sytest\:/sytest:ro matrixdotorg/sytest-synapse:bookworm
```
