### PR TITLE
Manually install `libcrypt-dev` to fix docker image building

### DIFF
--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get -qq update && apt-get -qq install -y \
     haproxy \
     jq \
     libffi-dev \
+    libcrypt-dev \
     libjpeg-dev \
     libpq-dev \
     libssl-dev \


### PR DESCRIPTION
This is required by our perl code, apparently. It used to be pulled in by the libc development packages (via `build-essential`) but as of https://lists.debian.org/debian-devel/2025/04/msg00113.html it needs to be manually installed.

Fixes the docker images building and pushing for `debian:testing` (aka `forky`). See a recent failing job: https://github.com/matrix-org/sytest/actions/runs/28107345580

Note: CI in other PRs weren't failing, as that is a separate Dockerfile (i.e. `docker/synapse.Dockerfile`) from the one that is built on `develop` (`docker/base.Dockerfile`).